### PR TITLE
buildkite(hook): install gradle with some retry

### DIFF
--- a/.buildkite/hooks/prepare-common.sh
+++ b/.buildkite/hooks/prepare-common.sh
@@ -1,6 +1,26 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+retry() {
+    local retries=$1
+    shift
+
+    local count=0
+    until "$@"; do
+        exit=$?
+        wait=$((2 ** count))
+        count=$((count + 1))
+        if [ $count -lt "$retries" ]; then
+            >&2 echo "Retry $count/$retries exited $exit, retrying in $wait seconds..."
+            sleep $wait
+        else
+            >&2 echo "Retry $count/$retries exited $exit, no more retries left."
+            return $exit
+        fi
+    done
+    return 0
+}
+
 echo "--- Install JDK17 :java:"
 # JDK version is defined in two different locations, here and .github/workflows/build.yml
 JAVA_URL=https://jvm-catalog.elastic.co/jdk
@@ -16,3 +36,5 @@ export PATH
 
 java -version || true
 
+echo "--- Install Gradle :gradle:"
+retry 5 ./gradlew tasks --quiet


### PR DESCRIPTION
It failed, and we don't want environmental issues in the releases. For such, let's use the `pre-command` to install gradle 

<img width="1172" alt="image" src="https://github.com/elastic/elastic-otel-java/assets/2871786/4b8acf87-bfdd-4d25-ae5b-56255488c920">

In this [build](https://buildkite.com/elastic/elastic-otel-java-release/builds/1#018dd0d4-72f1-49f7-b4b0-29ef41bfca89) (Only accessible by Elastic employees)
