### PR TITLE
Add profiler stack trace IDs as otel attributes

### DIFF
--- a/common/src/main/java/co/elastic/otel/common/AbstractChainingSpanProcessor.java
+++ b/common/src/main/java/co/elastic/otel/common/AbstractChainingSpanProcessor.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.otel.common;
+
+import io.opentelemetry.context.Context;
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.trace.ReadWriteSpan;
+import io.opentelemetry.sdk.trace.ReadableSpan;
+import io.opentelemetry.sdk.trace.SpanProcessor;
+import java.util.Arrays;
+
+/**
+ * A @{@link SpanProcessor} which in addition to all standard operations is capable of modifying and
+ * optionally filtering or delaying spans in the end-callback.
+ *
+ * <p>This is done by chaining processors and registering only the first processor with the SDK.
+ * Subclasses must ensure that {@link SpanProcessor#onEnd(ReadableSpan)} is called for {@link
+ * AbstractChainingSpanProcessor#next}.
+ */
+public abstract class AbstractChainingSpanProcessor implements SpanProcessor {
+
+  protected final SpanProcessor next;
+  private final boolean nextRequiresStart;
+
+  /**
+   * @param next the next processor to be invoked after the one being constructed.
+   */
+  public AbstractChainingSpanProcessor(SpanProcessor next) {
+    this.next = next;
+    nextRequiresStart = next.isStartRequired();
+  }
+
+  /**
+   * Equivalent of {@link SpanProcessor#onStart(Context, ReadWriteSpan)}. The onStart callback of
+   * the next processor must not be invoked from this method, this is already handled by the
+   * implementation of {@link #onStart(Context, ReadWriteSpan)}.
+   */
+  protected void doOnStart(Context context, ReadWriteSpan readWriteSpan) {}
+
+  /**
+   * @return true, if this implementation would like {@link #doOnStart(Context, ReadWriteSpan)} to
+   *     be invoked.
+   */
+  protected abstract boolean requiresStart();
+
+  protected CompletableResultCode doForceFlush() {
+    return CompletableResultCode.ofSuccess();
+  }
+
+  protected CompletableResultCode doShutdown() {
+    return CompletableResultCode.ofSuccess();
+  }
+
+  @Override
+  public final void onStart(Context context, ReadWriteSpan readWriteSpan) {
+    try {
+      if (requiresStart()) {
+        doOnStart(context, readWriteSpan);
+      }
+    } finally {
+      if (nextRequiresStart) {
+        next.onStart(context, readWriteSpan);
+      }
+    }
+  }
+
+  @Override
+  public final boolean isStartRequired() {
+    return requiresStart() || nextRequiresStart;
+  }
+
+  @Override
+  public final CompletableResultCode shutdown() {
+    return CompletableResultCode.ofAll(Arrays.asList(doShutdown(), next.shutdown()));
+  }
+
+  @Override
+  public final CompletableResultCode forceFlush() {
+    return CompletableResultCode.ofAll(Arrays.asList(doForceFlush(), next.forceFlush()));
+  }
+
+  @Override
+  public final void close() {
+    SpanProcessor.super.close();
+  }
+}

--- a/common/src/main/java/co/elastic/otel/common/AbstractSimpleChainingSpanProcessor.java
+++ b/common/src/main/java/co/elastic/otel/common/AbstractSimpleChainingSpanProcessor.java
@@ -18,42 +18,23 @@
  */
 package co.elastic.otel.common;
 
-import io.opentelemetry.context.Context;
-import io.opentelemetry.sdk.common.CompletableResultCode;
-import io.opentelemetry.sdk.trace.ReadWriteSpan;
 import io.opentelemetry.sdk.trace.ReadableSpan;
 import io.opentelemetry.sdk.trace.SpanProcessor;
-import java.util.Arrays;
 
 /**
- * A @{@link io.opentelemetry.sdk.trace.SpanProcessor} which in addition to all standard operations
- * is capable of modifying and optionally filtering spans in the end-callback.
- *
- * <p>This is done by chaining processors and registering only the first processor with the SDK.
  * Mutations can be performed in {@link #doOnEnd(ReadableSpan)} by wrapping the span in a {@link
  * MutableSpan}
  */
-public abstract class AbstractSimpleChainingSpanProcessor implements SpanProcessor {
-
-  protected final SpanProcessor next;
-  private final boolean nextRequiresStart;
+public abstract class AbstractSimpleChainingSpanProcessor extends AbstractChainingSpanProcessor {
   private final boolean nextRequiresEnd;
 
   /**
    * @param next the next processor to be invoked after the one being constructed.
    */
   public AbstractSimpleChainingSpanProcessor(SpanProcessor next) {
-    this.next = next;
-    nextRequiresStart = next.isStartRequired();
+    super(next);
     nextRequiresEnd = next.isEndRequired();
   }
-
-  /**
-   * Equivalent of {@link SpanProcessor#onStart(Context, ReadWriteSpan)}. The onStart callback of
-   * the next processor must not be invoked from this method, this is already handled by the
-   * implementation of {@link #onStart(Context, ReadWriteSpan)}.
-   */
-  protected void doOnStart(Context context, ReadWriteSpan readWriteSpan) {}
 
   /**
    * Equivalent of {@link SpanProcessor#onEnd(ReadableSpan)}}.
@@ -70,40 +51,9 @@ public abstract class AbstractSimpleChainingSpanProcessor implements SpanProcess
   }
 
   /**
-   * @return true, if this implementation would like {@link #doOnStart(Context, ReadWriteSpan)} to
-   *     be invoked.
-   */
-  protected boolean requiresStart() {
-    return true;
-  }
-
-  /**
    * @return true, if this implementation would like {@link #doOnEnd(ReadableSpan)} to be invoked.
    */
-  protected boolean requiresEnd() {
-    return true;
-  }
-
-  protected CompletableResultCode doForceFlush() {
-    return CompletableResultCode.ofSuccess();
-  }
-
-  protected CompletableResultCode doShutdown() {
-    return CompletableResultCode.ofSuccess();
-  }
-
-  @Override
-  public final void onStart(Context context, ReadWriteSpan readWriteSpan) {
-    try {
-      if (requiresStart()) {
-        doOnStart(context, readWriteSpan);
-      }
-    } finally {
-      if (nextRequiresStart) {
-        next.onStart(context, readWriteSpan);
-      }
-    }
-  }
+  protected abstract boolean requiresEnd();
 
   @Override
   public final void onEnd(ReadableSpan readableSpan) {
@@ -120,27 +70,7 @@ public abstract class AbstractSimpleChainingSpanProcessor implements SpanProcess
   }
 
   @Override
-  public final boolean isStartRequired() {
-    return requiresStart() || nextRequiresStart;
-  }
-
-  @Override
   public final boolean isEndRequired() {
     return requiresEnd() || nextRequiresEnd;
-  }
-
-  @Override
-  public final CompletableResultCode shutdown() {
-    return CompletableResultCode.ofAll(Arrays.asList(doShutdown(), next.shutdown()));
-  }
-
-  @Override
-  public final CompletableResultCode forceFlush() {
-    return CompletableResultCode.ofAll(Arrays.asList(doForceFlush(), next.forceFlush()));
-  }
-
-  @Override
-  public final void close() {
-    SpanProcessor.super.close();
   }
 }

--- a/common/src/main/java/co/elastic/otel/common/ElasticAttributes.java
+++ b/common/src/main/java/co/elastic/otel/common/ElasticAttributes.java
@@ -36,8 +36,8 @@ public interface ElasticAttributes {
   /** Used as marker on span-links to override the parent-child relationship for inferred spans. */
   AttributeKey<Boolean> IS_CHILD = AttributeKey.booleanKey("elastic.is_child");
 
-  AttributeKey<List<String>> PROFILER_STACK_TRACE_IDS = AttributeKey.stringArrayKey(
-      "elastic.profiler_stack_trace_ids");
+  AttributeKey<List<String>> PROFILER_STACK_TRACE_IDS =
+      AttributeKey.stringArrayKey("elastic.profiler_stack_trace_ids");
 
   // TODO : replace this with semantic conventions v1.24.0 equivalent once released
   AttributeKey<String> SPAN_STACKTRACE = AttributeKey.stringKey("code.stacktrace");

--- a/common/src/main/java/co/elastic/otel/common/ElasticAttributes.java
+++ b/common/src/main/java/co/elastic/otel/common/ElasticAttributes.java
@@ -19,6 +19,7 @@
 package co.elastic.otel.common;
 
 import io.opentelemetry.api.common.AttributeKey;
+import java.util.List;
 
 public interface ElasticAttributes {
   AttributeKey<Long> SELF_TIME = AttributeKey.longKey("elastic.span.self_time");
@@ -34,6 +35,9 @@ public interface ElasticAttributes {
 
   /** Used as marker on span-links to override the parent-child relationship for inferred spans. */
   AttributeKey<Boolean> IS_CHILD = AttributeKey.booleanKey("elastic.is_child");
+
+  AttributeKey<List<String>> PROFILER_STACK_TRACE_IDS = AttributeKey.stringArrayKey(
+      "elastic.profiler_stack_trace_ids");
 
   // TODO : replace this with semantic conventions v1.24.0 equivalent once released
   AttributeKey<String> SPAN_STACKTRACE = AttributeKey.stringKey("code.stacktrace");

--- a/common/src/main/java/co/elastic/otel/common/util/HexUtils.java
+++ b/common/src/main/java/co/elastic/otel/common/util/HexUtils.java
@@ -47,6 +47,14 @@ public class HexUtils {
     appendHexChar(value, builder);
   }
 
+  public static void appendAsHex(byte[] value, StringBuilder builder) {
+    for (byte val : value) {
+      int intVal = ((int) val) & 0xFF;
+      appendHexChar(intVal >> 4, builder);
+      appendHexChar(intVal, builder);
+    }
+  }
+
   private static void appendHexChar(long value, StringBuilder sb) {
     sb.append(HEX_CHARS[(int) (value & 0x0F)]);
   }

--- a/common/src/test/java/co/elastic/otel/common/ChainingSpanProcessorAutoConfigurationTest.java
+++ b/common/src/test/java/co/elastic/otel/common/ChainingSpanProcessorAutoConfigurationTest.java
@@ -82,7 +82,18 @@ public class ChainingSpanProcessorAutoConfigurationTest {
         (props, registerer) ->
             registerer.register(
                 next -> {
-                  chainingProcessor.set(new AbstractSimpleChainingSpanProcessor(next) {});
+                  chainingProcessor.set(
+                      new AbstractSimpleChainingSpanProcessor(next) {
+                        @Override
+                        protected boolean requiresEnd() {
+                          return false;
+                        }
+
+                        @Override
+                        protected boolean requiresStart() {
+                          return false;
+                        }
+                      });
                   return chainingProcessor.get();
                 });
 
@@ -143,6 +154,11 @@ public class ChainingSpanProcessorAutoConfigurationTest {
                     }
 
                     @Override
+                    protected boolean requiresStart() {
+                      return true;
+                    }
+
+                    @Override
                     protected ReadableSpan doOnEnd(ReadableSpan readableSpan) {
                       int cnt = endCountA.incrementAndGet();
                       assertionCollector.collect(
@@ -152,6 +168,11 @@ public class ChainingSpanProcessorAutoConfigurationTest {
                             assertThat(AutoConfiguredDataCapture.getSpans()).hasSize(cnt - 1);
                           });
                       return readableSpan;
+                    }
+
+                    @Override
+                    protected boolean requiresEnd() {
+                      return true;
                     }
                   },
               ChainingSpanProcessorRegisterer.ORDER_FIRST);
@@ -170,6 +191,11 @@ public class ChainingSpanProcessorAutoConfigurationTest {
                     }
 
                     @Override
+                    protected boolean requiresStart() {
+                      return true;
+                    }
+
+                    @Override
                     protected ReadableSpan doOnEnd(ReadableSpan readableSpan) {
                       int cnt = endCountC.incrementAndGet();
                       assertionCollector.collect(
@@ -179,6 +205,11 @@ public class ChainingSpanProcessorAutoConfigurationTest {
                             assertThat(AutoConfiguredDataCapture.getSpans()).hasSize(cnt - 1);
                           });
                       return readableSpan;
+                    }
+
+                    @Override
+                    protected boolean requiresEnd() {
+                      return true;
                     }
                   },
               ChainingSpanProcessorRegisterer.ORDER_LAST);
@@ -200,6 +231,11 @@ public class ChainingSpanProcessorAutoConfigurationTest {
                     }
 
                     @Override
+                    protected boolean requiresStart() {
+                      return true;
+                    }
+
+                    @Override
                     protected ReadableSpan doOnEnd(ReadableSpan readableSpan) {
                       int cnt = endCountB.incrementAndGet();
                       assertionCollector.collect(
@@ -209,6 +245,11 @@ public class ChainingSpanProcessorAutoConfigurationTest {
                             assertThat(AutoConfiguredDataCapture.getSpans()).hasSize(cnt - 1);
                           });
                       return readableSpan;
+                    }
+
+                    @Override
+                    protected boolean requiresEnd() {
+                      return true;
                     }
                   },
               ChainingSpanProcessorRegisterer.ORDER_DEFAULT);

--- a/common/src/test/java/co/elastic/otel/common/util/HexUtilsTest.java
+++ b/common/src/test/java/co/elastic/otel/common/util/HexUtilsTest.java
@@ -40,4 +40,14 @@ public class HexUtilsTest {
 
     assertThat(data).containsExactly(42, 0x00, 0x05, 0xab, 0xf1, 42);
   }
+
+  @Test
+  public void bytesToHexString() {
+    StringBuilder result = new StringBuilder();
+
+    HexUtils.appendAsHex(new byte[] {0x01, (byte) 0xAB, (byte) 0xFF}, result);
+
+    assertThat(result.toString()).isEqualTo("01abff");
+  }
+
 }

--- a/common/src/test/java/co/elastic/otel/common/util/HexUtilsTest.java
+++ b/common/src/test/java/co/elastic/otel/common/util/HexUtilsTest.java
@@ -49,5 +49,4 @@ public class HexUtilsTest {
 
     assertThat(result.toString()).isEqualTo("01abff");
   }
-
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -50,6 +50,7 @@ logback = "ch.qos.logback:logback-classic:1.4.14"
 jackson = "com.fasterxml.jackson.core:jackson-databind:2.16.0"
 protobuf-util = "com.google.protobuf:protobuf-java-util:3.25.2"
 mockito = "org.mockito:mockito-core:5.10.0"
+disruptor = "com.lmax:disruptor:3.4.4"
 
 junitBom = { group = "org.junit", name = "junit-bom", version.ref = "junit" }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -51,6 +51,7 @@ jackson = "com.fasterxml.jackson.core:jackson-databind:2.16.0"
 protobuf-util = "com.google.protobuf:protobuf-java-util:3.25.2"
 mockito = "org.mockito:mockito-core:5.10.0"
 disruptor = "com.lmax:disruptor:3.4.4"
+hdrhistogram = "org.hdrhistogram:HdrHistogram:2.1.12"
 
 junitBom = { group = "org.junit", name = "junit-bom", version.ref = "junit" }
 

--- a/inferred-spans/build.gradle.kts
+++ b/inferred-spans/build.gradle.kts
@@ -8,7 +8,7 @@ dependencies {
   compileOnly("io.opentelemetry:opentelemetry-sdk")
   compileOnly("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi")
   compileOnly(libs.findbugs.jsr305)
-  implementation("com.lmax:disruptor:3.4.4")
+  implementation(libs.disruptor)
   implementation("org.jctools:jctools-core:4.0.1")
   implementation(project(":common"))
 

--- a/jvmti-access/src/main/java/co/elastic/otel/UniversalProfilingCorrelation.java
+++ b/jvmti-access/src/main/java/co/elastic/otel/UniversalProfilingCorrelation.java
@@ -142,8 +142,8 @@ public class UniversalProfilingCorrelation {
    * <p>The returned message is a singleton and will be reused on subsequent invocations. Therefore,
    * the return value only remains valid until the next call of this method.
    *
-   * @throws DecodeException if anything went wrong decoding the current message. This exception
-   *     indicates that the call can be retried to fetch the next message.
+   * @throws DecodeException if anything went wrong decoding the current message. This
+   *     exception indicates that the call can be retried to fetch the next message.
    */
   @Nullable
   public static synchronized ProfilerMessage readProfilerReturnChannelMessage()

--- a/jvmti-access/src/main/java/co/elastic/otel/UniversalProfilingCorrelation.java
+++ b/jvmti-access/src/main/java/co/elastic/otel/UniversalProfilingCorrelation.java
@@ -142,8 +142,8 @@ public class UniversalProfilingCorrelation {
    * <p>The returned message is a singleton and will be reused on subsequent invocations. Therefore,
    * the return value only remains valid until the next call of this method.
    *
-   * @throws DecodeException if anything went wrong decoding the current message. This
-   *     exception indicates that the call can be retried to fetch the next message.
+   * @throws DecodeException if anything went wrong decoding the current message. This exception
+   *     indicates that the call can be retried to fetch the next message.
    */
   @Nullable
   public static synchronized ProfilerMessage readProfilerReturnChannelMessage()

--- a/jvmti-access/src/main/java/co/elastic/otel/profiler/DecodeException.java
+++ b/jvmti-access/src/main/java/co/elastic/otel/profiler/DecodeException.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package co.elastic.otel.profiler;
 
 public class DecodeException extends Exception {

--- a/jvmti-access/src/main/java/co/elastic/otel/profiler/DecodeException.java
+++ b/jvmti-access/src/main/java/co/elastic/otel/profiler/DecodeException.java
@@ -1,27 +1,5 @@
-/*
- * Licensed to Elasticsearch B.V. under one or more contributor
- * license agreements. See the NOTICE file distributed with
- * this work for additional information regarding copyright
- * ownership. Elasticsearch B.V. licenses this file to you under
- * the Apache License, Version 2.0 (the "License"); you may
- * not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
 package co.elastic.otel.profiler;
 
-/**
- * Indicates that a message could not be decoded. Possible reasons are for example the message was
- * smaller than it should be or contained malformed content.
- */
 public class DecodeException extends Exception {
 
   public DecodeException(String message, Throwable cause) {

--- a/universal-profiling-integration/build.gradle.kts
+++ b/universal-profiling-integration/build.gradle.kts
@@ -16,6 +16,7 @@ dependencies {
   implementation(project(":common"))
   implementation("io.opentelemetry.semconv:opentelemetry-semconv")
   implementation(libs.disruptor)
+  implementation(libs.hdrhistogram) //only used for the WriterReaderPhaser
 
   compileOnly("io.opentelemetry:opentelemetry-sdk")
   compileOnly(libs.findbugs.jsr305)

--- a/universal-profiling-integration/build.gradle.kts
+++ b/universal-profiling-integration/build.gradle.kts
@@ -15,7 +15,7 @@ dependencies {
   implementation(project(":jvmti-access"))
   implementation(project(":common"))
   implementation("io.opentelemetry.semconv:opentelemetry-semconv")
-
+  implementation(libs.disruptor)
 
   compileOnly("io.opentelemetry:opentelemetry-sdk")
   compileOnly(libs.findbugs.jsr305)

--- a/universal-profiling-integration/build.gradle.kts
+++ b/universal-profiling-integration/build.gradle.kts
@@ -25,4 +25,5 @@ dependencies {
   testImplementation("io.opentelemetry:opentelemetry-sdk")
   testImplementation("io.opentelemetry:opentelemetry-sdk-testing")
   testImplementation(libs.assertj.core)
+  testImplementation(libs.awaitility)
 }

--- a/universal-profiling-integration/src/jmh/java/co/elastic/otel/UniversalProfilingIntegrationBenchmark.java
+++ b/universal-profiling-integration/src/jmh/java/co/elastic/otel/UniversalProfilingIntegrationBenchmark.java
@@ -78,12 +78,12 @@ public class UniversalProfilingIntegrationBenchmark {
 
     @Setup(Level.Iteration)
     public void init(Blackhole blackhole) {
-      SdkTracerProviderBuilder builder =
-          SdkTracerProvider.builder().addSpanProcessor(new BlackholeSpanProcessor(blackhole));
+      BlackholeSpanProcessor spanProcessor = new BlackholeSpanProcessor(blackhole);
+      SdkTracerProviderBuilder builder = SdkTracerProvider.builder();
       if (universalProfilerProcessorActive) {
         Resource res =
             Resource.builder().put(ResourceAttributes.SERVICE_NAME, "benchmark-service").build();
-        builder.addSpanProcessor(new UniversalProfilingProcessor(res));
+        builder.addSpanProcessor(UniversalProfilingProcessor.builder(spanProcessor, res).build());
       }
       tracerProvider = builder.build();
 

--- a/universal-profiling-integration/src/main/java/co/elastic/otel/ProfilerSharedMemoryWriter.java
+++ b/universal-profiling-integration/src/main/java/co/elastic/otel/ProfilerSharedMemoryWriter.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package co.elastic.otel;
 
 import co.elastic.otel.common.util.HexUtils;
@@ -22,8 +40,8 @@ public class ProfilerSharedMemoryWriter {
 
   private static volatile int writeForMemoryBarrier = 0;
 
-  static ByteBuffer generateProcessCorrelationStorage(Resource serviceResource,
-      String socketFilePath) {
+  static ByteBuffer generateProcessCorrelationStorage(
+      Resource serviceResource, String socketFilePath) {
     String serviceName = serviceResource.getAttribute(ResourceAttributes.SERVICE_NAME);
     if (serviceName == null) {
       throw new IllegalStateException("A service name must be configured!");

--- a/universal-profiling-integration/src/main/java/co/elastic/otel/ProfilerSharedMemoryWriter.java
+++ b/universal-profiling-integration/src/main/java/co/elastic/otel/ProfilerSharedMemoryWriter.java
@@ -1,0 +1,92 @@
+package co.elastic.otel;
+
+import co.elastic.otel.common.util.HexUtils;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.semconv.ResourceAttributes;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+
+public class ProfilerSharedMemoryWriter {
+
+  private static final int TLS_MINOR_VERSION_OFFSET = 0;
+  private static final int TLS_VALID_OFFSET = 2;
+  private static final int TLS_TRACE_PRESENT_OFFSET = 3;
+  private static final int TLS_TRACE_FLAGS_OFFSET = 4;
+  private static final int TLS_TRACE_ID_OFFSET = 5;
+  private static final int TLS_SPAN_ID_OFFSET = 21;
+  private static final int TLS_LOCAL_ROOT_SPAN_ID_OFFSET = 29;
+  static final int TLS_STORAGE_SIZE = 37;
+
+  private static volatile int writeForMemoryBarrier = 0;
+
+  static ByteBuffer generateProcessCorrelationStorage(Resource serviceResource,
+      String socketFilePath) {
+    String serviceName = serviceResource.getAttribute(ResourceAttributes.SERVICE_NAME);
+    if (serviceName == null) {
+      throw new IllegalStateException("A service name must be configured!");
+    }
+    String environment = serviceResource.getAttribute(ResourceAttributes.SERVICE_NAMESPACE);
+
+    ByteBuffer buffer = ByteBuffer.allocateDirect(4096);
+    buffer.order(ByteOrder.nativeOrder());
+    buffer.position(0);
+
+    buffer.putChar((char) 1); // layout-minor-version
+    writeUtf8Str(buffer, serviceName);
+    writeUtf8Str(buffer, environment == null ? "" : environment);
+    writeUtf8Str(buffer, socketFilePath); // socket-file-path
+    return buffer;
+  }
+
+  private static void writeUtf8Str(ByteBuffer buffer, String str) {
+    byte[] utf8 = str.getBytes(StandardCharsets.UTF_8);
+    buffer.putInt(utf8.length);
+    buffer.put(utf8);
+  }
+
+  /**
+   * This method ensures that all writes which happened prior to this method call are not moved
+   * after the method call due to reordering.
+   *
+   * <p>This is realized based on the Java Memory Model guarantess for volatile variables. Relevant
+   * resources:
+   *
+   * <ul>
+   *   <li><a
+   *       href="https://stackoverflow.com/questions/17108541/happens-before-relationships-with-volatile-fields-and-synchronized-blocks-in-jav">StackOverflow
+   *       topic</a>
+   *   <li><a href="https://gee.cs.oswego.edu/dl/jmm/cookbook.html">JSR Compiler Cookbook</a>
+   * </ul>
+   */
+  private static void memoryStoreStoreBarrier() {
+    writeForMemoryBarrier = 42;
+  }
+
+  static void updateThreadCorrelationStorage(Span newSpan) {
+    ByteBuffer tls = UniversalProfilingCorrelation.getCurrentThreadStorage(true, TLS_STORAGE_SIZE);
+    // tls might be null if unsupported or something went wrong on initialization
+    if (tls != null) {
+      // the valid flag is used to signal the host-agent that it is reading incomplete data
+      tls.put(TLS_VALID_OFFSET, (byte) 0);
+      memoryStoreStoreBarrier();
+      tls.putChar(TLS_MINOR_VERSION_OFFSET, (char) 1);
+
+      SpanContext spanCtx = newSpan.getSpanContext();
+      if (spanCtx.isValid() && !spanCtx.isRemote()) {
+        tls.put(TLS_TRACE_PRESENT_OFFSET, (byte) 1);
+        tls.put(TLS_TRACE_FLAGS_OFFSET, spanCtx.getTraceFlags().asByte());
+        HexUtils.writeHexAsBinary(spanCtx.getTraceId(), 0, tls, TLS_TRACE_ID_OFFSET, 16);
+        HexUtils.writeHexAsBinary(spanCtx.getSpanId(), 0, tls, TLS_SPAN_ID_OFFSET, 8);
+        // TODO: write local root span ID here
+        HexUtils.writeHexAsBinary("0000000000000000", 0, tls, TLS_LOCAL_ROOT_SPAN_ID_OFFSET, 8);
+      } else {
+        tls.put(TLS_TRACE_PRESENT_OFFSET, (byte) 0);
+      }
+      memoryStoreStoreBarrier();
+      tls.put(TLS_VALID_OFFSET, (byte) 1);
+    }
+  }
+}

--- a/universal-profiling-integration/src/main/java/co/elastic/otel/SpanByIdSet.java
+++ b/universal-profiling-integration/src/main/java/co/elastic/otel/SpanByIdSet.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.otel;
+
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.sdk.trace.ReadableSpan;
+import java.lang.ref.Reference;
+import java.lang.ref.ReferenceQueue;
+import java.lang.ref.WeakReference;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import javax.annotation.Nullable;
+
+public class SpanByIdSet {
+
+  /**
+   * The value of an entry is always the same as the key in this map (=it is a set). We just use a
+   * map to allow a lookup of the original {@link WeakSpanWithId} via a {@link LookupKey}. While the
+   * type of this map is {@link TraceIdKeyed}, it only stores {@link WeakSpanWithId}s.
+   */
+  private final Map<TraceIdKeyed, TraceIdKeyed> spansById = new ConcurrentHashMap<>();
+
+  private final ReferenceQueue<ReadableSpan> collectedSpansQueue = new ReferenceQueue<>();
+
+  public void add(ReadableSpan span) {
+    WeakSpanWithId wrapper = new WeakSpanWithId(span, collectedSpansQueue);
+    spansById.putIfAbsent(wrapper, wrapper);
+  }
+
+  public void remove(ReadableSpan span) {
+    SpanContext ctx = span.getSpanContext();
+    LookupKey key = new LookupKey(ctx.getTraceId(), ctx.getSpanId());
+    spansById.remove(key);
+  }
+
+  public synchronized void expungeStaleEntries() {
+    Reference<? extends ReadableSpan> ref;
+    while ((ref = collectedSpansQueue.poll()) != null) {
+      WeakSpanWithId elem = ((WeakSpanWithId) ref);
+      spansById.remove(elem);
+    }
+  }
+
+  @Nullable
+  public ReadableSpan get(String traceId, String spanId) {
+    LookupKey key = new LookupKey(traceId, spanId);
+    WeakSpanWithId result = (WeakSpanWithId) spansById.get(key);
+    return result != null ? result.get() : null;
+  }
+
+  // For testing only
+  int size() {
+    return spansById.size();
+  }
+
+  private interface TraceIdKeyed {
+
+    String getTraceId();
+
+    String getSpanId();
+
+    static boolean equals(TraceIdKeyed self, Object o) {
+      if (!(o instanceof TraceIdKeyed)) {
+        return false;
+      }
+
+      TraceIdKeyed that = (TraceIdKeyed) o;
+
+      if (!self.getTraceId().equals(that.getTraceId())) {
+        return false;
+      }
+      return self.getSpanId().equals(that.getSpanId());
+    }
+
+    static int hashCode(TraceIdKeyed self) {
+      int result = self.getTraceId().hashCode();
+      result = 31 * result + self.getSpanId().hashCode();
+      return result;
+    }
+  }
+
+  private static class WeakSpanWithId extends WeakReference<ReadableSpan> implements TraceIdKeyed {
+    private final String traceId;
+    private final String spanId;
+
+    WeakSpanWithId(ReadableSpan span, ReferenceQueue<ReadableSpan> refQueue) {
+      super(span, refQueue);
+      SpanContext ctx = span.getSpanContext();
+      traceId = ctx.getTraceId();
+      spanId = ctx.getSpanId();
+      assertLowerCase(traceId);
+      assertLowerCase(spanId);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      return TraceIdKeyed.equals(this, o);
+    }
+
+    @Override
+    public int hashCode() {
+      return TraceIdKeyed.hashCode(this);
+    }
+
+    @Override
+    public String getTraceId() {
+      return traceId;
+    }
+
+    @Override
+    public String getSpanId() {
+      return spanId;
+    }
+  }
+
+  private static class LookupKey implements TraceIdKeyed {
+    private final String traceId;
+    private final String spanId;
+
+    public LookupKey(String traceId, String spanId) {
+      this.traceId = traceId;
+      this.spanId = spanId;
+      assertLowerCase(traceId);
+      assertLowerCase(spanId);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      return TraceIdKeyed.equals(this, o);
+    }
+
+    @Override
+    public int hashCode() {
+      return TraceIdKeyed.hashCode(this);
+    }
+
+    @Override
+    public String getTraceId() {
+      return traceId;
+    }
+
+    @Override
+    public String getSpanId() {
+      return spanId;
+    }
+  }
+
+  private static void assertLowerCase(String str) {
+    for (int i = 0; i < str.length(); i++) {
+      char c = str.charAt(i);
+      if (Character.isAlphabetic(c) && !Character.isLowerCase(c)) {
+        throw new IllegalArgumentException("Expected string to be lower case: " + str);
+      }
+    }
+  }
+}

--- a/universal-profiling-integration/src/main/java/co/elastic/otel/SpanProfilingSamplesCorrelator.java
+++ b/universal-profiling-integration/src/main/java/co/elastic/otel/SpanProfilingSamplesCorrelator.java
@@ -1,0 +1,183 @@
+package co.elastic.otel;
+
+import co.elastic.otel.common.ElasticAttributes;
+import co.elastic.otel.common.LocalRootSpan;
+import co.elastic.otel.common.MutableSpan;
+import co.elastic.otel.common.SpanValue;
+import co.elastic.otel.disruptor.FreezableList;
+import co.elastic.otel.disruptor.MoveableEvent;
+import co.elastic.otel.disruptor.PeekingPoller;
+import com.lmax.disruptor.EventPoller;
+import com.lmax.disruptor.RingBuffer;
+import com.lmax.disruptor.YieldingWaitStrategy;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.sdk.trace.ReadableSpan;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
+import java.util.function.LongSupplier;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class SpanProfilingSamplesCorrelator {
+
+  private static final Logger logger = Logger.getLogger(
+      SpanProfilingSamplesCorrelator.class.getName());
+
+  private static final SpanValue<FreezableList<String>> profilerStackTraceIds = SpanValue.createSparse();
+
+  private final SpanByIdSet spansById = new SpanByIdSet();
+
+  private final Consumer<ReadableSpan> sendSpan;
+
+  private final LongSupplier nanoClock;
+
+  private final RingBuffer<DelayedSpan> delayedSpans;
+  private final PeekingPoller<DelayedSpan> delayedSpansPoller;
+
+  private volatile long spanDelayNanos;
+
+  private final AtomicLong publishEnterCounter = new AtomicLong();
+  private final AtomicLong publishExitCounter = new AtomicLong();
+
+  public SpanProfilingSamplesCorrelator(
+      int bufferCapacity,
+      LongSupplier nanoClock,
+      long spanDelayNanos,
+      Consumer<ReadableSpan> sendSpan
+  ) {
+    this.nanoClock = nanoClock;
+    this.spanDelayNanos = spanDelayNanos;
+    this.sendSpan = sendSpan;
+
+    bufferCapacity = nextPowerOf2(bufferCapacity);
+    // We use a wait strategy which doesn't involve signaling via condition variables
+    // because we never block anyway (we use polling)
+    delayedSpans = RingBuffer.createMultiProducer(DelayedSpan::new, bufferCapacity,
+        new YieldingWaitStrategy());
+    EventPoller<DelayedSpan> nonPeekingPoller = delayedSpans.newPoller();
+    delayedSpans.addGatingSequences(nonPeekingPoller.getSequence());
+
+    delayedSpansPoller = new PeekingPoller<>(nonPeekingPoller, DelayedSpan::new);
+  }
+
+  public void onSpanStart(ReadableSpan span, Context parentCtx) {
+    boolean sampled = span.getSpanContext().getTraceFlags().isSampled();
+    boolean isLocalRoot = LocalRootSpan.getFor(span) == span;
+
+    if (sampled && isLocalRoot) {
+      spansById.add(span);
+    }
+  }
+
+  public void sendOrBufferSpan(ReadableSpan span) {
+    boolean sampled = span.getSpanContext().getTraceFlags().isSampled();
+    if (!sampled || LocalRootSpan.getFor(span) != span) {
+      sendSpan.accept(span);
+      return;
+    }
+
+    publishEnterCounter.incrementAndGet();
+    try {
+      if (spanDelayNanos == 0) {
+        correlateAndSendSpan(span);
+        return;
+      }
+
+      boolean couldPublish = delayedSpans.tryPublishEvent((event, idx, sp, timestamp) -> {
+        event.span = sp;
+        event.endNanoTimestamp = timestamp;
+      }, span, nanoClock.getAsLong());
+
+      if (!couldPublish) {
+        logger.log(Level.WARNING,
+            "The following span could not be delayed for correlation due to a full buffer, it will be sent immediately, {0}",
+            span);
+        correlateAndSendSpan(span);
+      }
+    } finally {
+      publishExitCounter.incrementAndGet();
+    }
+
+  }
+
+  public void correlate(String traceId, String localRootSpanId, CharSequence stackTraceId,
+      int count) {
+    ReadableSpan span = spansById.get(traceId, localRootSpanId);
+    if (span != null) {
+      FreezableList<String> list = profilerStackTraceIds.computeIfNull(span, FreezableList::new);
+      String stId = stackTraceId.toString();
+      for (int i = 0; i < count; i++) {
+        list.addIfNotFrozen(stId);
+      }
+    }
+  }
+
+  public synchronized void flushPendingDelayedSpans() {
+    try {
+      delayedSpansPoller.poll(delayedSpan -> {
+        long elapsed = nanoClock.getAsLong() - delayedSpan.endNanoTimestamp;
+        if (elapsed >= spanDelayNanos) {
+          return false; //span is not yet ready to be sent
+        }
+        correlateAndSendSpan(delayedSpan.span);
+        delayedSpan.clear();
+        return true;
+      });
+    } catch (Exception e) {
+      throw new IllegalStateException(e);
+    }
+    spansById.expungeStaleEntries();
+  }
+
+  public synchronized void shutdownAndFlushAll() {
+    spanDelayNanos = 0L; //This will cause spans to not be buffered anymore
+
+    // avoid race condition: we wait until we are
+    // sure that no more spans will be added to the ringbuffer
+    long waitFor = publishEnterCounter.get();
+    while (publishExitCounter.get() < waitFor) {
+      Thread.yield();
+    }
+    //every span is now pending because the desired delay is zero
+    flushPendingDelayedSpans();
+  }
+
+  private void correlateAndSendSpan(ReadableSpan span) {
+    spansById.remove(span);
+    FreezableList<String> list = profilerStackTraceIds.get(span);
+    if (list != null) {
+      MutableSpan mutableSpan = MutableSpan.makeMutable(span);
+      mutableSpan.setAttribute(ElasticAttributes.PROFILER_STACK_TRACE_IDS, list.freezeAndGet());
+      sendSpan.accept(mutableSpan);
+    } else {
+      sendSpan.accept(span);
+    }
+  }
+
+  private static class DelayedSpan implements MoveableEvent<DelayedSpan> {
+
+    ReadableSpan span;
+    long endNanoTimestamp;
+
+    @Override
+    public void moveInto(DelayedSpan other) {
+      other.span = span;
+      other.endNanoTimestamp = endNanoTimestamp;
+    }
+
+    @Override
+    public void clear() {
+      span = null;
+      endNanoTimestamp = -1;
+    }
+  }
+
+  private static int nextPowerOf2(int val) {
+    int result = 2;
+    while (result < val) {
+      result *= 2;
+    }
+    return result;
+  }
+
+}

--- a/universal-profiling-integration/src/main/java/co/elastic/otel/UniversalProfilingProcessor.java
+++ b/universal-profiling-integration/src/main/java/co/elastic/otel/UniversalProfilingProcessor.java
@@ -114,7 +114,7 @@ public class UniversalProfilingProcessor extends AbstractChainingSpanProcessor {
             ExecutorUtils.threadFactory("elastic-profiler-correlation-", true);
         messagePollAndSpanFlushExecutor = Executors.newSingleThreadScheduledExecutor(threadFac);
         messagePollAndSpanFlushExecutor.scheduleWithFixedDelay(
-            this::pollMessageAndFlushPendingSpans,
+            this::pollMessagesAndFlushPendingSpans,
             POLL_FREQUENCY_MS,
             POLL_FREQUENCY_MS,
             TimeUnit.MILLISECONDS);
@@ -218,7 +218,7 @@ public class UniversalProfilingProcessor extends AbstractChainingSpanProcessor {
   }
 
   // visible for testing
-  synchronized void pollMessageAndFlushPendingSpans() {
+  synchronized void pollMessagesAndFlushPendingSpans() {
     // Order is important: we only want to flush spans after we have consumed all pending messages
     // otherwise the data for the spans to be flushed might be incomplete
     consumeProfilerMessages();

--- a/universal-profiling-integration/src/main/java/co/elastic/otel/UniversalProfilingProcessor.java
+++ b/universal-profiling-integration/src/main/java/co/elastic/otel/UniversalProfilingProcessor.java
@@ -18,10 +18,14 @@
  */
 package co.elastic.otel;
 
+import co.elastic.otel.common.AbstractChainingSpanProcessor;
 import co.elastic.otel.common.LocalRootSpan;
+import co.elastic.otel.common.util.ExecutorUtils;
 import co.elastic.otel.common.util.HexUtils;
+import co.elastic.otel.profiler.DecodeException;
+import co.elastic.otel.profiler.ProfilerMessage;
+import co.elastic.otel.profiler.TraceCorrelationMessage;
 import io.opentelemetry.api.trace.Span;
-import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.ContextStorage;
 import io.opentelemetry.context.Scope;
@@ -30,30 +34,37 @@ import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.ReadWriteSpan;
 import io.opentelemetry.sdk.trace.ReadableSpan;
 import io.opentelemetry.sdk.trace.SpanProcessor;
-import io.opentelemetry.semconv.ResourceAttributes;
 import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
-import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Base64;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.function.LongSupplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
 
-public class UniversalProfilingProcessor implements SpanProcessor {
-
-  private static final int TLS_MINOR_VERSION_OFFSET = 0;
-  private static final int TLS_VALID_OFFSET = 2;
-  private static final int TLS_TRACE_PRESENT_OFFSET = 3;
-  private static final int TLS_TRACE_FLAGS_OFFSET = 4;
-  private static final int TLS_TRACE_ID_OFFSET = 5;
-  private static final int TLS_SPAN_ID_OFFSET = 21;
-  private static final int TLS_LOCAL_ROOT_SPAN_ID_OFFSET = 29;
-  static final int TLS_STORAGE_SIZE = 37;
+public class UniversalProfilingProcessor extends AbstractChainingSpanProcessor {
 
   private static final Logger log = Logger.getLogger(UniversalProfilingProcessor.class.getName());
+  private static final long POLL_FREQUENCY_MS = 20;
 
   private static boolean anyInstanceActive = false;
 
-  public UniversalProfilingProcessor(Resource serviceResource) {
+  private final SpanProfilingSamplesCorrelator correlator;
+
+  private final ScheduledExecutorService messagePollAndSpanFlushExecutor;
+
+  UniversalProfilingProcessor(
+      SpanProcessor next,
+      Resource serviceResource,
+      int bufferSize,
+      Duration spanDelay,
+      LongSupplier nanoClock
+  ) {
+    super(next);
     synchronized (UniversalProfilingProcessor.class) {
       if (anyInstanceActive) {
         throw new IllegalStateException(
@@ -62,52 +73,65 @@ public class UniversalProfilingProcessor implements SpanProcessor {
       }
       anyInstanceActive = true;
     }
-    populateProcessCorrelationStorage(serviceResource);
+
+    correlator = new SpanProfilingSamplesCorrelator(
+        bufferSize,
+        nanoClock,
+        spanDelay.toNanos(),
+        this.next::onEnd
+    );
+
+    ByteBuffer buff = ProfilerSharedMemoryWriter
+        .generateProcessCorrelationStorage(serviceResource, "");
+    UniversalProfilingCorrelation.setProcessStorage(buff);
     ActivationListener.setProcessor(this);
+
+    ThreadFactory threadFac = ExecutorUtils.threadFactory("elastic-profiler-correlation-", true);
+    messagePollAndSpanFlushExecutor = Executors.newSingleThreadScheduledExecutor(threadFac);
+    messagePollAndSpanFlushExecutor.scheduleWithFixedDelay(this::pollMessageAndFlushPendingSpans,
+        POLL_FREQUENCY_MS, POLL_FREQUENCY_MS, TimeUnit.MILLISECONDS);
+
   }
 
-  private void populateProcessCorrelationStorage(Resource serviceResource) {
-    String serviceName = serviceResource.getAttribute(ResourceAttributes.SERVICE_NAME);
-    if (serviceName == null) {
-      throw new IllegalStateException("A service name must be configured!");
+  public static UniversalProfilingProcessorBuilder builder(SpanProcessor next, Resource resource) {
+    return new UniversalProfilingProcessorBuilder(next, resource);
+  }
+
+  @Override
+  protected void doOnStart(Context context, ReadWriteSpan readWriteSpan) {
+    LocalRootSpan.onSpanStart(readWriteSpan, context);
+    correlator.onSpanStart(readWriteSpan, context);
+  }
+
+  @Override
+  public void onEnd(ReadableSpan readableSpan) {
+    correlator.sendOrBufferSpan(readableSpan);
+  }
+
+
+  @Override
+  protected CompletableResultCode doShutdown() {
+    ActivationListener.setProcessor(null);
+    UniversalProfilingCorrelation.reset();
+    anyInstanceActive = false;
+    messagePollAndSpanFlushExecutor.shutdown();
+    try {
+      messagePollAndSpanFlushExecutor.awaitTermination(10, TimeUnit.SECONDS);
+    } catch (InterruptedException e) {
+      log.log(Level.WARNING, "Could not wait for executor termination", e);
     }
-    String environment = serviceResource.getAttribute(ResourceAttributes.SERVICE_NAMESPACE);
-
-    ByteBuffer buffer = ByteBuffer.allocateDirect(4096);
-    buffer.order(ByteOrder.nativeOrder());
-    buffer.position(0);
-
-    buffer.putChar((char) 1); // layout-minor-version
-    writeUtf8Str(buffer, serviceName);
-    writeUtf8Str(buffer, environment == null ? "" : environment);
-    // TODO: implement socket connection
-    writeUtf8Str(buffer, ""); // socket-file-path
-
-    UniversalProfilingCorrelation.setProcessStorage(buffer);
-  }
-
-  private static void writeUtf8Str(ByteBuffer buffer, String str) {
-    byte[] utf8 = str.getBytes(StandardCharsets.UTF_8);
-    buffer.putInt(utf8.length);
-    buffer.put(utf8);
+    correlator.shutdownAndFlushAll();
+    return CompletableResultCode.ofSuccess();
   }
 
   @Override
-  public void onStart(Context parentContext, ReadWriteSpan span) {
-    LocalRootSpan.onSpanStart(span, parentContext);
-  }
-
-  @Override
-  public boolean isStartRequired() {
+  protected boolean requiresStart() {
     return true;
   }
 
   @Override
-  public void onEnd(ReadableSpan span) {}
-
-  @Override
   public boolean isEndRequired() {
-    return false;
+    return true;
   }
 
   @Nullable
@@ -116,61 +140,10 @@ public class UniversalProfilingProcessor implements SpanProcessor {
       Span oldSpan = safeSpanFromContext(previous);
       Span newSpan = safeSpanFromContext(next);
       if (oldSpan != newSpan && !oldSpan.getSpanContext().equals(newSpan.getSpanContext())) {
-        updateThreadCorrelationStorage(newSpan);
+        ProfilerSharedMemoryWriter.updateThreadCorrelationStorage(newSpan);
       }
     } catch (Throwable t) {
       log.log(Level.SEVERE, "Error on context update", t);
-    }
-  }
-
-  private volatile int writeForMemoryBarrier = 0;
-
-  /**
-   * This method ensures that all writes which happened prior to this method call are not moved
-   * after the method call due to reordering.
-   *
-   * <p>This is realized based on the Java Memory Model guarantess for volatile variables. Relevant
-   * resources:
-   *
-   * <ul>
-   *   <li><a
-   *       href="https://stackoverflow.com/questions/17108541/happens-before-relationships-with-volatile-fields-and-synchronized-blocks-in-jav">StackOverflow
-   *       topic</a>
-   *   <li><a href="https://gee.cs.oswego.edu/dl/jmm/cookbook.html">JSR Compiler Cookbook</a>
-   * </ul>
-   */
-  private void memoryStoreStoreBarrier() {
-    writeForMemoryBarrier = 42;
-  }
-
-  private void updateThreadCorrelationStorage(Span newSpan) {
-    ByteBuffer tls = UniversalProfilingCorrelation.getCurrentThreadStorage(true, TLS_STORAGE_SIZE);
-    // tls might be null if unsupported or something went wrong on initialization
-    if (tls != null) {
-      // the valid flag is used to signal the host-agent that it is reading incomplete data
-      tls.put(TLS_VALID_OFFSET, (byte) 0);
-      memoryStoreStoreBarrier();
-      tls.putChar(TLS_MINOR_VERSION_OFFSET, (char) 1);
-
-      SpanContext spanCtx = newSpan.getSpanContext();
-      if (spanCtx.isValid() && !spanCtx.isRemote()) {
-        Span localRoot = LocalRootSpan.getFor(newSpan);
-        if (localRoot != null) {
-          String localRootSpanId = localRoot.getSpanContext().getSpanId();
-          tls.put(TLS_TRACE_PRESENT_OFFSET, (byte) 1);
-          tls.put(TLS_TRACE_FLAGS_OFFSET, spanCtx.getTraceFlags().asByte());
-          HexUtils.writeHexAsBinary(spanCtx.getTraceId(), 0, tls, TLS_TRACE_ID_OFFSET, 16);
-          HexUtils.writeHexAsBinary(spanCtx.getSpanId(), 0, tls, TLS_SPAN_ID_OFFSET, 8);
-          HexUtils.writeHexAsBinary(localRootSpanId, 0, tls, TLS_LOCAL_ROOT_SPAN_ID_OFFSET, 8);
-        } else {
-          tls.put(TLS_TRACE_PRESENT_OFFSET, (byte) 0);
-          log.log(Level.WARNING, "Cannot propagate trace with unknown local root: {0}", newSpan);
-        }
-      } else {
-        tls.put(TLS_TRACE_PRESENT_OFFSET, (byte) 0);
-      }
-      memoryStoreStoreBarrier();
-      tls.put(TLS_VALID_OFFSET, (byte) 1);
     }
   }
 
@@ -181,13 +154,45 @@ public class UniversalProfilingProcessor implements SpanProcessor {
     return Span.fromContext(context);
   }
 
-  @Override
-  public CompletableResultCode shutdown() {
-    ActivationListener.setProcessor(null);
-    UniversalProfilingCorrelation.reset();
-    anyInstanceActive = false;
-    return CompletableResultCode.ofSuccess();
+  private synchronized void pollMessageAndFlushPendingSpans() {
+    // Order is important: we only want to flush spans after we have consumed all pending messages
+    // otherwise the data for the spans to be flushed might be incomplete
+    consumeProfilerMessages();
+    correlator.flushPendingDelayedSpans();
   }
+
+  private void consumeProfilerMessages() {
+    StringBuilder tempBuffer = new StringBuilder();
+    while (true) {
+      try {
+        ProfilerMessage message = UniversalProfilingCorrelation.readProfilerReturnChannelMessage();
+        if (message == null) {
+          break;
+        } else if (message instanceof TraceCorrelationMessage) {
+          handleMessage((TraceCorrelationMessage) message, tempBuffer);
+        }
+      } catch (DecodeException e) {
+        log.log(Level.WARNING, "Failed to read profiler message", e);
+      } catch (Exception e) {
+        log.log(Level.SEVERE, "Cannot read from profiler socket", e);
+        break;
+      }
+    }
+  }
+
+  private void handleMessage(TraceCorrelationMessage message, StringBuilder tempBuffer) {
+    tempBuffer.setLength(0);
+    HexUtils.appendAsHex(message.getTraceId(), tempBuffer);
+    String traceId = tempBuffer.toString();
+
+    tempBuffer.setLength(0);
+    HexUtils.appendAsHex(message.getLocalRootSpanId(), tempBuffer);
+    String localRootSpanId = tempBuffer.toString();
+
+    String stackTraceId = Base64.getUrlEncoder().encodeToString(message.getStackTraceId());
+    correlator.correlate(traceId, localRootSpanId, stackTraceId, message.getSampleCount());
+  }
+
 
   private static class ActivationListener implements ContextStorage {
 

--- a/universal-profiling-integration/src/main/java/co/elastic/otel/UniversalProfilingProcessor.java
+++ b/universal-profiling-integration/src/main/java/co/elastic/otel/UniversalProfilingProcessor.java
@@ -50,10 +50,28 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
 
+/**
+ * This processor correlates traces collected with CPU profiling data from the elastic universal
+ * profiler.
+ *
+ * <ul>
+ *   <li>The trace context and service information are provided to the profiler via native memory
+ *   <li>This processor receives profiling data from the profiler via an unix domain socket
+ *   <li>Local root spans will be delayed until their profiling data has arrived, the data will be
+ *       added to them as the {@link
+ *       co.elastic.otel.common.ElasticAttributes#PROFILER_STACK_TRACE_IDS} attribute
+ * </ul>
+ */
 public class UniversalProfilingProcessor extends AbstractChainingSpanProcessor {
 
   private static final Logger log = Logger.getLogger(UniversalProfilingProcessor.class.getName());
+
+  /**
+   * The frequency at which the processor polls the unix domain socket for new messages from the
+   * profiler.
+   */
   private static final long POLL_FREQUENCY_MS = 20;
+
   private static boolean anyInstanceActive = false;
 
   private final SpanProfilingSamplesCorrelator correlator;

--- a/universal-profiling-integration/src/main/java/co/elastic/otel/UniversalProfilingProcessorBuilder.java
+++ b/universal-profiling-integration/src/main/java/co/elastic/otel/UniversalProfilingProcessorBuilder.java
@@ -1,0 +1,44 @@
+package co.elastic.otel;
+
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.trace.SpanProcessor;
+import java.time.Duration;
+import java.util.function.LongSupplier;
+
+public class UniversalProfilingProcessorBuilder {
+
+
+  private final Resource resource;
+  private final SpanProcessor nextProcessor;
+  private Duration spanDelay = Duration.ofSeconds(10);
+
+  private LongSupplier nanoClock = System::nanoTime;
+
+  private int bufferSize = 8096;
+
+  UniversalProfilingProcessorBuilder(SpanProcessor next, Resource resource) {
+    this.resource = resource;
+    this.nextProcessor = next;
+  }
+
+  public UniversalProfilingProcessor build() {
+    return new UniversalProfilingProcessor(nextProcessor, resource, bufferSize, spanDelay,
+        nanoClock);
+  }
+
+  UniversalProfilingProcessorBuilder clock(LongSupplier nanoClock) {
+    this.nanoClock = nanoClock;
+    return this;
+  }
+
+  UniversalProfilingProcessorBuilder spanDelay(Duration delay) {
+    this.spanDelay = delay;
+    return this;
+  }
+
+  UniversalProfilingProcessorBuilder bufferSize(int bufferSize) {
+    this.bufferSize = bufferSize;
+    return this;
+  }
+
+}

--- a/universal-profiling-integration/src/main/java/co/elastic/otel/UniversalProfilingProcessorBuilder.java
+++ b/universal-profiling-integration/src/main/java/co/elastic/otel/UniversalProfilingProcessorBuilder.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package co.elastic.otel;
 
 import io.opentelemetry.sdk.resources.Resource;
@@ -7,7 +25,6 @@ import java.util.function.LongSupplier;
 
 public class UniversalProfilingProcessorBuilder {
 
-
   private final Resource resource;
   private final SpanProcessor nextProcessor;
   private Duration spanDelay = Duration.ofSeconds(10);
@@ -16,14 +33,16 @@ public class UniversalProfilingProcessorBuilder {
 
   private int bufferSize = 8096;
 
+  private String socketDir = System.getProperty("java.io.tmpdir");
+
   UniversalProfilingProcessorBuilder(SpanProcessor next, Resource resource) {
     this.resource = resource;
     this.nextProcessor = next;
   }
 
   public UniversalProfilingProcessor build() {
-    return new UniversalProfilingProcessor(nextProcessor, resource, bufferSize, spanDelay,
-        nanoClock);
+    return new UniversalProfilingProcessor(
+        nextProcessor, resource, bufferSize, spanDelay, socketDir, nanoClock);
   }
 
   UniversalProfilingProcessorBuilder clock(LongSupplier nanoClock) {
@@ -31,14 +50,18 @@ public class UniversalProfilingProcessorBuilder {
     return this;
   }
 
-  UniversalProfilingProcessorBuilder spanDelay(Duration delay) {
+  public UniversalProfilingProcessorBuilder spanDelay(Duration delay) {
     this.spanDelay = delay;
     return this;
   }
 
-  UniversalProfilingProcessorBuilder bufferSize(int bufferSize) {
+  public UniversalProfilingProcessorBuilder bufferSize(int bufferSize) {
     this.bufferSize = bufferSize;
     return this;
   }
 
+  public UniversalProfilingProcessorBuilder socketDir(String path) {
+    this.socketDir = path;
+    return this;
+  }
 }

--- a/universal-profiling-integration/src/main/java/co/elastic/otel/disruptor/FreezableList.java
+++ b/universal-profiling-integration/src/main/java/co/elastic/otel/disruptor/FreezableList.java
@@ -1,0 +1,22 @@
+package co.elastic.otel.disruptor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class FreezableList<T> {
+
+  private List<T> list = new ArrayList<>();
+  private boolean isFrozen = false;
+
+  public synchronized void addIfNotFrozen(T value) {
+    if (isFrozen) {
+      return;
+    }
+    list.add(value);
+  }
+
+  public synchronized List<T> freezeAndGet() {
+    isFrozen = true;
+    return list;
+  }
+}

--- a/universal-profiling-integration/src/main/java/co/elastic/otel/disruptor/FreezableList.java
+++ b/universal-profiling-integration/src/main/java/co/elastic/otel/disruptor/FreezableList.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package co.elastic.otel.disruptor;
 
 import java.util.ArrayList;

--- a/universal-profiling-integration/src/main/java/co/elastic/otel/disruptor/MoveableEvent.java
+++ b/universal-profiling-integration/src/main/java/co/elastic/otel/disruptor/MoveableEvent.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.otel.disruptor;
+
+public interface MoveableEvent<SELF extends MoveableEvent<?>> {
+
+  /**
+   * Moves the content from this event into the provided other event. This event should be in a
+   * resetted state after the call.
+   */
+  void moveInto(SELF other);
+
+  void clear();
+}

--- a/universal-profiling-integration/src/main/java/co/elastic/otel/disruptor/PeekingPoller.java
+++ b/universal-profiling-integration/src/main/java/co/elastic/otel/disruptor/PeekingPoller.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.otel.disruptor;
+
+import com.lmax.disruptor.EventPoller;
+import java.util.function.Supplier;
+
+public class PeekingPoller<Event extends MoveableEvent<Event>> {
+
+  public interface Handler<Event extends MoveableEvent<Event>> {
+
+    /**
+     * Handles an event fetched from the ring buffer.
+     *
+     * @return true, if the event was handled and shall be removed. False if the event was not
+     *     handled, no further invocations of handleEvent are desired and the same event shall be
+     *     provided for the next {@link PeekingPoller#poll(Handler)} call:
+     */
+    boolean handleEvent(Event e);
+  }
+
+  private final EventPoller<Event> poller;
+  private final Event peekedEvent;
+  private boolean peekedEventPopulated;
+
+  Handler<? super Event> currentHandler;
+  private final EventPoller.Handler<Event> subHandler = this::handleEvent;
+
+  public PeekingPoller(EventPoller<Event> wrappedPoller, Supplier<Event> emptyEventFactory) {
+    this.poller = wrappedPoller;
+    peekedEvent = emptyEventFactory.get();
+    peekedEventPopulated = false;
+  }
+
+  public synchronized void poll(Handler<? super Event> handler) throws Exception {
+    if (peekedEventPopulated) {
+      boolean handled = handler.handleEvent(peekedEvent);
+      if (!handled) {
+        return;
+      }
+      peekedEvent.clear();
+      peekedEventPopulated = false;
+    }
+    currentHandler = handler;
+    try {
+      poller.poll(subHandler);
+    } finally {
+      currentHandler = null;
+    }
+  }
+
+  private boolean handleEvent(Event event, long sequence, boolean endOfBatch) {
+    boolean handled = currentHandler.handleEvent(event);
+    if (handled) {
+      return true;
+    } else {
+      peekedEventPopulated = true;
+      event.moveInto(peekedEvent);
+      return false;
+    }
+  }
+}

--- a/universal-profiling-integration/src/main/java/co/elastic/otel/disruptor/PeekingPoller.java
+++ b/universal-profiling-integration/src/main/java/co/elastic/otel/disruptor/PeekingPoller.java
@@ -22,9 +22,9 @@ import com.lmax.disruptor.EventPoller;
 import java.util.function.Supplier;
 
 /**
- * Wrapper around {@link EventPoller} which allows to "peek" elements.
- * The provided event handling callback can decide to not handle an event.
- * In that case, the event will be provided again as first element on the next call to {@link #poll(Handler)}.
+ * Wrapper around {@link EventPoller} which allows to "peek" elements. The provided event handling
+ * callback can decide to not handle an event. In that case, the event will be provided again as
+ * first element on the next call to {@link #poll(Handler)}.
  */
 public class PeekingPoller<Event extends MoveableEvent<Event>> {
 

--- a/universal-profiling-integration/src/main/java/co/elastic/otel/disruptor/PeekingPoller.java
+++ b/universal-profiling-integration/src/main/java/co/elastic/otel/disruptor/PeekingPoller.java
@@ -21,6 +21,11 @@ package co.elastic.otel.disruptor;
 import com.lmax.disruptor.EventPoller;
 import java.util.function.Supplier;
 
+/**
+ * Wrapper around {@link EventPoller} which allows to "peek" elements.
+ * The provided event handling callback can decide to not handle an event.
+ * In that case, the event will be provided again as first element on the next call to {@link #poll(Handler)}.
+ */
 public class PeekingPoller<Event extends MoveableEvent<Event>> {
 
   public interface Handler<Event extends MoveableEvent<Event>> {
@@ -30,7 +35,7 @@ public class PeekingPoller<Event extends MoveableEvent<Event>> {
      *
      * @return true, if the event was handled and shall be removed. False if the event was not
      *     handled, no further invocations of handleEvent are desired and the same event shall be
-     *     provided for the next {@link PeekingPoller#poll(Handler)} call:
+     *     provided for the next {@link PeekingPoller#poll(Handler)} call.
      */
     boolean handleEvent(Event e);
   }

--- a/universal-profiling-integration/src/test/java/co/elastic/otel/SpanByIdSetTest.java
+++ b/universal-profiling-integration/src/test/java/co/elastic/otel/SpanByIdSetTest.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.otel;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+import co.elastic.otel.common.util.HexUtils;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.TraceFlags;
+import io.opentelemetry.api.trace.TraceState;
+import io.opentelemetry.sdk.trace.ReadableSpan;
+import java.lang.ref.WeakReference;
+import java.time.Duration;
+import java.util.Random;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class SpanByIdSetTest {
+
+  private final Random rnd = new Random(12345);
+
+  private SpanByIdSet set;
+
+  @BeforeEach
+  public void init() {
+    set = new SpanByIdSet();
+  }
+
+  @Test
+  public void checkLookup() {
+    ReadableSpan ab = mockSpan("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "bbbbbbbbbbbbbbbb");
+    ReadableSpan ac = mockSpan("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "cccccccccccccccc");
+    ReadableSpan db = mockSpan("dddddddddddddddddddddddddddddddd", "bbbbbbbbbbbbbbbb");
+    ReadableSpan dc = mockSpan("dddddddddddddddddddddddddddddddd", "cccccccccccccccc");
+
+    set.add(ab);
+    set.add(ac);
+    set.add(db);
+    set.add(dc);
+
+    assertThat(set.get("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "bbbbbbbbbbbbbbbb")).isSameAs(ab);
+    assertThat(set.get("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "cccccccccccccccc")).isSameAs(ac);
+    assertThat(set.get("dddddddddddddddddddddddddddddddd", "bbbbbbbbbbbbbbbb")).isSameAs(db);
+    assertThat(set.get("dddddddddddddddddddddddddddddddd", "cccccccccccccccc")).isSameAs(dc);
+  }
+
+  @Test
+  public void duplicateAddAndRemove() {
+    ReadableSpan span = mockSpan();
+    SpanContext ctx = span.getSpanContext();
+
+    set.add(span);
+    assertThat(set.get(ctx.getTraceId(), ctx.getSpanId())).isSameAs(span);
+
+    set.add(span);
+    assertThat(set.get(ctx.getTraceId(), ctx.getSpanId())).isSameAs(span);
+
+    set.remove(span);
+    assertThat(set.get(ctx.getTraceId(), ctx.getSpanId())).isNull();
+    set.remove(span);
+    assertThat(set.get(ctx.getTraceId(), ctx.getSpanId())).isNull();
+  }
+
+  @Test
+  public void testStaleEntriesExpunged() {
+    ReadableSpan span1 = mockSpan();
+    ReadableSpan span2 = mockSpan();
+    SpanContext sp1Ctx = span1.getSpanContext();
+    SpanContext sp2Ctx = span2.getSpanContext();
+
+    WeakReference<ReadableSpan> weakSp1 = new WeakReference<>(span1);
+
+    set.add(span1);
+    set.add(span2);
+
+    assertThat(set.size()).isEqualTo(2);
+    assertThat(set.get(sp1Ctx.getTraceId(), sp1Ctx.getSpanId())).isSameAs(span1);
+    assertThat(set.get(sp2Ctx.getTraceId(), sp2Ctx.getSpanId())).isSameAs(span2);
+
+    span1 = null;
+    waitToBeGCed(weakSp1);
+
+    assertThat(set.size()).isEqualTo(2);
+    assertThat(set.get(sp1Ctx.getTraceId(), sp1Ctx.getSpanId())).isNull();
+    assertThat(set.get(sp2Ctx.getTraceId(), sp2Ctx.getSpanId())).isSameAs(span2);
+
+    set.expungeStaleEntries();
+
+    assertThat(set.size()).isEqualTo(1);
+    assertThat(set.get(sp1Ctx.getTraceId(), sp1Ctx.getSpanId())).isNull();
+    assertThat(set.get(sp2Ctx.getTraceId(), sp2Ctx.getSpanId())).isSameAs(span2);
+  }
+
+  private static void waitToBeGCed(WeakReference<ReadableSpan> weakSp1) {
+    await()
+        .atMost(Duration.ofSeconds(10))
+        .pollInterval(Duration.ofMillis(1))
+        .until(
+            () -> {
+              System.gc();
+              return weakSp1.get() == null;
+            });
+  }
+
+  private ReadableSpan mockSpan() {
+    StringBuilder traceId = new StringBuilder();
+    HexUtils.appendLongAsHex(rnd.nextLong(), traceId);
+    HexUtils.appendLongAsHex(rnd.nextLong(), traceId);
+    StringBuilder spanId = new StringBuilder();
+    HexUtils.appendLongAsHex(rnd.nextLong(), spanId);
+    return mockSpan(traceId.toString(), spanId.toString());
+  }
+
+  private ReadableSpan mockSpan(String traceId, String spanId) {
+    SpanContext ctx =
+        SpanContext.create(traceId, spanId, TraceFlags.getDefault(), TraceState.getDefault());
+    ReadableSpan result = mock(ReadableSpan.class);
+    doReturn(ctx).when(result).getSpanContext();
+    return result;
+  }
+}

--- a/universal-profiling-integration/src/test/java/co/elastic/otel/UniversalProfilingProcessorTest.java
+++ b/universal-profiling-integration/src/test/java/co/elastic/otel/UniversalProfilingProcessorTest.java
@@ -301,7 +301,7 @@ public class UniversalProfilingProcessorTest {
         sendMsg(span2, st2, 2);
 
         // ensure that the messages are processed now
-        processor.pollMessageAndFlushPendingSpans();
+        processor.pollMessagesAndFlushPendingSpans();
 
         span1.end();
         span2.end();
@@ -379,7 +379,7 @@ public class UniversalProfilingProcessorTest {
         sendMsg(span1, randomStackTraceId(1), 1);
 
         // ensure that the messages are processed now
-        processor.pollMessageAndFlushPendingSpans();
+        processor.pollMessagesAndFlushPendingSpans();
         span1.end();
 
         assertThat(spans.getFinishedSpanItems())
@@ -406,7 +406,7 @@ public class UniversalProfilingProcessorTest {
         sendMsg(child, randomStackTraceId(1), 1);
 
         // ensure that the messages are processed now
-        processor.pollMessageAndFlushPendingSpans();
+        processor.pollMessagesAndFlushPendingSpans();
         child.end();
 
         assertThat(spans.getFinishedSpanItems())

--- a/universal-profiling-integration/src/test/java/co/elastic/otel/UniversalProfilingProcessorTest.java
+++ b/universal-profiling-integration/src/test/java/co/elastic/otel/UniversalProfilingProcessorTest.java
@@ -19,56 +19,145 @@
 package co.elastic.otel;
 
 import static co.elastic.otel.ProfilerSharedMemoryWriter.TLS_STORAGE_SIZE;
-import static org.assertj.core.api.Assertions.assertThat;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
 
+import co.elastic.otel.common.ElasticAttributes;
 import co.elastic.otel.testing.MapGetter;
+import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.sdk.trace.SpanProcessor;
+import io.opentelemetry.sdk.trace.data.LinkData;
+import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
+import io.opentelemetry.sdk.trace.samplers.Sampler;
+import io.opentelemetry.sdk.trace.samplers.SamplingResult;
 import io.opentelemetry.semconv.ResourceAttributes;
+import java.lang.ref.WeakReference;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Duration;
+import java.util.Base64;
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.io.TempDir;
 
 @DisabledOnOs(OS.WINDOWS)
 public class UniversalProfilingProcessorTest {
 
-  private InMemorySpanExporter spans;
+  InMemorySpanExporter spans;
+  UniversalProfilingProcessor processor;
+
+  @TempDir private Path tempDir;
 
   @BeforeEach
-  public void initSpanExporter() {
-    spans = InMemorySpanExporter.create();
+  public void reset() {
+    spans = null;
+    processor = null;
   }
 
-  @Test
-  public void testRemoteSpanIgnored() {
-    try (OpenTelemetrySdk sdk = initSdk()) {
+  private OpenTelemetrySdk initSdk() {
+    return initSdk(builder -> {
+    });
+  }
 
-      Map<String, String> headers = new HashMap<>();
-      headers.put("traceparent", "00-0af7651916cd43dd8448eb211c80319c-00f067aa0ba902b7-01");
-      Context remoteCtx =
-          W3CTraceContextPropagator.getInstance().extract(Context.root(), headers, new MapGetter());
+  private OpenTelemetrySdk initSdk(Consumer<UniversalProfilingProcessorBuilder> customizer) {
+    Resource res = Resource.builder().put(ResourceAttributes.SERVICE_NAME, "my-service").build();
+    return initSdk(res, customizer, Sampler.alwaysOn());
+  }
 
-      assertThat(Span.fromContext(remoteCtx).getSpanContext().isRemote()).isTrue();
+  private OpenTelemetrySdk initSdk(
+      Consumer<UniversalProfilingProcessorBuilder> customizer, Sampler sampler) {
+    Resource res = Resource.builder().put(ResourceAttributes.SERVICE_NAME, "my-service").build();
+    return initSdk(res, customizer, sampler);
+  }
 
-      Tracer tracer = sdk.getTracer("test-tracer");
+  private OpenTelemetrySdk initSdk(
+      Resource res, Consumer<UniversalProfilingProcessorBuilder> customizer, Sampler sampler) {
+    spans = InMemorySpanExporter.create();
 
-      Span span = tracer.spanBuilder("first").startSpan();
+    // The InMemoryExporter resets the buffered spans on shutdown
+    // we however want to assert the exported spans after shutdown in some tests
+    SpanExporter ignoreShutdown =
+        new SpanExporter() {
+          @Override
+          public CompletableResultCode export(Collection<SpanData> collection) {
+            return spans.export(collection);
+          }
+
+          @Override
+          public CompletableResultCode flush() {
+            return CompletableResultCode.ofSuccess();
+          }
+
+          @Override
+          public CompletableResultCode shutdown() {
+            return CompletableResultCode.ofSuccess();
+          }
+        };
+
+    SpanProcessor exporter =
+        SimpleSpanProcessor.builder(ignoreShutdown).setExportUnsampledSpans(true).build();
+
+    UniversalProfilingProcessorBuilder builder =
+        UniversalProfilingProcessor.builder(exporter, res).socketDir(tempDir.toString());
+    customizer.accept(builder);
+    processor = builder.build();
+    return OpenTelemetrySdk.builder()
+        .setTracerProvider(
+            SdkTracerProvider.builder()
+                .addResource(res)
+                .addSpanProcessor(processor)
+                .setSampler(sampler)
+                .build())
+        .build();
+  }
+
+  @Nested
+  class SharedMemory {
+
+    @Test
+    public void testRemoteSpanIgnored() {
+      try (OpenTelemetrySdk sdk = initSdk()) {
+
+        Map<String, String> headers = new HashMap<>();
+        headers.put("traceparent", "00-0af7651916cd43dd8448eb211c80319c-00f067aa0ba902b7-01");
+        Context remoteCtx =
+            W3CTraceContextPropagator.getInstance()
+                .extract(Context.root(), headers, new MapGetter());
+
+        assertThat(Span.fromContext(remoteCtx).getSpanContext().isRemote()).isTrue();
+
+        Tracer tracer = sdk.getTracer("test-tracer");
+
+        Span span = tracer.spanBuilder("first").startSpan();
 
       checkTlsIs(Span.getInvalid(), null);
       try (Scope s1 = span.makeCurrent()) {
@@ -81,16 +170,16 @@ public class UniversalProfilingProcessorTest {
     }
   }
 
-  @Test
-  public void testNestedActivations() {
-    try (OpenTelemetrySdk sdk = initSdk()) {
+    @Test
+    public void testNestedActivations() {
+      try (OpenTelemetrySdk sdk = initSdk()) {
 
-      Tracer tracer = sdk.getTracer("test-tracer");
+        Tracer tracer = sdk.getTracer("test-tracer");
 
-      Span first = tracer.spanBuilder("first").startSpan();
-      Span second = tracer.spanBuilder("second").startSpan();
-      Span third =
-          tracer.spanBuilder("third").setParent(Context.current().with(second)).startSpan();
+        Span first = tracer.spanBuilder("first").startSpan();
+        Span second = tracer.spanBuilder("second").startSpan();
+        Span third =
+            tracer.spanBuilder("third").setParent(Context.current().with(second)).startSpan();
 
       checkTlsIs(Span.getInvalid(), null);
       try (Scope s1 = first.makeCurrent()) {
@@ -115,40 +204,44 @@ public class UniversalProfilingProcessorTest {
     }
   }
 
-  @Test
-  public void testProcessStoragePopulated() {
-    Resource withNamespace =
-        Resource.builder()
-            .put(ResourceAttributes.SERVICE_NAME, "service Ä 1")
-            .put(ResourceAttributes.SERVICE_NAMESPACE, "my nameßspace")
-            .build();
-    try (OpenTelemetrySdk sdk = initSdk(withNamespace)) {
-      checkProcessStorage("service Ä 1", "my nameßspace");
+    @Test
+    public void testProcessStoragePopulated() {
+      Resource withNamespace =
+          Resource.builder()
+              .put(ResourceAttributes.SERVICE_NAME, "service Ä 1")
+              .put(ResourceAttributes.SERVICE_NAMESPACE, "my nameßspace")
+              .build();
+      try (OpenTelemetrySdk sdk = initSdk(withNamespace, b -> {
+      }, Sampler.alwaysOn())) {
+        checkProcessStorage("service Ä 1", "my nameßspace");
+      }
+
+      Resource withoutNamespace =
+          Resource.builder().put(ResourceAttributes.SERVICE_NAME, "service Ä 2").build();
+      try (OpenTelemetrySdk sdk = initSdk(withoutNamespace, b -> {
+      }, Sampler.alwaysOn())) {
+        checkProcessStorage("service Ä 2", "");
+      }
     }
 
-    Resource withoutNamespace =
-        Resource.builder().put(ResourceAttributes.SERVICE_NAME, "service Ä 2").build();
-    try (OpenTelemetrySdk sdk = initSdk(withoutNamespace)) {
-      checkProcessStorage("service Ä 2", "");
+    private void checkProcessStorage(String expectedServiceName, String expectedEnv) {
+      ByteBuffer buffer = JvmtiAccessImpl.createProcessProfilingCorrelationBufferAlias(1000);
+      buffer.order(ByteOrder.nativeOrder());
+
+      String sockRegex = tempDir.toAbsolutePath().toString() + "/essock[a-zA-Z0-9]{8}";
+
+      assertThat(buffer.getChar()).isEqualTo((char) 1); // layout-minor-version
+      assertThat(readUtf8Str(buffer)).isEqualTo(expectedServiceName);
+      assertThat(readUtf8Str(buffer)).isEqualTo(expectedEnv);
+      assertThat(readUtf8Str(buffer)).matches(sockRegex); // socket file path
     }
-  }
 
-  private void checkProcessStorage(String expectedServiceName, String expectedEnv) {
-    ByteBuffer buffer = JvmtiAccessImpl.createProcessProfilingCorrelationBufferAlias(1000);
-    buffer.order(ByteOrder.nativeOrder());
-
-    assertThat(buffer.getChar()).isEqualTo((char) 1); // layout-minor-version
-    assertThat(readUtf8Str(buffer)).isEqualTo(expectedServiceName);
-    assertThat(readUtf8Str(buffer)).isEqualTo(expectedEnv);
-    assertThat(readUtf8Str(buffer)).isEqualTo(""); // socket file path
-  }
-
-  private static String readUtf8Str(ByteBuffer buffer) {
-    int serviceNameLen = buffer.getInt();
-    byte[] serviceUtf8 = new byte[serviceNameLen];
-    buffer.get(serviceUtf8);
-    return new String(serviceUtf8, StandardCharsets.UTF_8);
-  }
+    private static String readUtf8Str(ByteBuffer buffer) {
+      int serviceNameLen = buffer.getInt();
+      byte[] serviceUtf8 = new byte[serviceNameLen];
+      buffer.get(serviceUtf8);
+      return new String(serviceUtf8, StandardCharsets.UTF_8);
+    }
 
   private void checkTlsIs(Span span, Span localRoot) {
     ByteBuffer tls = JvmtiAccessImpl.createThreadProfilingCorrelationBufferAlias(TLS_STORAGE_SIZE);
@@ -158,11 +251,11 @@ public class UniversalProfilingProcessorTest {
       assertThat(tls.get(2)).isEqualTo((byte) 1); // valid byte
     }
 
-    SpanContext ctx = span.getSpanContext();
-    if (ctx.isValid()) {
-      assertThat(tls).isNotNull();
-      assertThat(tls.get(3)).isEqualTo((byte) 1); // trace-present-flag
-      assertThat(tls.get(4)).isEqualTo(ctx.getTraceFlags().asByte()); // trace-flags
+      SpanContext ctx = span.getSpanContext();
+      if (ctx.isValid()) {
+        assertThat(tls).isNotNull();
+        assertThat(tls.get(3)).isEqualTo((byte) 1); // trace-present-flag
+        assertThat(tls.get(4)).isEqualTo(ctx.getTraceFlags().asByte()); // trace-flags
 
       byte[] traceId = new byte[16];
       byte[] spanId = new byte[8];
@@ -181,19 +274,273 @@ public class UniversalProfilingProcessorTest {
     }
   }
 
-  private OpenTelemetrySdk initSdk() {
-    Resource res = Resource.builder().put(ResourceAttributes.SERVICE_NAME, "my-service").build();
-    return initSdk(res);
-  }
+  @Nested
+  class SpanCorrelation {
 
-  private OpenTelemetrySdk initSdk(Resource res) {
-    SpanProcessor exporter = SimpleSpanProcessor.create(spans);
-    return OpenTelemetrySdk.builder()
-        .setTracerProvider(
-            SdkTracerProvider.builder()
-                .addResource(res)
-                .addSpanProcessor(UniversalProfilingProcessor.builder(exporter, res).build())
-                .build())
-        .build();
+    @Test
+    void checkCorrelationFunctional() {
+
+      AtomicLong clock = new AtomicLong(0L);
+
+      try (OpenTelemetrySdk sdk =
+          initSdk(builder -> builder.clock(clock::get).spanDelay(Duration.ofNanos(1)))) {
+        Tracer tracer = sdk.getTracer("test-tracer");
+
+        Span span1 = tracer.spanBuilder("span1").startSpan();
+        Span span2 = tracer.spanBuilder("span2").startSpan();
+
+        byte[] st1 = randomStackTraceId(1);
+        sendMsg(span1, st1, 1);
+
+        // Send some garbage which should not affect our processing
+        JvmtiAccessImpl.sendToProfilerReturnChannelSocket0(new byte[] {1, 2, 3});
+
+        byte[] st2 = randomStackTraceId(2);
+        sendMsg(span2, st2, 2);
+
+        // ensure that the messages are processed now
+        processor.pollMessageAndFlushPendingSpans();
+
+        span1.end();
+        span2.end();
+
+        // ensure that spans are not sent, their delay has not yet elapsed
+        assertThat(spans.getFinishedSpanItems()).isEmpty();
+
+        byte[] st3 = randomStackTraceId(3);
+        sendMsg(span2, st2, 1);
+        sendMsg(span1, st3, 2);
+        sendMsg(span2, st3, 1);
+
+        clock.set(1L);
+        // now the background thread should consume those messages and flush the spans
+        await()
+            .atMost(Duration.ofSeconds(10))
+            .untilAsserted(
+                () -> {
+                  List<SpanData> spanData = spans.getFinishedSpanItems();
+                  assertThat(spanData)
+                      .hasSize(2)
+                      .anySatisfy(sp -> assertThat(sp).hasName("span1"))
+                      .anySatisfy(sp -> assertThat(sp).hasName("span2"));
+
+                  SpanData sp1Data =
+                      spanData.stream()
+                          .filter(sp -> sp.getName().equals("span1"))
+                          .findFirst()
+                          .get();
+                  assertThat(
+                      sp1Data.getAttributes().get(ElasticAttributes.PROFILER_STACK_TRACE_IDS))
+                      .containsExactlyInAnyOrder(base64(st1), base64(st3), base64(st3));
+
+                  SpanData sp2Data =
+                      spanData.stream()
+                          .filter(sp -> sp.getName().equals("span2"))
+                          .findFirst()
+                          .get();
+                  assertThat(
+                      sp2Data.getAttributes().get(ElasticAttributes.PROFILER_STACK_TRACE_IDS))
+                      .containsExactlyInAnyOrder(
+                          base64(st2), base64(st2), base64(st2), base64(st3));
+                });
+      }
+    }
+
+    @Test
+    void unsampledSpansNotCorrelated() {
+      Sampler sampler =
+          new Sampler() {
+            @Override
+            public SamplingResult shouldSample(
+                Context context,
+                String s,
+                String s1,
+                SpanKind spanKind,
+                Attributes attributes,
+                List<LinkData> list) {
+              return SamplingResult.recordOnly();
+            }
+
+            @Override
+            public String getDescription() {
+              return "";
+            }
+          };
+      try (OpenTelemetrySdk sdk =
+          initSdk(builder -> builder.clock(() -> 0L).spanDelay(Duration.ofNanos(1)), sampler)) {
+        Tracer tracer = sdk.getTracer("test-tracer");
+
+        Span span1 = tracer.spanBuilder("span1").startSpan();
+        assertThat(span1.getSpanContext().isSampled()).isFalse();
+
+        // Still send a stacktrace to make sure it is actually ignored
+        sendMsg(span1, randomStackTraceId(1), 1);
+
+        // ensure that the messages are processed now
+        processor.pollMessageAndFlushPendingSpans();
+        span1.end();
+
+        assertThat(spans.getFinishedSpanItems())
+            .hasSize(1)
+            .anySatisfy(
+                sp -> {
+                  assertThat(sp).hasName("span1");
+                  assertThat(sp.getAttributes().get(ElasticAttributes.PROFILER_STACK_TRACE_IDS))
+                      .isNull();
+                });
+      }
+    }
+
+    @Test
+    void nonLocalRootSpansNotDelayed() {
+      try (OpenTelemetrySdk sdk =
+          initSdk(builder -> builder.clock(() -> 0L).spanDelay(Duration.ofNanos(1)))) {
+        Tracer tracer = sdk.getTracer("test-tracer");
+
+        Span root = tracer.spanBuilder("root").startSpan();
+        Span child = tracer.spanBuilder("child").setParent(Context.root().with(root)).startSpan();
+
+        // Still send a stacktrace to make sure it is actually ignored
+        sendMsg(child, randomStackTraceId(1), 1);
+
+        // ensure that the messages are processed now
+        processor.pollMessageAndFlushPendingSpans();
+        child.end();
+
+        assertThat(spans.getFinishedSpanItems())
+            .hasSize(1)
+            .anySatisfy(
+                sp -> {
+                  assertThat(sp).hasName("child");
+                  assertThat(sp.getAttributes().get(ElasticAttributes.PROFILER_STACK_TRACE_IDS))
+                      .isNull();
+                });
+      }
+    }
+
+    @Test
+    void shutdownFlushesBufferedSpans() {
+      byte[] st1 = randomStackTraceId(1);
+
+      try (OpenTelemetrySdk sdk =
+          initSdk(builder -> builder.clock(() -> 0L).spanDelay(Duration.ofNanos(1)))) {
+        Tracer tracer = sdk.getTracer("test-tracer");
+
+        Span root = tracer.spanBuilder("root").startSpan();
+        root.end();
+
+        assertThat(spans.getFinishedSpanItems()).isEmpty();
+
+        sendMsg(root, st1, 1);
+      }
+
+      assertThat(spans.getFinishedSpanItems())
+          .hasSize(1)
+          .anySatisfy(
+              sp -> {
+                assertThat(sp).hasName("root");
+                assertThat(sp.getAttributes().get(ElasticAttributes.PROFILER_STACK_TRACE_IDS))
+                    .containsExactly(base64(st1));
+              });
+    }
+
+    @Test
+    void bufferCapacityExceeded() {
+      try (OpenTelemetrySdk sdk =
+          initSdk(
+              builder -> builder.clock(() -> 0L).spanDelay(Duration.ofNanos(1)).bufferSize(2))) {
+
+        Tracer tracer = sdk.getTracer("test-tracer");
+
+        Span span1 = tracer.spanBuilder("span1").startSpan();
+        span1.end();
+        Span span2 = tracer.spanBuilder("span2").startSpan();
+        span2.end();
+        // now the buffer should be full, span 3 should be sent immediately
+        Span span3 = tracer.spanBuilder("span3").startSpan();
+        span3.end();
+
+        assertThat(spans.getFinishedSpanItems())
+            .hasSize(1)
+            .anySatisfy(sp -> assertThat(sp).hasName("span3"));
+      }
+    }
+
+    @Test
+    void badSocketPath() throws Exception {
+      Path notADir = tempDir.resolve("not_a_dir");
+      Files.createFile(notADir);
+      String absPath = notADir.toAbsolutePath().toString();
+
+      assertThatThrownBy(
+          () -> {
+            try (OpenTelemetrySdk sdk = initSdk(builder -> builder.socketDir(absPath))) {
+            }
+          })
+          .hasMessageContaining("socket");
+
+      // Ensure no garbage is left behind, we can cleanly start again with good settings
+      try (OpenTelemetrySdk sdk = initSdk()) {
+        assertThat(Paths.get(processor.socketPath)).exists();
+      }
+    }
+
+    @Test
+    void socketParentDirCreated() throws Exception {
+      Path subDirs = tempDir.resolve("create/me");
+      String absolute = subDirs.toAbsolutePath().toString();
+
+      // Ensure no garbage is left behind, we can cleanly start with good settings
+      try (OpenTelemetrySdk sdk = initSdk(builder -> builder.socketDir(absolute))) {
+        assertThat(Paths.get(processor.socketPath)).exists();
+        assertThat(processor.socketPath).startsWith(absolute + "/");
+      }
+    }
+
+    @Test
+    void ensureCorrelationDoesNotPreventSpanGC() {
+      try (OpenTelemetrySdk sdk = initSdk()) {
+        Tracer tracer = sdk.getTracer("dummy-scope");
+        Span gcedWithoutEnd = tracer.spanBuilder("root").startSpan();
+
+        WeakReference weakSpan = new WeakReference(gcedWithoutEnd);
+        gcedWithoutEnd = null;
+
+        await()
+            .atMost(Duration.ofSeconds(10))
+            .pollInterval(Duration.ofMillis(1))
+            .untilAsserted(
+                () -> {
+                  System.gc();
+                  assertThat(weakSpan.get()).isNull();
+                });
+      }
+    }
+
+    private byte[] randomStackTraceId(int seed) {
+      byte[] id = new byte[16];
+      new Random(seed).nextBytes(id);
+      return id;
+    }
+
+    private String base64(byte[] data) {
+      return Base64.getUrlEncoder().withoutPadding().encodeToString(data);
+    }
+
+    void sendMsg(Span localRoot, byte[] stackTraceId, int count) {
+      byte[] traceId = localRoot.getSpanContext().getTraceIdBytes();
+      byte[] rootSpanId = localRoot.getSpanContext().getSpanIdBytes();
+
+      ByteBuffer message = ByteBuffer.allocate(46);
+      message.order(ByteOrder.nativeOrder());
+      message.putShort((short) 1); // message-type = correlation message
+      message.putShort((short) 1); // message-version
+      message.put(traceId);
+      message.put(rootSpanId);
+      message.put(stackTraceId);
+      message.putShort((short) count);
+
+      JvmtiAccessImpl.sendToProfilerReturnChannelSocket0(message.array());
+    }
   }
 }

--- a/universal-profiling-integration/src/test/java/co/elastic/otel/UniversalProfilingProcessorTest.java
+++ b/universal-profiling-integration/src/test/java/co/elastic/otel/UniversalProfilingProcessorTest.java
@@ -84,8 +84,7 @@ public class UniversalProfilingProcessorTest {
   }
 
   private OpenTelemetrySdk initSdk() {
-    return initSdk(builder -> {
-    });
+    return initSdk(builder -> {});
   }
 
   private OpenTelemetrySdk initSdk(Consumer<UniversalProfilingProcessorBuilder> customizer) {
@@ -211,15 +210,13 @@ public class UniversalProfilingProcessorTest {
               .put(ResourceAttributes.SERVICE_NAME, "service Ä 1")
               .put(ResourceAttributes.SERVICE_NAMESPACE, "my nameßspace")
               .build();
-      try (OpenTelemetrySdk sdk = initSdk(withNamespace, b -> {
-      }, Sampler.alwaysOn())) {
+      try (OpenTelemetrySdk sdk = initSdk(withNamespace, b -> {}, Sampler.alwaysOn())) {
         checkProcessStorage("service Ä 1", "my nameßspace");
       }
 
       Resource withoutNamespace =
           Resource.builder().put(ResourceAttributes.SERVICE_NAME, "service Ä 2").build();
-      try (OpenTelemetrySdk sdk = initSdk(withoutNamespace, b -> {
-      }, Sampler.alwaysOn())) {
+      try (OpenTelemetrySdk sdk = initSdk(withoutNamespace, b -> {}, Sampler.alwaysOn())) {
         checkProcessStorage("service Ä 2", "");
       }
     }
@@ -332,7 +329,7 @@ public class UniversalProfilingProcessorTest {
                           .findFirst()
                           .get();
                   assertThat(
-                      sp1Data.getAttributes().get(ElasticAttributes.PROFILER_STACK_TRACE_IDS))
+                          sp1Data.getAttributes().get(ElasticAttributes.PROFILER_STACK_TRACE_IDS))
                       .containsExactlyInAnyOrder(base64(st1), base64(st3), base64(st3));
 
                   SpanData sp2Data =
@@ -341,7 +338,7 @@ public class UniversalProfilingProcessorTest {
                           .findFirst()
                           .get();
                   assertThat(
-                      sp2Data.getAttributes().get(ElasticAttributes.PROFILER_STACK_TRACE_IDS))
+                          sp2Data.getAttributes().get(ElasticAttributes.PROFILER_STACK_TRACE_IDS))
                       .containsExactlyInAnyOrder(
                           base64(st2), base64(st2), base64(st2), base64(st3));
                 });
@@ -475,10 +472,9 @@ public class UniversalProfilingProcessorTest {
       String absPath = notADir.toAbsolutePath().toString();
 
       assertThatThrownBy(
-          () -> {
-            try (OpenTelemetrySdk sdk = initSdk(builder -> builder.socketDir(absPath))) {
-            }
-          })
+              () -> {
+                try (OpenTelemetrySdk sdk = initSdk(builder -> builder.socketDir(absPath))) {}
+              })
           .hasMessageContaining("socket");
 
       // Ensure no garbage is left behind, we can cleanly start again with good settings

--- a/universal-profiling-integration/src/test/java/co/elastic/otel/UniversalProfilingProcessorTest.java
+++ b/universal-profiling-integration/src/test/java/co/elastic/otel/UniversalProfilingProcessorTest.java
@@ -84,7 +84,8 @@ public class UniversalProfilingProcessorTest {
   }
 
   private OpenTelemetrySdk initSdk() {
-    return initSdk(builder -> {});
+    return initSdk(builder -> {
+    });
   }
 
   private OpenTelemetrySdk initSdk(Consumer<UniversalProfilingProcessorBuilder> customizer) {
@@ -210,13 +211,15 @@ public class UniversalProfilingProcessorTest {
               .put(ResourceAttributes.SERVICE_NAME, "service Ä 1")
               .put(ResourceAttributes.SERVICE_NAMESPACE, "my nameßspace")
               .build();
-      try (OpenTelemetrySdk sdk = initSdk(withNamespace, b -> {}, Sampler.alwaysOn())) {
+      try (OpenTelemetrySdk sdk = initSdk(withNamespace, b -> {
+      }, Sampler.alwaysOn())) {
         checkProcessStorage("service Ä 1", "my nameßspace");
       }
 
       Resource withoutNamespace =
           Resource.builder().put(ResourceAttributes.SERVICE_NAME, "service Ä 2").build();
-      try (OpenTelemetrySdk sdk = initSdk(withoutNamespace, b -> {}, Sampler.alwaysOn())) {
+      try (OpenTelemetrySdk sdk = initSdk(withoutNamespace, b -> {
+      }, Sampler.alwaysOn())) {
         checkProcessStorage("service Ä 2", "");
       }
     }
@@ -329,7 +332,7 @@ public class UniversalProfilingProcessorTest {
                           .findFirst()
                           .get();
                   assertThat(
-                          sp1Data.getAttributes().get(ElasticAttributes.PROFILER_STACK_TRACE_IDS))
+                      sp1Data.getAttributes().get(ElasticAttributes.PROFILER_STACK_TRACE_IDS))
                       .containsExactlyInAnyOrder(base64(st1), base64(st3), base64(st3));
 
                   SpanData sp2Data =
@@ -338,7 +341,7 @@ public class UniversalProfilingProcessorTest {
                           .findFirst()
                           .get();
                   assertThat(
-                          sp2Data.getAttributes().get(ElasticAttributes.PROFILER_STACK_TRACE_IDS))
+                      sp2Data.getAttributes().get(ElasticAttributes.PROFILER_STACK_TRACE_IDS))
                       .containsExactlyInAnyOrder(
                           base64(st2), base64(st2), base64(st2), base64(st3));
                 });
@@ -472,9 +475,10 @@ public class UniversalProfilingProcessorTest {
       String absPath = notADir.toAbsolutePath().toString();
 
       assertThatThrownBy(
-              () -> {
-                try (OpenTelemetrySdk sdk = initSdk(builder -> builder.socketDir(absPath))) {}
-              })
+          () -> {
+            try (OpenTelemetrySdk sdk = initSdk(builder -> builder.socketDir(absPath))) {
+            }
+          })
           .hasMessageContaining("socket");
 
       // Ensure no garbage is left behind, we can cleanly start again with good settings
@@ -488,7 +492,6 @@ public class UniversalProfilingProcessorTest {
       Path subDirs = tempDir.resolve("create/me");
       String absolute = subDirs.toAbsolutePath().toString();
 
-      // Ensure no garbage is left behind, we can cleanly start with good settings
       try (OpenTelemetrySdk sdk = initSdk(builder -> builder.socketDir(absolute))) {
         assertThat(Paths.get(processor.socketPath)).exists();
         assertThat(processor.socketPath).startsWith(absolute + "/");

--- a/universal-profiling-integration/src/test/java/co/elastic/otel/disruptor/PeekingPollerTest.java
+++ b/universal-profiling-integration/src/test/java/co/elastic/otel/disruptor/PeekingPollerTest.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.otel.disruptor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.lmax.disruptor.EventPoller;
+import com.lmax.disruptor.RingBuffer;
+import com.lmax.disruptor.YieldingWaitStrategy;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+import org.junit.jupiter.api.Test;
+
+public class PeekingPollerTest {
+
+  private static class DummyEvent implements MoveableEvent<DummyEvent> {
+
+    private int val;
+
+    public DummyEvent() {
+      this(-1);
+    }
+
+    public DummyEvent(int val) {
+      this.val = val;
+    }
+
+    @Override
+    public void moveInto(DummyEvent other) {
+      other.val = val;
+      clear();
+    }
+
+    @Override
+    public void clear() {
+      val = -1;
+    }
+  }
+
+  private static class RecordingHandler implements PeekingPoller.Handler<DummyEvent> {
+
+    List<Integer> invocations = new ArrayList<>();
+    Function<Integer, Boolean> resultProvider;
+
+    @Override
+    public boolean handleEvent(DummyEvent event) {
+      invocations.add(event.val);
+      return resultProvider.apply(event.val);
+    }
+
+    void reset() {
+      invocations.clear();
+    }
+  }
+
+  @Test
+  public void testPeekingFunction() throws Exception {
+    RingBuffer<DummyEvent> rb =
+        RingBuffer.createMultiProducer(DummyEvent::new, 4, new YieldingWaitStrategy());
+    EventPoller<DummyEvent> nonPeekingPoller = rb.newPoller();
+    rb.addGatingSequences(nonPeekingPoller.getSequence());
+
+    PeekingPoller<DummyEvent> poller =
+        new PeekingPoller<DummyEvent>(nonPeekingPoller, DummyEvent::new);
+
+    RecordingHandler handler = new RecordingHandler();
+    handler.resultProvider = val -> false;
+    poller.poll(handler);
+    assertThat(handler.invocations).isEmpty();
+
+    assertThat(rb.tryPublishEvent((ev, srq) -> ev.val = 1)).isTrue();
+    assertThat(rb.tryPublishEvent((ev, srq) -> ev.val = 2)).isTrue();
+    assertThat(rb.tryPublishEvent((ev, srq) -> ev.val = 3)).isTrue();
+    assertThat(rb.tryPublishEvent((ev, srq) -> ev.val = 4)).isTrue();
+    assertThat(rb.tryPublishEvent((ev, srq) -> ev.val = 5)).isFalse();
+
+    poller.poll(handler);
+    assertThat(handler.invocations).containsExactly(1);
+    poller.poll(handler);
+    assertThat(handler.invocations).containsExactly(1, 1);
+
+    // It should now be possible to add one more element to the buffer
+    assertThat(rb.tryPublishEvent((ev, srq) -> ev.val = 5)).isTrue();
+    assertThat(rb.tryPublishEvent((ev, srq) -> ev.val = 6)).isFalse();
+
+    poller.poll(handler);
+    assertThat(handler.invocations).containsExactly(1, 1, 1);
+
+    // now consume elements up to index 2
+    handler.reset();
+    handler.resultProvider = i -> i != 3;
+
+    poller.poll(handler);
+    assertThat(handler.invocations).containsExactly(1, 2, 3);
+
+    // It should now be possible to add two more element to the buffer
+    assertThat(rb.tryPublishEvent((ev, srq) -> ev.val = 6)).isTrue();
+    assertThat(rb.tryPublishEvent((ev, srq) -> ev.val = 7)).isTrue();
+    assertThat(rb.tryPublishEvent((ev, srq) -> ev.val = 8)).isFalse();
+
+    poller.poll(handler);
+    assertThat(handler.invocations).containsExactly(1, 2, 3, 3);
+
+    // drain remaining elements
+    handler.reset();
+    handler.resultProvider = i -> true;
+
+    poller.poll(handler);
+    assertThat(handler.invocations).containsExactly(3, 4, 5, 6, 7);
+  }
+}


### PR DESCRIPTION
Implements the final part of the universal profiling correlation: The IDs of CPU stacktraces are attached as OTel attributes to local root spans. In order to ensure that the spans are not sent before all their data has arrived, they are buffered and delayed for a configurable amount of time.

In a future iteration we hopefully won't need to configure this aspect: The profiler will tell the agent via the communication socket what delay is expected, so that the agent can configure it automatically.