### PR TITLE
Fix and centralize publishing logic

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -52,6 +52,7 @@ jobs:
           vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
           vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
           pipeline: elastic-otel-java-snapshot
+          pipelineCommit: ${{ github.ref_name }}
           waitFor: false
           printBuildLogs: false
           buildEnvVars: |

--- a/agent/build.gradle.kts
+++ b/agent/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
   alias(catalog.plugins.licenseReport)
 }
 
-description = rootProject.description + " agent"
+description = "Elastic OpenTelemetry java distribution agent"
 
 base.archivesName.set("elastic-otel-javaagent")
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id "idea"
-  id "maven-publish"
   id "base" // required to get 'clean' task
   alias(catalog.plugins.nexusPublish)
 }
@@ -85,15 +84,6 @@ subprojects {
     }
   }
 
-  publishing {
-    repositories {
-      // dry-run repository will be wiped on 'clean' task
-      maven {
-        name = 'dryRun'
-        url = rootProject.layout.buildDirectory.dir("dry-run-maven-repo")
-      }
-    }
-  }
 }
 
 nexusPublishing {

--- a/buildSrc/src/main/kotlin/elastic-otel.library-packaging-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/elastic-otel.library-packaging-conventions.gradle.kts
@@ -11,7 +11,6 @@ tasks {
 
       include("LICENSE")
       include("NOTICE")
-      include("licenses/**")
     }
   }
 

--- a/buildSrc/src/main/kotlin/elastic-otel.sign-and-publish-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/elastic-otel.sign-and-publish-conventions.gradle.kts
@@ -19,6 +19,10 @@ publishingConventions.artifactTasks.convention(listOf())
 
 afterEvaluate {
 
+  if (project.description == null || project.description!!.isBlank()) {
+    throw GradleException("Project description must be set to publish the project to maven central!")
+  }
+
   publishing {
 
     repositories {
@@ -53,6 +57,7 @@ afterEvaluate {
         }
 
         pom {
+
           name.set(project.description)
           description.set(project.description)
           url.set("https://github.com/elastic/elastic-otel-java")

--- a/buildSrc/src/main/kotlin/elastic-otel.sign-and-publish-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/elastic-otel.sign-and-publish-conventions.gradle.kts
@@ -1,0 +1,91 @@
+plugins {
+  `maven-publish`
+  publishing
+  signing
+}
+
+interface PublishingConventionsPluginExtension {
+  /**
+   * By default the convention will publish the artifacts and pom as libraries.
+   * To override the behaviour provide the tasks producing the artifacts as this property.
+   * This should only be required when publishing fat-jars with custom packaging.
+   */
+  val artifactTasks: ListProperty<Task>
+}
+
+val publishingConventions = project.extensions.create<PublishingConventionsPluginExtension>("publishingConventions")
+publishingConventions.artifactTasks.convention(listOf())
+
+
+afterEvaluate {
+
+  publishing {
+
+    repositories {
+      // dry-run repository will be wiped on 'clean' task
+      maven {
+        name = "dryRun"
+        url = rootProject.layout.buildDirectory.dir("dry-run-maven-repo").get().asFile.toURI()
+      }
+    }
+
+    publications {
+      register("maven", MavenPublication::class) {
+        artifactId = base.archivesName.get()
+
+        val artifactTasks = publishingConventions.artifactTasks.get()
+        if (artifactTasks.isEmpty()) {
+          //publish as library with dependencies
+          from(components["java"])
+          versionMapping {
+            usage("java-api") {
+              fromResolutionOf("runtimeClasspath")
+            }
+            usage("java-runtime") {
+              fromResolutionResult()
+            }
+          }
+        } else {
+          //publish just the artifacts (fat-jars).
+          for (task in artifactTasks) {
+            artifact(task)
+          }
+        }
+
+        pom {
+          name.set(project.description)
+          description.set(project.description)
+          url.set("https://github.com/elastic/elastic-otel-java")
+          licenses {
+            license {
+              name.set("The Apache License, Version 2.0")
+              url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
+            }
+          }
+          developers {
+            developer {
+              name.set("Elastic Inc.")
+              url.set("https://www.elastic.co")
+            }
+          }
+          scm {
+            connection.set("scm:git:git@github.com:elastic/elastic-otel-java.git")
+            developerConnection.set("scm:git:git@github.com:elastic/elastic-otel-java.git")
+            url.set("https://github.com/elastic/elastic-otel-java")
+          }
+        }
+      }
+    }
+  }
+
+  signing {
+    setRequired({
+      // only sign in CI
+      System.getenv("CI") == "true"
+    })
+    // use in-memory ascii-armored key in environment variables
+    useInMemoryPgpKeys(System.getenv("KEY_ID_SECRET"), System.getenv("SECRING_ASC"), System.getenv("KEYPASS_SECRET"))
+    sign(publishing.publications["maven"])
+  }
+
+}

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -1,5 +1,7 @@
 plugins {
-    id("java-library")
+  id("java-library")
+  id("elastic-otel.library-packaging-conventions")
+  id("elastic-otel.sign-and-publish-conventions")
 }
 
 dependencies {

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -4,6 +4,8 @@ plugins {
   id("elastic-otel.sign-and-publish-conventions")
 }
 
+description = "Elastic OpenTelemetry common utilities"
+
 dependencies {
     annotationProcessor(libs.autoservice.processor)
     api("com.blogspot.mydailyjava:weak-lock-free:0.18")

--- a/inferred-spans/build.gradle.kts
+++ b/inferred-spans/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
   `java-library`
-  id("signing")
   id("elastic-otel.library-packaging-conventions")
+  id("elastic-otel.sign-and-publish-conventions")
 }
 
 description = rootProject.description + " inferred-spans"
@@ -47,55 +47,4 @@ tasks.processResources {
 
 tasks.withType<Test>().all {
   jvmArgs("-Djava.util.logging.config.file="+sourceSets.test.get().output.resourcesDir+"/logging.properties")
-}
-
-publishing {
-  publications {
-    create<MavenPublication>("maven") {
-
-      from(components["java"])
-
-      versionMapping {
-        usage("java-api") {
-          fromResolutionOf("runtimeClasspath")
-        }
-        usage("java-runtime") {
-          fromResolutionResult()
-        }
-      }
-
-      pom {
-        name.set(project.description)
-        description.set(project.description)
-        url.set("https://github.com/elastic/elastic-otel-java")
-        licenses {
-          license {
-            name.set("The Apache License, Version 2.0")
-            url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
-          }
-        }
-        developers {
-          developer {
-            name.set("Elastic Inc.")
-            url.set("https://www.elastic.co")
-          }
-        }
-        scm {
-          connection.set("scm:git:git@github.com:elastic/elastic-otel-java.git")
-          developerConnection.set("scm:git:git@github.com:elastic/elastic-otel-java.git")
-          url.set("https://github.com/elastic/elastic-otel-java")
-        }
-      }
-    }
-  }
-}
-
-signing {
-  setRequired({
-    // only sign in CI
-    System.getenv("CI") == "true"
-  })
-  // use in-memory ascii-armored key in environment variables
-  useInMemoryPgpKeys(System.getenv("KEY_ID_SECRET"), System.getenv("SECRING_ASC"), System.getenv("KEYPASS_SECRET"))
-  sign(publishing.publications["maven"])
 }

--- a/inferred-spans/build.gradle.kts
+++ b/inferred-spans/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
   id("elastic-otel.sign-and-publish-conventions")
 }
 
-description = rootProject.description + " inferred-spans"
+description = "Elastic OpenTelemetry Inferred Spans extension"
 
 dependencies {
   annotationProcessor(libs.autoservice.processor)


### PR DESCRIPTION
Closes #151.

Also currently our release was kind of broken: we published `inferred-spans` as a library, but didn't publish the `common` project it depends on.