### PR TITLE
add context_propagation_only option to options list

### DIFF
--- a/custom/src/main/java/co/elastic/otel/config/Configurations.java
+++ b/custom/src/main/java/co/elastic/otel/config/Configurations.java
@@ -626,5 +626,4 @@ public class Configurations {
           ConfigurationOption.unspecifiedOption()
               .key("context_propagation_only")
               .buildNotEnabled());
-
 }


### PR DESCRIPTION
added in 1.44 and breaking the build because it's not reconciled here