### PR TITLE
first few config options implemented

### DIFF
--- a/custom/src/main/java/co/elastic/otel/config/types/BooleanConfigurationOption.java
+++ b/custom/src/main/java/co/elastic/otel/config/types/BooleanConfigurationOption.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.otel.config.types;
+
+import co.elastic.otel.config.ConfigurationOption;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+public class BooleanConfigurationOption extends ConfigurationOption<Boolean> {
+
+  protected BooleanConfigurationOption(
+      boolean dynamic,
+      boolean sensitive,
+      String key,
+      String label,
+      String description,
+      Boolean defaultValue,
+      String configurationCategory,
+      List<String> tags,
+      boolean required,
+      List<ChangeListener<Boolean>> changeListeners,
+      List<Validator<Boolean>> validators,
+      List<String> aliasKeys,
+      Map<String, String> validOptions,
+      ChangesFromV1Definitions changesFromV1Definitions) {
+    super(
+        dynamic,
+        sensitive,
+        key,
+        label,
+        description,
+        defaultValue,
+        configurationCategory,
+        null,
+        null,
+        tags,
+        required,
+        changeListeners,
+        validators,
+        aliasKeys,
+        validOptions,
+        changesFromV1Definitions);
+  }
+
+  @Override
+  public Boolean convert(String s) throws IllegalArgumentException {
+    return Boolean.parseBoolean(s);
+  }
+
+  public static class BooleanConfigurationOptionBuilder
+      extends ConfigurationOptionBuilder<Boolean> {
+
+    public BooleanConfigurationOption build() {
+      return new BooleanConfigurationOption(
+          dynamic,
+          sensitive,
+          key,
+          label,
+          description,
+          defaultValue,
+          configurationCategory,
+          tags == null ? new ArrayList<>() : Arrays.asList(tags),
+          required,
+          changeListeners,
+          validators,
+          aliasKeys == null ? new ArrayList<>() : Arrays.asList(aliasKeys),
+          validOptions,
+          changesFromV1Definitions);
+    }
+  }
+}

--- a/custom/src/main/java/co/elastic/otel/config/types/EnumConfigurationOption.java
+++ b/custom/src/main/java/co/elastic/otel/config/types/EnumConfigurationOption.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.otel.config.types;
+
+import co.elastic.otel.config.ConfigurationOption;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+public class EnumConfigurationOption<T extends Enum<T>> extends ConfigurationOption<T> {
+  private final Class<T> enumClass;
+
+  protected EnumConfigurationOption(
+      boolean dynamic,
+      boolean sensitive,
+      String key,
+      String label,
+      String description,
+      T defaultValue,
+      String configurationCategory,
+      List<String> tags,
+      boolean required,
+      List<ChangeListener<T>> changeListeners,
+      List<Validator<T>> validators,
+      List<String> aliasKeys,
+      Map<String, String> validOptions,
+      ChangesFromV1Definitions changesFromV1Definitions,
+      Class<T> enumClass) {
+    super(
+        dynamic,
+        sensitive,
+        key,
+        label,
+        description,
+        defaultValue,
+        configurationCategory,
+        null,
+        null,
+        tags,
+        required,
+        changeListeners,
+        validators,
+        aliasKeys,
+        validOptions,
+        changesFromV1Definitions);
+    this.enumClass = enumClass;
+  }
+
+  @Override
+  public T convert(String name) throws IllegalArgumentException {
+    return Enum.valueOf(enumClass, name);
+  }
+
+  public static class EnumConfigurationOptionBuilder<T extends Enum<T>>
+      extends ConfigurationOptionBuilder<T> {
+
+    private final Class<T> enumClass;
+
+    public EnumConfigurationOptionBuilder(Class<T> enumClass) {
+      this.enumClass = enumClass;
+    }
+
+    public EnumConfigurationOption<T> build() {
+      return new EnumConfigurationOption<>(
+          dynamic,
+          sensitive,
+          key,
+          label,
+          description,
+          defaultValue,
+          configurationCategory,
+          tags == null ? new ArrayList<>() : Arrays.asList(tags),
+          required,
+          changeListeners,
+          validators,
+          aliasKeys == null ? new ArrayList<>() : Arrays.asList(aliasKeys),
+          validOptions,
+          changesFromV1Definitions,
+          enumClass);
+    }
+  }
+}

--- a/custom/src/main/java/co/elastic/otel/config/types/StringConfigurationOption.java
+++ b/custom/src/main/java/co/elastic/otel/config/types/StringConfigurationOption.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.otel.config.types;
+
+import co.elastic.otel.config.ConfigurationOption;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+public class StringConfigurationOption extends ConfigurationOption<String> {
+
+  protected StringConfigurationOption(
+      boolean dynamic,
+      boolean sensitive,
+      String key,
+      String label,
+      String description,
+      String defaultValue,
+      String configurationCategory,
+      List<String> tags,
+      boolean required,
+      List<ChangeListener<String>> changeListeners,
+      List<Validator<String>> validators,
+      List<String> aliasKeys,
+      Map<String, String> validOptions,
+      ChangesFromV1Definitions changesFromV1Definitions) {
+    super(
+        dynamic,
+        sensitive,
+        key,
+        label,
+        description,
+        defaultValue,
+        configurationCategory,
+        null,
+        null,
+        tags,
+        required,
+        changeListeners,
+        validators,
+        aliasKeys,
+        validOptions,
+        changesFromV1Definitions);
+  }
+
+  @Override
+  public String convert(String s) throws IllegalArgumentException {
+    return s;
+  }
+
+  public static class StringConfigurationOptionBuilder extends ConfigurationOptionBuilder<String> {
+
+    public StringConfigurationOption build() {
+      return new StringConfigurationOption(
+          dynamic,
+          sensitive,
+          key,
+          label,
+          description,
+          defaultValue,
+          configurationCategory,
+          tags == null ? new ArrayList<>() : Arrays.asList(tags),
+          required,
+          changeListeners,
+          validators,
+          aliasKeys == null ? new ArrayList<>() : Arrays.asList(aliasKeys),
+          validOptions,
+          changesFromV1Definitions);
+    }
+  }
+}

--- a/custom/src/main/java/co/elastic/otel/config/types/UrlConfigurationOption.java
+++ b/custom/src/main/java/co/elastic/otel/config/types/UrlConfigurationOption.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.otel.config.types;
+
+import co.elastic.otel.config.ConfigurationOption;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+public class UrlConfigurationOption extends ConfigurationOption<URL> {
+
+  protected UrlConfigurationOption(
+      boolean dynamic,
+      boolean sensitive,
+      String key,
+      String label,
+      String description,
+      URL defaultValue,
+      String configurationCategory,
+      List<String> tags,
+      boolean required,
+      List<ChangeListener<URL>> changeListeners,
+      List<Validator<URL>> validators,
+      List<String> aliasKeys,
+      Map<String, String> validOptions,
+      ChangesFromV1Definitions changesFromV1Definitions) {
+    super(
+        dynamic,
+        sensitive,
+        key,
+        label,
+        description,
+        defaultValue,
+        configurationCategory,
+        null,
+        null,
+        tags,
+        required,
+        changeListeners,
+        validators,
+        aliasKeys,
+        validOptions,
+        changesFromV1Definitions);
+  }
+
+  @Override
+  public URL convert(String s) throws IllegalArgumentException {
+    try {
+      return new URL(removeTrailingSlash(s));
+    } catch (MalformedURLException e) {
+      throw new IllegalArgumentException(e.getMessage());
+    }
+  }
+
+  public static String removeTrailingSlash(String url) {
+    if (url != null && url.endsWith("/")) {
+      return url.substring(0, url.length() - 1);
+    }
+    return url;
+  }
+
+  public String toSafeString(URL value) {
+    if (value == null) {
+      return null;
+    }
+    final String userInfo = value.getUserInfo();
+    final String urlAsString = value.toString();
+    if (userInfo != null) {
+      return urlAsString.replace(userInfo, getSafeUserInfo(userInfo));
+    } else {
+      return urlAsString;
+    }
+  }
+
+  private String getSafeUserInfo(String userInfo) {
+    return userInfo.split(":", 2)[0] + ":XXX";
+  }
+
+  public static class UrlConfigurationOptionBuilder extends ConfigurationOptionBuilder<URL> {
+
+    public UrlConfigurationOption build() {
+      return new UrlConfigurationOption(
+          dynamic,
+          sensitive,
+          key,
+          label,
+          description,
+          defaultValue,
+          configurationCategory,
+          tags == null ? new ArrayList<>() : Arrays.asList(tags),
+          required,
+          changeListeners,
+          validators,
+          aliasKeys == null ? new ArrayList<>() : Arrays.asList(aliasKeys),
+          validOptions,
+          changesFromV1Definitions);
+    }
+  }
+}

--- a/custom/src/main/java/co/elastic/otel/logging/LogLevel.java
+++ b/custom/src/main/java/co/elastic/otel/logging/LogLevel.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.otel.logging;
+
+public enum LogLevel {
+  OFF(false),
+  ERROR(false),
+  CRITICAL(false),
+  WARN(false),
+  WARNING(false),
+  INFO(false),
+  DEBUG(true),
+  TRACE(true);
+
+  // Otel agent has a debug on/off mode, hence this particular support
+  private final boolean isDebug;
+
+  LogLevel(boolean isDebug) {
+    this.isDebug = isDebug;
+  }
+
+  public boolean isDebug() {
+    return isDebug;
+  }
+}

--- a/custom/src/test/java/co/elastic/otel/config/ReconcileOptionsTest.java
+++ b/custom/src/test/java/co/elastic/otel/config/ReconcileOptionsTest.java
@@ -202,7 +202,8 @@ public class ReconcileOptionsTest {
             ? null
             : Arrays.asList(validators),
         aliasKeys == new ArrayList<String>() ? null : Arrays.asList(aliasKeys),
-        validOptions);
+        validOptions,
+        null);
   }
 
   private static Object getField(Class<?> clazz, Object obj, String fieldName)

--- a/smoke-tests/src/test/java/com/example/javaagent/smoketest/SmokeTest.java
+++ b/smoke-tests/src/test/java/com/example/javaagent/smoketest/SmokeTest.java
@@ -90,7 +90,7 @@ abstract class SmokeTest {
             .withExposedPorts(8080)
             .waitingFor(Wait.forHttp("/health").forPort(8080))
             .withNetwork(network)
-            .withNetworkAliases("backend")
+            .withNetworkAliases("elastic")
             .withLogConsumer(new Slf4jLogConsumer(logger));
 
     if (JavaExecutable.isDebugging()
@@ -119,7 +119,7 @@ abstract class SmokeTest {
             // batch span processor: very short delay for testing
             .withEnv("OTEL_BSP_SCHEDULE_DELAY", "10")
             .withEnv("OTEL_PROPAGATORS", "tracecontext,baggage")
-            .withEnv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://backend:8080");
+            .withEnv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://elastic:8080");
 
     StringBuilder jvmArgs = new StringBuilder();
 


### PR DESCRIPTION
Looks like many classes, but they break down into easy sets:

1. the config/types: I chose to implement individual config type classes rather than the generic one that stagemonitor has because stagemonitor has to handle any type but we can specifically handle just the type we need. It's extra code but less generic which makes it easier to understand (I think).
2. Configurations class just implementing 3 of the configs
3. ConfigurationOption adding the additional methods needed for those 3 configs
4. the meat is in the ElasticAutoConfigurationCustomizerprovider.java adding in the properties defined. We need both the properties supplier (to set defaults, eg the `otel.javaagent.debug` set there will get overridden by any command-line setting) and the properties customizer because we can't correctly set the default for the server URLs per the comment there


