### PR TITLE
Revert "build: bump the github-actions group with 1 update"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,13 +37,13 @@ jobs:
 
       - name: Store test results
         if: success() || failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: test-results
           path: '**/build/test-results/test/TEST-*.xml'
 
       - name: Agent artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: elastic-otel-javaagent
           path: |


### PR DESCRIPTION
Reverts elastic/elastic-otel-java#68

We cannot use `v4` at the moment, unless we change the `test-reporter` action or replace it... for now let's keep using v3.

we will need to plan how to proceed then