### PR TITLE
script upstream update

### DIFF
--- a/.ci/update-upstream.sh
+++ b/.ci/update-upstream.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+set -x
+
+upstreamRef="${1:-main}"
+
+upstream_base_url="https://raw.githubusercontent.com/open-telemetry/opentelemetry-java-instrumentation/${upstreamRef}"
+project_root="$(dirname "${0}")/.."
+
+upstream_version() {
+    set +e
+    curl -s "${upstream_base_url}/${1}" \
+        | grep "val.*${2}.*=" \
+        | sed 's/.*=//' \
+        | tr -d '"' \
+        | tr -d '[:blank:]' \
+        || echo 'unknown'
+    set -e
+}
+
+upstreamAgentVersion="$(upstream_version 'version.gradle.kts' stableVersion)"
+upstreamAgentAlphaVersion="$(upstream_version 'version.gradle.kts' alphaVersion)"
+upstreamSdkVersion="$(upstream_version 'dependencyManagement/build.gradle.kts' otelSdkVersion)"
+upstreamContribVersion="$(upstream_version 'dependencyManagement/build.gradle.kts' otelContribVersion)"
+
+sed -i "s/^openTelemetrySdk = \".*/openTelemetrySdk = \"${upstreamSdkVersion}\"/" "${project_root}/gradle/libs.versions.toml"
+sed -i "s/^opentelemetryJavaagent = \".*/opentelemetryJavaagent = \"${upstreamAgentVersion}\"/" "${project_root}/gradle/libs.versions.toml"
+sed -i "s/^opentelemetryJavaagentAlpha = \".*/opentelemetryJavaagentAlpha = \"${upstreamAgentAlphaVersion}\"/" "${project_root}/gradle/libs.versions.toml"
+sed -i "s/^opentelemetryContribAlpha = \".*/opentelemetryContribAlpha = \"${upstreamContribVersion}\"/" "${project_root}/gradle/libs.versions.toml"
+

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,20 +6,23 @@ junit = "5.10.2"
 autoservice = "1.1.1"
 
 # otel SDK and API
+# updated from upstream agent with .ci/update-upstream.sh
 opentelemetrySdk = "1.35.0"
 
 # otel protocol (OTLP)
 opentelemetryProto = "1.1.0-alpha"
 
 # otel agent, those two should be updated together
+# updated from upstream agent with .ci/update-upstream.sh
 opentelemetryJavaagent = "2.1.0"
-opentelemetryJavaagentAlpha = "2.2.0-alpha-SNAPSHOT"
+opentelemetryJavaagentAlpha = "2.1.0-alpha"
 
 # otel semconv java generated bindings, needs to be kept in sync with version in otel agent
 opentelemetrySemconv = "1.23.1-alpha"
 
 # otel contrib
-opentelemetryContribAlpha = "1.34.0-alpha-SNAPSHOT"
+# updated from upstream agent with .ci/update-upstream.sh
+opentelemetryContribAlpha = "1.33.0-alpha"
 
 [libraries]
 


### PR DESCRIPTION
Adds a simple (and brittle) shell script that helps updating upstream dependencies when there is a new release.

takes git ref as parameter and does a simple parsing of the upstream agent dependencies files, so it's not perfect nor robust but does the job for now until we need better.

For reference, updates in the upstream project seem to also be relying on sed commands, for example here:
- https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/.github/scripts/update-sdk-version.sh
- https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/.github/scripts/update-version.sh