### PR TITLE
Dependabot use root path

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,7 +20,7 @@ updates:
 
   # Gradle
   - package-ecosystem: "gradle"
-    directory: "/gradle/" # for now only on the version catalog to prevent noise
+    directory: "/"
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10


### PR DESCRIPTION
Try to make dependabot work with the versions catalog, my assumption being that not using the root path "/" made dependabot ignore the project, where I initially though that only the dependencies listed in `/gradle/` would be updated.