### PR TITLE
Release process: allow skipping maven-publish in case of retriggers of the workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,7 +111,7 @@ jobs:
     name: Wait for release to be available on maven-central
     if: inputs.dry_run == false
     needs:
-      - release
+      - validate-tag
     steps:
       - uses: elastic/apm-pipeline-library/.github/actions/await-maven-artifact@current
         with:


### PR DESCRIPTION
The await-maven-artifact job and all its dependents should not depend on the actual release-task:

It is possible that the maven-publish succeeded, but something else was wrong with the workflow (e.g. the GH-release could not be created due to a workflow error).

In that case we'll need to update the workflow and retrigger the release while skipping the maven-central deployment.
This will only work if those follow up jobs don't directly depend on the release job, because otherwise they'll be skipped aswell.