### PR TITLE
Split building and testing in workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,7 @@ jobs:
         with:
           name: working-dir-build-cache
           path: ./wdarch/working-dir-build-cache.tar.gz
+          retention-days: 1 # No need to waste space when this artifact is only used as part of the build process
 
       - name: Agent artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,11 +32,14 @@ jobs:
           # We also compile the test-classes, even though we are skipping the tests
           command: "./gradlew build testClasses -x test"
 
+      - name: Create working dir archive
+        run: "tar --exclude='./working-dir-build-cache.tar.gz' -czf ./working-dir-build-cache.tar.gz ."
+
       - name: Cache working directory with build results
         uses: actions/upload-artifact@v3
         with:
           name: working-dir-build-cache
-          path: ./
+          path: ./working-dir-build-cache.tar.gz
 
       - name: Agent artifact
         uses: actions/upload-artifact@v3
@@ -55,6 +58,8 @@ jobs:
         with:
           name: working-dir-build-cache
           path: ./
+      - name: Untar cached build working directory
+        run: "tar -xvf working-dir-build-cache.tar.gz"
       - name: Run tests
         uses: ./.github/workflows/gradle-goal
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,17 +19,18 @@ jobs:
       - uses: actions/checkout@v4
       - uses: gradle/wrapper-validation-action@v2.1.1
 
-  gradle:
+  build:
     runs-on: ubuntu-latest
     steps:
 
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Gradle build, test and check
+      - name: Gradle build without tests
         uses: ./.github/workflows/gradle-goal
         with:
-          command: "./gradlew check"
+          # We also compile the test-classes, even though we are skipping the tests
+          command: "./gradlew build testClasses -x test"
 
       - name: Warmup gradle wrapper
         uses: ./.github/workflows/gradle-goal
@@ -42,9 +43,36 @@ jobs:
           name: test-results
           path: '**/build/test-results/test/TEST-*.xml'
 
+      - name: Cache working directory with build results
+        uses: actions/upload-artifact@v3
+        with:
+          name: working-dir-build-cache
+          path: ./
+
       - name: Agent artifact
         uses: actions/upload-artifact@v3
         with:
           name: elastic-otel-javaagent
           path: |
             ./agent/build/libs/elastic-otel-javaagent-*.jar
+
+  test:
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+      - name: Download cached build working directory
+        uses: actions/download-artifact@v3
+        with:
+          name: working-dir-build-cache
+          path: ./
+      - name: Run tests
+        uses: ./.github/workflows/gradle-goal
+        with:
+          command: "./gradlew test"
+      - name: Store test results
+        if: success() || failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-results
+          path: '**/build/test-results/test/TEST-*.xml'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,11 @@ jobs:
           # We also compile the test-classes, even though we are skipping the tests
           command: "./gradlew build testClasses -x test"
 
+      - name: Test upload v4 performance
+        uses: actions/upload-artifact@v4
+        with:
+          name: wd-upload-perf-test
+          path: ./
       # We first tar the working directory and then upload it
       # We do this because uploading directories with many files directly as artifacts is very slow
       - name: Create working dir archive
@@ -41,7 +46,6 @@ jobs:
         with:
           name: working-dir-build-cache
           path: ./wdarch/working-dir-build-cache.tar.gz
-
       - name: Agent artifact
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,17 +33,17 @@ jobs:
           command: "./gradlew build testClasses -x test"
 
       # We first tar the working directory and then upload it
-      # We do this because uploading directories with many files directly as artifacts is very slow
+      # We do this because the upload-artifact action doesn't preserve file permissions
       - name: Create working dir archive
         run: "mkdir ./wdarch && tar --exclude='./wdarch' -czf ./wdarch/working-dir-build-cache.tar.gz ."
       - name: Cache working directory with build results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: working-dir-build-cache
           path: ./wdarch/working-dir-build-cache.tar.gz
 
       - name: Agent artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: elastic-otel-javaagent
           path: |
@@ -56,7 +56,7 @@ jobs:
     steps:
       # We use the cached working directory so that we don't have to recompile everything
       - name: Download cached build working directory
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: working-dir-build-cache
           path: ./

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,13 +33,13 @@ jobs:
           command: "./gradlew build testClasses -x test"
 
       - name: Create working dir archive
-        run: "tar --exclude='./working-dir-build-cache.tar.gz' -czf ./working-dir-build-cache.tar.gz ."
+        run: "mkdir ./wdarch && tar --exclude='./wdarch' -czf ./wdarch/working-dir-build-cache.tar.gz ."
 
       - name: Cache working directory with build results
         uses: actions/upload-artifact@v3
         with:
           name: working-dir-build-cache
-          path: ./working-dir-build-cache.tar.gz
+          path: ./wdarch/working-dir-build-cache.tar.gz
 
       - name: Agent artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,11 +32,6 @@ jobs:
           # We also compile the test-classes, even though we are skipping the tests
           command: "./gradlew build testClasses -x test"
 
-      - name: Test upload v4 performance
-        uses: actions/upload-artifact@v4
-        with:
-          name: wd-upload-perf-test
-          path: ./
       # We first tar the working directory and then upload it
       # We do this because uploading directories with many files directly as artifacts is very slow
       - name: Create working dir archive
@@ -46,6 +41,7 @@ jobs:
         with:
           name: working-dir-build-cache
           path: ./wdarch/working-dir-build-cache.tar.gz
+
       - name: Agent artifact
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,9 +32,10 @@ jobs:
           # We also compile the test-classes, even though we are skipping the tests
           command: "./gradlew build testClasses -x test"
 
+      # We first tar the working directory and then upload it
+      # We do this because uploading directories with many files directly as artifacts is very slow
       - name: Create working dir archive
         run: "mkdir ./wdarch && tar --exclude='./wdarch' -czf ./wdarch/working-dir-build-cache.tar.gz ."
-
       - name: Cache working directory with build results
         uses: actions/upload-artifact@v3
         with:
@@ -53,6 +54,7 @@ jobs:
     needs:
       - build
     steps:
+      # We use the cached working directory so that we don't have to recompile everything
       - name: Download cached build working directory
         uses: actions/download-artifact@v3
         with:
@@ -63,7 +65,11 @@ jobs:
       - name: Run tests
         uses: ./.github/workflows/gradle-goal
         with:
-          command: "./gradlew test"
+          # We manually skip the compileJni task because we know it is up-to-date in the cached
+          # working directory. The up-to-date check of this task checks for the presence of docker
+          # images used for compiling the native library, which do not exist because we are in a new
+          # environment.
+          command: "./gradlew test -x compileJni"
       - name: Store test results
         if: success() || failure()
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,22 +32,14 @@ jobs:
           # We also compile the test-classes, even though we are skipping the tests
           command: "./gradlew build testClasses -x test"
 
-      - name: Test upload v4 performance
+      - name: Cache working directory with build results
         uses: actions/upload-artifact@v4
         with:
-          name: wd-upload-perf-test
-          path: ./
-      # We first tar the working directory and then upload it
-      # We do this because uploading directories with many files directly as artifacts is very slow
-      - name: Create working dir archive
-        run: "mkdir ./wdarch && tar --exclude='./wdarch' -czf ./wdarch/working-dir-build-cache.tar.gz ."
-      - name: Cache working directory with build results
-        uses: actions/upload-artifact@v3
-        with:
           name: working-dir-build-cache
-          path: ./wdarch/working-dir-build-cache.tar.gz
+          path: ./
+          retention-days: 1 # No need to waste space when this artifact is only used as part of the build process
       - name: Agent artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: elastic-otel-javaagent
           path: |
@@ -60,12 +52,10 @@ jobs:
     steps:
       # We use the cached working directory so that we don't have to recompile everything
       - name: Download cached build working directory
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: working-dir-build-cache
           path: ./
-      - name: Untar cached build working directory
-        run: "tar -xvf working-dir-build-cache.tar.gz"
       - name: Run tests
         uses: ./.github/workflows/gradle-goal
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,17 +32,6 @@ jobs:
           # We also compile the test-classes, even though we are skipping the tests
           command: "./gradlew build testClasses -x test"
 
-      - name: Warmup gradle wrapper
-        uses: ./.github/workflows/gradle-goal
-        with:
-          command: "./gradlew check"
-      - name: Store test results
-        if: success() || failure()
-        uses: actions/upload-artifact@v3
-        with:
-          name: test-results
-          path: '**/build/test-results/test/TEST-*.xml'
-
       - name: Cache working directory with build results
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,14 +32,22 @@ jobs:
           # We also compile the test-classes, even though we are skipping the tests
           command: "./gradlew build testClasses -x test"
 
-      - name: Cache working directory with build results
+      - name: Test upload v4 performance
         uses: actions/upload-artifact@v4
         with:
-          name: working-dir-build-cache
+          name: wd-upload-perf-test
           path: ./
-          retention-days: 1 # No need to waste space when this artifact is only used as part of the build process
+      # We first tar the working directory and then upload it
+      # We do this because uploading directories with many files directly as artifacts is very slow
+      - name: Create working dir archive
+        run: "mkdir ./wdarch && tar --exclude='./wdarch' -czf ./wdarch/working-dir-build-cache.tar.gz ."
+      - name: Cache working directory with build results
+        uses: actions/upload-artifact@v3
+        with:
+          name: working-dir-build-cache
+          path: ./wdarch/working-dir-build-cache.tar.gz
       - name: Agent artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: elastic-otel-javaagent
           path: |
@@ -52,10 +60,12 @@ jobs:
     steps:
       # We use the cached working directory so that we don't have to recompile everything
       - name: Download cached build working directory
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: working-dir-build-cache
           path: ./
+      - name: Untar cached build working directory
+        run: "tar -xvf working-dir-build-cache.tar.gz"
       - name: Run tests
         uses: ./.github/workflows/gradle-goal
         with:


### PR DESCRIPTION
This has two benefits:
 * Allows us to easily introduce a matric-job for testing various JVM versions without always having to recompile
 * If the workflow fails, it will be immediately clear if it was due to compilation/checkStyle or tests
 
 Preparation for #180.