### PR TITLE
Fix dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,6 @@
 ---
 version: 2
 
-registries:
-
 updates:
   # GitHub actions
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
We didn't get any gradle dependabot PRs yet, which made me think that it is not working correctly.

I've enabled the `dependency-graph` setting on this repo, which allows us to access the dependabot "complaints" in `insights`/`dependency graph`/`dependabot`. There dependabot complained about our dependabot.yml:

```
Dependabot encountered the following error when parsing your .github/dependabot.yml:

     The property '#/registries' of type null did not match the following type: object
Please update the config file to conform with Dependabot's specification.
```