### PR TITLE
Disable flaky AWS resource test

### DIFF
--- a/smoke-tests/src/test/java/com/example/javaagent/smoketest/AwsResourceProvidersTest.java
+++ b/smoke-tests/src/test/java/com/example/javaagent/smoketest/AwsResourceProvidersTest.java
@@ -33,6 +33,7 @@ import org.mockserver.model.HttpResponse;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.utility.MountableFile;
 
+@Disabled // because currently flaky
 public class AwsResourceProvidersTest extends TestAppSmokeTest {
 
   protected static final String MOCK_SERVER_HOST = "mock-server";


### PR DESCRIPTION
Disabling the test for now, properly fixing this will be done in #52 