### PR TITLE
Allow testing for different JVM versions and implementations

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,3 +28,5 @@ updates:
       - dependency-name: "io.opentelemetry.instrumentation:*"
       - dependency-name: "io.opentelemetry.contrib:*"
       - dependency-name: "io.opentelemetry:*"
+      # Newer Mockito versions don't support java 8 anymore
+      - dependency-name: "org.mockito:mockito-core"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,6 +54,24 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build
+    strategy:
+      fail-fast: false #Even if the tests fail on one JDK we want to know if it also fails on others
+      matrix:
+        include:
+          - version: 8
+            vm: 'hotspot'
+          - version: 11
+            vm: 'hotspot'
+          - version: 17
+            vm: 'hotspot'
+          - version: 21
+            vm: 'hotspot'
+          - version: 22
+            vm: 'hotspot'
+          - version: 8
+            vm: 'openj9'
+          - version: 21
+            vm: 'openj9'
     steps:
       # We use the cached working directory so that we don't have to recompile everything
       - name: Download cached build working directory
@@ -70,10 +88,10 @@ jobs:
           # working directory. The up-to-date check of this task checks for the presence of docker
           # images used for compiling the native library, which do not exist because we are in a new
           # environment.
-          command: "./gradlew test -x compileJni"
+          command: "./gradlew test -x compileJni -PtestJavaVersion=${{ matrix.version }} -PtestJavaVM=${{ matrix.vm }}"
       - name: Store test results
         if: success() || failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: test-results
+          name: test-results-${{ matrix.version }}-${{ matrix.vm }}
           path: '**/build/test-results/test/TEST-*.xml'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,7 @@ jobs:
             vm: 'hotspot'
           - version: 22
             vm: 'hotspot'
-          - version: 8
+          - version: 11
             vm: 'openj9'
           - version: 21
             vm: 'openj9'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,6 +58,10 @@ jobs:
       # Even if the tests fail on one JDK we want to know if it also fails on others
       fail-fast: false 
       matrix:
+        # The JVMs for testing will be automatically downloaded by gradle using the toolchains-feature
+        # We use the following plugin to download them: https://github.com/gradle/foojay-toolchains
+        # We should make sure to always add the latest releases here when they are GA
+        # non LTS-releases should be removed if a newer version is GA
         include:
           - version: 8
             vm: 'hotspot'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,8 +66,6 @@ jobs:
             vm: 'hotspot'
           - version: 21
             vm: 'hotspot'
-          - version: 22
-            vm: 'hotspot'
           - version: 11
             vm: 'openj9'
           - version: 21

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,8 @@ jobs:
     needs:
       - build
     strategy:
-      fail-fast: false #Even if the tests fail on one JDK we want to know if it also fails on others
+      # Even if the tests fail on one JDK we want to know if it also fails on others
+      fail-fast: false 
       matrix:
         include:
           - version: 8

--- a/.github/workflows/test-reporter.yml
+++ b/.github/workflows/test-reporter.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: elastic/apm-pipeline-library/.github/actions/test-report@current
         with:
-          artifact: test-results            # artifact name
-          name: JUnit Tests                 # Name of the check run which will be created
+          artifact: /test-results-(.*)/     # artifact name
+          name: 'Test Results $1'           # Name of the check run which will be created
           path: "**/*.xml"                  # Path to test results (inside artifact .zip)
           reporter: java-junit              # Format of test results

--- a/README.md
+++ b/README.md
@@ -18,10 +18,16 @@ Use the `-javaagent:` JVM argument with the path to agent jar.
 java -javaagent:/path/to/agent.jar \
 -jar myapp.jar
 ```
-## Build
+## Build and Test
 
 Execute `./gradlew assemble`, the agent binary will be in `./agent/build/libs/elastic-otel-javaagent-${VERSION}.jar`
 where `${VERSION}` is the current project version set in [`version.properties`](version.properties).
+
+You can run the tests locally using `./gradlew test`. You can optionally specify the
+ * Java Version to test on, e.g. `-PtestJavaVersion=8`
+ * Java implementation to run on (`hotspot` or `openJ9`):  `-PtestJavaVM=openj9`
+
+You don't need to have a corresponding JVM installed, gradle automatically will download a matching one.
 
 ## Features
 

--- a/build.gradle
+++ b/build.gradle
@@ -78,6 +78,9 @@ subprojects {
     compileJava {
       options.release.set(8)
     }
+    compileTestJava {
+      options.release.set(8)
+    }
   }
 
 }

--- a/buildSrc/src/main/kotlin/elastic-otel.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/elastic-otel.java-conventions.gradle.kts
@@ -1,0 +1,23 @@
+plugins {
+  id("java")
+}
+
+afterEvaluate {
+  val testJavaVersion = gradle.startParameter.projectProperties["testJavaVersion"]?.let(JavaVersion::toVersion)
+  val useJ9 = gradle.startParameter.projectProperties["testJavaVM"]?.run { this == "openj9" }
+    ?: false
+  tasks.withType<Test>().configureEach {
+    if (testJavaVersion != null) {
+      javaLauncher.set(
+        javaToolchains.launcherFor {
+          languageVersion.set(JavaLanguageVersion.of(testJavaVersion.majorVersion))
+          implementation.set(if (useJ9) JvmImplementation.J9 else JvmImplementation.VENDOR_SPECIFIC)
+        }
+      )
+
+      //only run tests which have a compatible bytecode version
+      val compileVersion = JavaVersion.toVersion(project.tasks.compileTestJava.get().options.release.get())
+      isEnabled = isEnabled && testJavaVersion.isCompatibleWith(compileVersion)
+    }
+  }
+}

--- a/buildSrc/src/main/kotlin/elastic-otel.library-packaging-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/elastic-otel.library-packaging-conventions.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
-  id("java")
+  `java-library`
+  id("elastic-otel.java-conventions")
 }
 
 tasks {

--- a/buildSrc/src/main/kotlin/elastic-otel.test-with-agent-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/elastic-otel.test-with-agent-conventions.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  id("java")
+  id("elastic-otel.java-conventions")
 }
 
 val agentForTesting: Configuration by configurations.creating

--- a/custom/build.gradle.kts
+++ b/custom/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  java
+  id("elastic-otel.library-packaging-conventions")
 }
 
 dependencies {
@@ -24,7 +24,10 @@ dependencies {
   testImplementation(project(":testing-common"))
   testImplementation("io.opentelemetry:opentelemetry-sdk")
   testImplementation("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi")
-  testImplementation("io.opentelemetry.javaagent:opentelemetry-javaagent-tooling")
+  testImplementation("io.opentelemetry.javaagent:opentelemetry-javaagent-tooling") {
+    //The following dependency isn't actually needed, but breaks the classpath when testing with Java 8
+    exclude(group = "io.opentelemetry.javaagent", module = "opentelemetry-javaagent-tooling-java9")
+  }
   testImplementation("io.opentelemetry.semconv:opentelemetry-semconv")
 
   testAnnotationProcessor(libs.autoservice.processor)
@@ -36,5 +39,8 @@ dependencies {
   testImplementation("org.freemarker:freemarker:2.3.27-incubating")
 }
 tasks.withType<Test> {
-  systemProperty("elastic.otel.overwrite.config.docs", project.properties["elastic.otel.overwrite.config.docs"])
+  val overrideConfig = project.properties["elastic.otel.overwrite.config.docs"]
+  if (overrideConfig != null) {
+    systemProperty("elastic.otel.overwrite.config.docs", overrideConfig)
+  }
 }

--- a/custom/src/test/java/co/elastic/otel/config/ConfigurationExporterTest.java
+++ b/custom/src/test/java/co/elastic/otel/config/ConfigurationExporterTest.java
@@ -94,16 +94,15 @@ public class ConfigurationExporterTest {
             + "////\n");
     final Map<String, List<ConfigurationOption>> optionsByCategory = new HashMap<>();
     optionsByCategory.put("Elastic to Opentelemetry mapping", configurationRegistry);
-    temp.process(
-        Map.of(
-            "config",
-            optionsByCategory,
-            "keys",
-            configurationRegistry.stream()
-                .map(ConfigurationOption::getKey)
-                .sorted()
-                .collect(Collectors.toList())),
-        tempRenderedFile);
+    Map<String, Object> map = new HashMap<>();
+    map.put("config", optionsByCategory);
+    map.put(
+        "keys",
+        configurationRegistry.stream()
+            .map(ConfigurationOption::getKey)
+            .sorted()
+            .collect(Collectors.toList()));
+    temp.process(map, tempRenderedFile);
 
     return tempRenderedFile.toString();
   }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -37,7 +37,8 @@ logback = "ch.qos.logback:logback-classic:1.5.3"
 # version 2.16.1 has been compiled with java 21, which is likely a release error, thus stick to 2.16.0 until fixed in 2.16.2 or later
 jackson = "com.fasterxml.jackson.core:jackson-databind:2.16.0"
 protobuf-util = "com.google.protobuf:protobuf-java-util:3.25.3"
-mockito = "org.mockito:mockito-core:4.11.0" # last version supporting Java 8
+# last version supporting Java 8
+mockito = "org.mockito:mockito-core:4.11.0"
 
 junitBom = { group = "org.junit", name = "junit-bom", version.ref = "junit" }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -37,7 +37,7 @@ logback = "ch.qos.logback:logback-classic:1.5.3"
 # version 2.16.1 has been compiled with java 21, which is likely a release error, thus stick to 2.16.0 until fixed in 2.16.2 or later
 jackson = "com.fasterxml.jackson.core:jackson-databind:2.16.0"
 protobuf-util = "com.google.protobuf:protobuf-java-util:3.25.3"
-mockito = "org.mockito:mockito-core:5.11.0"
+mockito = "org.mockito:mockito-core:4.11.0" # last version supporting Java 8
 
 junitBom = { group = "org.junit", name = "junit-bom", version.ref = "junit" }
 

--- a/inferred-spans/build.gradle.kts
+++ b/inferred-spans/build.gradle.kts
@@ -1,5 +1,4 @@
 plugins {
-  `java-library`
   id("elastic-otel.library-packaging-conventions")
   id("elastic-otel.sign-and-publish-conventions")
 }

--- a/inferred-spans/src/test/java/co/elastic/otel/profiler/CallTreeSpanifyTest.java
+++ b/inferred-spans/src/test/java/co/elastic/otel/profiler/CallTreeSpanifyTest.java
@@ -23,6 +23,7 @@ import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.asser
 import co.elastic.otel.common.ElasticAttributes;
 import co.elastic.otel.profiler.pooling.ObjectPool;
 import co.elastic.otel.testing.DisabledOnAppleSilicon;
+import co.elastic.otel.testing.DisabledOnOpenJ9;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.TraceFlags;
 import io.opentelemetry.api.trace.TraceState;
@@ -51,6 +52,7 @@ class CallTreeSpanifyTest {
   @Test
   @DisabledOnOs(OS.WINDOWS)
   @DisabledOnAppleSilicon
+  @DisabledOnOpenJ9
   void testSpanification() throws Exception {
     FixedClock nanoClock = new FixedClock();
     try (ProfilerTestSetup setup =

--- a/inferred-spans/src/test/java/co/elastic/otel/profiler/CallTreeTest.java
+++ b/inferred-spans/src/test/java/co/elastic/otel/profiler/CallTreeTest.java
@@ -79,19 +79,19 @@ class CallTreeTest {
         CallTree.createRoot(
             ObjectPool.createRecyclable(100, CallTree.Root::new), traceContext.serialize(), 0);
     ObjectPool<CallTree> callTreePool = ObjectPool.createRecyclable(100, CallTree::new);
-    root.addStackTrace(List.of(StackFrame.of("A", "a")), 0, callTreePool, 0);
+    root.addStackTrace(Arrays.asList(StackFrame.of("A", "a")), 0, callTreePool, 0);
     root.addStackTrace(
-        List.of(StackFrame.of("A", "b"), StackFrame.of("A", "a")),
+        Arrays.asList(StackFrame.of("A", "b"), StackFrame.of("A", "a")),
         TimeUnit.MILLISECONDS.toNanos(10),
         callTreePool,
         0);
     root.addStackTrace(
-        List.of(StackFrame.of("A", "b"), StackFrame.of("A", "a")),
+        Arrays.asList(StackFrame.of("A", "b"), StackFrame.of("A", "a")),
         TimeUnit.MILLISECONDS.toNanos(20),
         callTreePool,
         0);
     root.addStackTrace(
-        List.of(StackFrame.of("A", "a")), TimeUnit.MILLISECONDS.toNanos(30), callTreePool, 0);
+        Arrays.asList(StackFrame.of("A", "a")), TimeUnit.MILLISECONDS.toNanos(30), callTreePool, 0);
     root.end(callTreePool, 0);
 
     System.out.println(root);
@@ -174,7 +174,7 @@ class CallTreeTest {
         },
         new Object[][] {
           {"a", 3},
-          {"  d", 1, List.of("c", "b")}
+          {"  d", 1, Arrays.asList("c", "b")}
         });
   }
 
@@ -240,7 +240,7 @@ class CallTreeTest {
           {"    2", 7},
           {"      b", 2},
           {"        c", 1},
-          {"      e", 1, List.of("d")},
+          {"      e", 1, Arrays.asList("d")},
         });
   }
 
@@ -321,7 +321,7 @@ class CallTreeTest {
             new Object[][] {
               {"a", 9},
               {"  1", 2},
-              {"  c", 3, List.of("b")},
+              {"  c", 3, Arrays.asList("b")},
               {"    2", 2},
             });
     assertThat(spans.get("a").getLinks())
@@ -354,7 +354,7 @@ class CallTreeTest {
             new Object[][] {
               {"a", 11},
               {"  1", 2},
-              {"  c", 4, List.of("b")},
+              {"  c", 4, Arrays.asList("b")},
               {"    2", 4},
               {"      3", 2},
             });
@@ -511,7 +511,7 @@ class CallTreeTest {
             },
             new Object[][] {
               {"1", 11},
-              {"  b", 2, List.of("a")},
+              {"  b", 2, Arrays.asList("a")},
               {"  2", 6},
               {"    3", 4},
               {"      c", 2}
@@ -537,7 +537,7 @@ class CallTreeTest {
         },
         new Object[][] {
           {"1", 13},
-          {"  b", 4, List.of("a")},
+          {"  b", 4, Arrays.asList("a")},
           {"    2", 2},
           {"  3", 6},
           {"    4", 4},
@@ -615,7 +615,7 @@ class CallTreeTest {
           {"1", 9},
           {"  a", 2},
           {"  2", 4},
-          {"    c", 2, List.of("b")}
+          {"    c", 2, Arrays.asList("b")}
         });
   }
 
@@ -896,7 +896,7 @@ class CallTreeTest {
         String spanName = ((String) expectedSpan[0]).trim();
         long durationMs = (int) expectedSpan[1] * 10;
         List<String> stackTrace =
-            expectedSpan.length == 3 ? (List<String>) expectedSpan[2] : List.of();
+            expectedSpan.length == 3 ? (List<String>) expectedSpan[2] : Arrays.asList();
         int nestingLevel = getNestingLevel((String) expectedSpan[0]);
         String parentName = getParentName(expectedSpans, i, nestingLevel);
         if (parentName == null) {

--- a/inferred-spans/src/test/java/co/elastic/otel/profiler/CallTreeTest.java
+++ b/inferred-spans/src/test/java/co/elastic/otel/profiler/CallTreeTest.java
@@ -142,9 +142,9 @@ class CallTreeTest {
     assertCallTree(
         new String[] {" bb bb", "aaaaaa"},
         new Object[][] {
-            {"a", 6},
-            {"  b", 2},
-            {"  b", 2}
+          {"a", 6},
+          {"  b", 2},
+          {"  b", 2}
         });
   }
 
@@ -153,14 +153,14 @@ class CallTreeTest {
     assertCallTree(
         new String[] {" cc ", " bbb", "aaaa"},
         new Object[][] {
-            {"a", 4},
-            {"  b", 3},
-            {"    c", 2}
+          {"a", 4},
+          {"  b", 3},
+          {"    c", 2}
         },
         new Object[][] {
-            {"a", 3},
-            {"  b", 2},
-            {"    c", 1}
+          {"a", 3},
+          {"  b", 2},
+          {"    c", 1}
         });
   }
 
@@ -169,14 +169,14 @@ class CallTreeTest {
     assertCallTree(
         new String[] {" dd ", " cc ", " bb ", "aaaa"},
         new Object[][] {
-            {"a", 4},
-            {"  b", 2},
-            {"    c", 2},
-            {"      d", 2}
+          {"a", 4},
+          {"  b", 2},
+          {"    c", 2},
+          {"      d", 2}
         },
         new Object[][] {
-            {"a", 3},
-            {"  d", 1, Arrays.asList("c", "b")}
+          {"a", 3},
+          {"  d", 1, Arrays.asList("c", "b")}
         });
   }
 
@@ -191,10 +191,10 @@ class CallTreeTest {
     assertCallTree(
         new String[] {"cccc", "aabb"},
         new Object[][] {
-            {"a", 2},
-            {"  c", 2},
-            {"b", 2},
-            {"  c", 2},
+          {"a", 2},
+          {"  c", 2},
+          {"b", 2},
+          {"  c", 2},
         });
   }
 
@@ -203,12 +203,12 @@ class CallTreeTest {
     assertCallTree(
         new String[] {"bbccbbcc", "bbbbbbbb", "aaaaaaaa"},
         new Object[][] {
-            {"a", 8},
-            {"  b", 8},
-            {"    b", 2},
-            {"    c", 2},
-            {"    b", 2},
-            {"    c", 2},
+          {"a", 8},
+          {"  b", 8},
+          {"    b", 2},
+          {"    c", 2},
+          {"    b", 2},
+          {"    c", 2},
         });
   }
 
@@ -217,11 +217,11 @@ class CallTreeTest {
     assertCallTree(
         new String[] {"bb", "aa"},
         new Object[][] {
-            {"a", 2},
-            {"  b", 2},
+          {"a", 2},
+          {"  b", 2},
         },
         new Object[][] {
-            {"b", 1},
+          {"b", 1},
         });
   }
 
@@ -230,19 +230,19 @@ class CallTreeTest {
     assertCallTree(
         new String[] {"    cc ee   ", "   bbb dd   ", " a aaaaaa a ", "1 2      2 1"},
         new Object[][] {
-            {"a", 8},
-            {"  b", 3},
-            {"    c", 2},
-            {"  d", 2},
-            {"    e", 2},
+          {"a", 8},
+          {"  b", 3},
+          {"    c", 2},
+          {"  d", 2},
+          {"    e", 2},
         },
         new Object[][] {
-            {"1", 11},
-            {"  a", 9},
-            {"    2", 7},
-            {"      b", 2},
-            {"        c", 1},
-            {"      e", 1, Arrays.asList("d")},
+          {"1", 11},
+          {"  a", 9},
+          {"    2", 7},
+          {"      b", 2},
+          {"        c", 1},
+          {"      e", 1, Arrays.asList("d")},
         });
   }
 
@@ -258,25 +258,25 @@ class CallTreeTest {
   void testDeactivationBeforeEnd() throws Exception {
     assertCallTree(
         new String[] {
-            "   dd      ",
-            "   cccc c  ",
-            "   bbbb bb ", // <- deactivation for span 2 happens before b and c ends
-            " a aaaa aa ", //    that means b and c must have started before 2 has been activated
-            "1 2    2  1" //    but we saw the first stack trace of b only after the activation of 2
+          "   dd      ",
+          "   cccc c  ",
+          "   bbbb bb ", // <- deactivation for span 2 happens before b and c ends
+          " a aaaa aa ", //    that means b and c must have started before 2 has been activated
+          "1 2    2  1" //    but we saw the first stack trace of b only after the activation of 2
         },
         new Object[][] {
-            {"a", 7},
-            {"  b", 6},
-            {"    c", 5},
-            {"      d", 2},
+          {"a", 7},
+          {"  b", 6},
+          {"    c", 5},
+          {"      d", 2},
         },
         new Object[][] {
-            {"1", 10},
-            {"  a", 8},
-            {"    b", 7},
-            {"      c", 6},
-            {"        2", 5},
-            {"          d", 1},
+          {"1", 10},
+          {"  a", 8},
+          {"    b", 7},
+          {"      c", 6},
+          {"        2", 5},
+          {"          d", 1},
         });
   }
 
@@ -291,15 +291,15 @@ class CallTreeTest {
     assertCallTree(
         new String[] {"   bbbb b     ", " a aaaa a a a ", "1 2    2 3 3 1"},
         new Object[][] {
-            {"a", 8},
-            {"  b", 5},
+          {"a", 8},
+          {"  b", 5},
         },
         new Object[][] {
-            {"1", 13},
-            {"  a", 11},
-            {"    b", 6},
-            {"      2", 5},
-            {"    3", 2},
+          {"1", 13},
+          {"  a", 11},
+          {"    b", 6},
+          {"      2", 5},
+          {"    3", 2},
         });
   }
 
@@ -316,15 +316,15 @@ class CallTreeTest {
         assertCallTree(
             new String[] {"      c c ", "      b b ", "a   a a aa", " 1 1 2 2  "},
             new Object[][] {
-                {"a", 5},
-                {"  b", 2},
-                {"    c", 2},
+              {"a", 5},
+              {"  b", 2},
+              {"    c", 2},
             },
             new Object[][] {
-                {"a", 9},
-                {"  1", 2},
-                {"  c", 3, Arrays.asList("b")},
-                {"    2", 2},
+              {"a", 9},
+              {"  1", 2},
+              {"  c", 3, Arrays.asList("b")},
+              {"    2", 2},
             });
     assertThat(spans.get("a").getLinks())
         .hasSize(1)
@@ -349,16 +349,16 @@ class CallTreeTest {
         assertCallTree(
             new String[] {"       c  c ", "       b  b ", "a   a  a  aa", " 1 1 23 32  "},
             new Object[][] {
-                {"a", 5},
-                {"  b", 2},
-                {"    c", 2},
+              {"a", 5},
+              {"  b", 2},
+              {"    c", 2},
             },
             new Object[][] {
-                {"a", 11},
-                {"  1", 2},
-                {"  c", 4, Arrays.asList("b")},
-                {"    2", 4},
-                {"      3", 2},
+              {"a", 11},
+              {"  1", 2},
+              {"  c", 4, Arrays.asList("b")},
+              {"    2", 4},
+              {"      3", 2},
             });
     assertThat(spans.get("a").getLinks())
         .hasSize(1)
@@ -379,13 +379,13 @@ class CallTreeTest {
     assertCallTree(
         new String[] {"bb   ", "aa a ", "  1 1"},
         new Object[][] {
-            {"a", 3},
-            {"  b", 2},
+          {"a", 3},
+          {"  b", 2},
         },
         new Object[][] {
-            {"a", 3},
-            {"  b", 1},
-            {"  1", 2}
+          {"a", 3},
+          {"  b", 1},
+          {"  1", 2}
         });
   }
 
@@ -398,13 +398,13 @@ class CallTreeTest {
     assertCallTree(
         new String[] {"bb   ", "aa  a", "  11 "},
         new Object[][] {
-            {"a", 3},
-            {"  b", 2},
+          {"a", 3},
+          {"  b", 2},
         },
         new Object[][] {
-            {"a", 4},
-            {"  b", 1},
-            {"  1", 1},
+          {"a", 4},
+          {"  b", 1},
+          {"  1", 1},
         });
   }
 
@@ -418,13 +418,13 @@ class CallTreeTest {
     assertCallTree(
         new String[] {" c   ", "bb   ", "aa  a", "  11 "},
         new Object[][] {
-            {"a", 3},
-            {"  b", 2},
+          {"a", 3},
+          {"  b", 2},
         },
         new Object[][] {
-            {"a", 4},
-            {"  b", 1},
-            {"  1", 1},
+          {"a", 4},
+          {"  b", 1},
+          {"  1", 1},
         });
   }
 
@@ -438,14 +438,14 @@ class CallTreeTest {
     assertCallTree(
         new String[] {"c  d   ", "b  b   ", "a  a  a", " 11 22 "},
         new Object[][] {
-            {"a", 3},
-            {"  b", 2},
+          {"a", 3},
+          {"  b", 2},
         },
         new Object[][] {
-            {"a", 6},
-            {"  b", 3},
-            {"    1", 1},
-            {"  2", 1},
+          {"a", 6},
+          {"  b", 3},
+          {"    1", 1},
+          {"  2", 1},
         });
   }
 
@@ -486,12 +486,12 @@ class CallTreeTest {
     assertCallTree(
         new String[] {"a  a  a", " 12 21 "},
         new Object[][] {
-            {"a", 3},
+          {"a", 3},
         },
         new Object[][] {
-            {"a", 6},
-            {"  1", 4},
-            {"    2", 2},
+          {"a", 6},
+          {"  1", 4},
+          {"    2", 2},
         });
   }
 
@@ -507,16 +507,16 @@ class CallTreeTest {
         assertCallTree(
             new String[] {" bbb        ", " aaa  ccc   ", "1   23   321"},
             new Object[][] {
-                {"a", 3},
-                {"  b", 3},
-                {"c", 3},
+              {"a", 3},
+              {"  b", 3},
+              {"c", 3},
             },
             new Object[][] {
-                {"1", 11},
-                {"  b", 2, Arrays.asList("a")},
-                {"  2", 6},
-                {"    3", 4},
-                {"      c", 2}
+              {"1", 11},
+              {"  b", 2, Arrays.asList("a")},
+              {"  2", 6},
+              {"    3", 4},
+              {"      c", 2}
             });
 
     assertThat(spans.get("b").getLinks()).isEmpty();
@@ -533,17 +533,17 @@ class CallTreeTest {
     assertCallTree(
         new String[] {"   d          ", " b b b        ", " a a a  ccc   ", "1 2 2 34   431"},
         new Object[][] {
-            {"a", 3},
-            {"  b", 3},
-            {"c", 3},
+          {"a", 3},
+          {"  b", 3},
+          {"c", 3},
         },
         new Object[][] {
-            {"1", 13},
-            {"  b", 4, Arrays.asList("a")},
-            {"    2", 2},
-            {"  3", 6},
-            {"    4", 4},
-            {"      c", 2}
+          {"1", 13},
+          {"  b", 4, Arrays.asList("a")},
+          {"    2", 2},
+          {"  3", 6},
+          {"    4", 4},
+          {"      c", 2}
         });
   }
 
@@ -560,18 +560,18 @@ class CallTreeTest {
         assertCallTree(
             new String[] {"  b b b  ccc    ", " aa a a  aaa  a ", "1  2 2 34   43 1"},
             new Object[][] {
-                {"a", 8},
-                {"  b", 3},
-                {"  c", 3},
+              {"a", 8},
+              {"  b", 3},
+              {"  c", 3},
             },
             new Object[][] {
-                {"1", 15},
-                {"  a", 13},
-                {"    b", 4},
-                {"      2", 2},
-                {"    3", 6},
-                {"      4", 4},
-                {"        c", 2}
+              {"1", 15},
+              {"  a", 13},
+              {"    b", 4},
+              {"      2", 2},
+              {"    3", 6},
+              {"      4", 4},
+              {"        c", 2}
             });
 
     assertThat(spans.get("b").getLinks())
@@ -609,15 +609,15 @@ class CallTreeTest {
     assertCallTree(
         new String[] {"     ccc  ", " aaa bbb  ", "1   2   21"},
         new Object[][] {
-            {"a", 3},
-            {"b", 3},
-            {"  c", 3},
+          {"a", 3},
+          {"b", 3},
+          {"  c", 3},
         },
         new Object[][] {
-            {"1", 9},
-            {"  a", 2},
-            {"  2", 4},
-            {"    c", 2, Arrays.asList("b")}
+          {"1", 9},
+          {"  a", 2},
+          {"  2", 4},
+          {"    c", 2, Arrays.asList("b")}
         });
   }
 
@@ -632,14 +632,14 @@ class CallTreeTest {
     assertCallTree(
         new String[] {" aaa bbb  ", "1   2   21"},
         new Object[][] {
-            {"a", 3},
-            {"b", 3},
+          {"a", 3},
+          {"b", 3},
         },
         new Object[][] {
-            {"1", 9},
-            {"  a", 2},
-            {"  2", 4},
-            {"    b", 2}
+          {"1", 9},
+          {"  a", 2},
+          {"  2", 4},
+          {"    b", 2}
         });
   }
 
@@ -671,14 +671,14 @@ class CallTreeTest {
     assertCallTree(
         new String[] {"     ccc  ", " aaa aaa  ", "1   2   21"},
         new Object[][] {
-            {"a", 6},
-            {"  c", 3},
+          {"a", 6},
+          {"  c", 3},
         },
         new Object[][] {
-            {"1", 9},
-            {"  a", 6},
-            {"    2", 4},
-            {"      c", 2}
+          {"1", 9},
+          {"  a", 6},
+          {"    2", 4},
+          {"      c", 2}
         });
   }
 
@@ -693,14 +693,14 @@ class CallTreeTest {
     assertCallTree(
         new String[] {"   bbb   ", " a aaa a ", "1 2   2 1"},
         new Object[][] {
-            {"a", 5},
-            {"  b", 3},
+          {"a", 5},
+          {"  b", 3},
         },
         new Object[][] {
-            {"1", 8},
-            {"  a", 6},
-            {"    2", 4},
-            {"      b", 2}
+          {"1", 8},
+          {"  a", 6},
+          {"    2", 4},
+          {"      b", 2}
         });
   }
 
@@ -716,25 +716,25 @@ class CallTreeTest {
   void testDectivationAfterEnd() throws Exception {
     assertCallTree(
         new String[] {
-            "     dd     ",
-            "   c ccc    ",
-            "  bb bbb    ", // <- deactivation for span 2 happens after b ends
-            " aaa aaa aa ", //    that means b must have ended after 2 has been deactivated
-            "1   2   2  1" //    but we saw the last stack trace of b before the deactivation of 2
+          "     dd     ",
+          "   c ccc    ",
+          "  bb bbb    ", // <- deactivation for span 2 happens after b ends
+          " aaa aaa aa ", //    that means b must have ended after 2 has been deactivated
+          "1   2   2  1" //    but we saw the last stack trace of b before the deactivation of 2
         },
         new Object[][] {
-            {"a", 8},
-            {"  b", 5},
-            {"    c", 4},
-            {"      d", 2},
+          {"a", 8},
+          {"  b", 5},
+          {"    c", 4},
+          {"      d", 2},
         },
         new Object[][] {
-            {"1", 11},
-            {"  a", 9},
-            {"    b", 6},
-            {"      c", 5},
-            {"        2", 4},
-            {"          d", 1},
+          {"1", 11},
+          {"  a", 9},
+          {"    b", 6},
+          {"      c", 5},
+          {"        2", 4},
+          {"          d", 1},
         });
   }
 
@@ -744,9 +744,9 @@ class CallTreeTest {
         new String[] {"    b    ", " aa a aa ", "1  2 2  1"},
         new Object[][] {{"a", 5}},
         new Object[][] {
-            {"1", 8},
-            {"  a", 6},
-            {"    2", 2},
+          {"1", 8},
+          {"  a", 6},
+          {"    2", 2},
         });
   }
 
@@ -765,9 +765,9 @@ class CallTreeTest {
         new String[] {"   c  c   ", "   b  b   ", " aaa  aaa ", "1   22   1"},
         new Object[][] {{"a", 6}},
         new Object[][] {
-            {"1", 9},
-            {"  a", 7},
-            {"    2", 1},
+          {"1", 9},
+          {"  a", 7},
+          {"    2", 1},
         });
   }
 
@@ -777,9 +777,9 @@ class CallTreeTest {
         new String[] {" aa  aa ", "1  22  1"},
         new Object[][] {{"a", 4}},
         new Object[][] {
-            {"1", 7},
-            {"  a", 5},
-            {"    2", 1},
+          {"1", 7},
+          {"  a", 5},
+          {"    2", 1},
         });
   }
 
@@ -789,10 +789,10 @@ class CallTreeTest {
         new String[] {" aa  aaa  aa ", "1  22   33  1"},
         new Object[][] {{"a", 7}},
         new Object[][] {
-            {"1", 12},
-            {"  a", 10},
-            {"    2", 1},
-            {"    3", 1},
+          {"1", 12},
+          {"  a", 10},
+          {"    2", 1},
+          {"    3", 1},
         });
   }
 
@@ -812,10 +812,10 @@ class CallTreeTest {
         new String[] {"  b  b c  c  ", " aa  aaa  aa ", "1  22   33  1"},
         new Object[][] {{"a", 7}},
         new Object[][] {
-            {"1", 12},
-            {"  a", 10},
-            {"    2", 1},
-            {"    3", 1},
+          {"1", 12},
+          {"  a", 10},
+          {"    2", 1},
+          {"    3", 1},
         });
   }
 
@@ -824,15 +824,15 @@ class CallTreeTest {
     assertCallTree(
         new String[] {"         bb    ", " aa  aaa aa aa ", "1  22   3  3  1"},
         new Object[][] {
-            {"a", 9},
-            {"  b", 2}
+          {"a", 9},
+          {"  b", 2}
         },
         new Object[][] {
-            {"1", 14},
-            {"  a", 12},
-            {"    2", 1},
-            {"    3", 3},
-            {"      b", 1},
+          {"1", 14},
+          {"  a", 12},
+          {"    2", 1},
+          {"    3", 3},
+          {"      b", 1},
         });
   }
 
@@ -849,12 +849,12 @@ class CallTreeTest {
     assertCallTree(
         new String[] {"  aaa ", "12 2 1"},
         new Object[][] {
-            {"a", 3},
+          {"a", 3},
         },
         new Object[][] {
-            {"1", 5},
-            {"  a", 3}, // a is actually a child of the transaction
-            {"    2", 2}, // 2 is not within the child_ids of a
+          {"1", 5},
+          {"  a", 3}, // a is actually a child of the transaction
+          {"    2", 2}, // 2 is not within the child_ids of a
         });
   }
 

--- a/inferred-spans/src/test/java/co/elastic/otel/profiler/CallTreeTest.java
+++ b/inferred-spans/src/test/java/co/elastic/otel/profiler/CallTreeTest.java
@@ -24,6 +24,7 @@ import static java.util.stream.Collectors.toMap;
 import co.elastic.otel.common.ElasticAttributes;
 import co.elastic.otel.profiler.pooling.ObjectPool;
 import co.elastic.otel.testing.DisabledOnAppleSilicon;
+import co.elastic.otel.testing.DisabledOnOpenJ9;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.Tracer;
@@ -52,6 +53,7 @@ import org.junit.jupiter.api.condition.OS;
 
 @DisabledOnOs(OS.WINDOWS)
 @DisabledOnAppleSilicon
+@DisabledOnOpenJ9
 class CallTreeTest {
 
   private ProfilerTestSetup profilerSetup;
@@ -140,9 +142,9 @@ class CallTreeTest {
     assertCallTree(
         new String[] {" bb bb", "aaaaaa"},
         new Object[][] {
-          {"a", 6},
-          {"  b", 2},
-          {"  b", 2}
+            {"a", 6},
+            {"  b", 2},
+            {"  b", 2}
         });
   }
 
@@ -151,14 +153,14 @@ class CallTreeTest {
     assertCallTree(
         new String[] {" cc ", " bbb", "aaaa"},
         new Object[][] {
-          {"a", 4},
-          {"  b", 3},
-          {"    c", 2}
+            {"a", 4},
+            {"  b", 3},
+            {"    c", 2}
         },
         new Object[][] {
-          {"a", 3},
-          {"  b", 2},
-          {"    c", 1}
+            {"a", 3},
+            {"  b", 2},
+            {"    c", 1}
         });
   }
 
@@ -167,14 +169,14 @@ class CallTreeTest {
     assertCallTree(
         new String[] {" dd ", " cc ", " bb ", "aaaa"},
         new Object[][] {
-          {"a", 4},
-          {"  b", 2},
-          {"    c", 2},
-          {"      d", 2}
+            {"a", 4},
+            {"  b", 2},
+            {"    c", 2},
+            {"      d", 2}
         },
         new Object[][] {
-          {"a", 3},
-          {"  d", 1, Arrays.asList("c", "b")}
+            {"a", 3},
+            {"  d", 1, Arrays.asList("c", "b")}
         });
   }
 
@@ -189,10 +191,10 @@ class CallTreeTest {
     assertCallTree(
         new String[] {"cccc", "aabb"},
         new Object[][] {
-          {"a", 2},
-          {"  c", 2},
-          {"b", 2},
-          {"  c", 2},
+            {"a", 2},
+            {"  c", 2},
+            {"b", 2},
+            {"  c", 2},
         });
   }
 
@@ -201,12 +203,12 @@ class CallTreeTest {
     assertCallTree(
         new String[] {"bbccbbcc", "bbbbbbbb", "aaaaaaaa"},
         new Object[][] {
-          {"a", 8},
-          {"  b", 8},
-          {"    b", 2},
-          {"    c", 2},
-          {"    b", 2},
-          {"    c", 2},
+            {"a", 8},
+            {"  b", 8},
+            {"    b", 2},
+            {"    c", 2},
+            {"    b", 2},
+            {"    c", 2},
         });
   }
 
@@ -215,11 +217,11 @@ class CallTreeTest {
     assertCallTree(
         new String[] {"bb", "aa"},
         new Object[][] {
-          {"a", 2},
-          {"  b", 2},
+            {"a", 2},
+            {"  b", 2},
         },
         new Object[][] {
-          {"b", 1},
+            {"b", 1},
         });
   }
 
@@ -228,19 +230,19 @@ class CallTreeTest {
     assertCallTree(
         new String[] {"    cc ee   ", "   bbb dd   ", " a aaaaaa a ", "1 2      2 1"},
         new Object[][] {
-          {"a", 8},
-          {"  b", 3},
-          {"    c", 2},
-          {"  d", 2},
-          {"    e", 2},
+            {"a", 8},
+            {"  b", 3},
+            {"    c", 2},
+            {"  d", 2},
+            {"    e", 2},
         },
         new Object[][] {
-          {"1", 11},
-          {"  a", 9},
-          {"    2", 7},
-          {"      b", 2},
-          {"        c", 1},
-          {"      e", 1, Arrays.asList("d")},
+            {"1", 11},
+            {"  a", 9},
+            {"    2", 7},
+            {"      b", 2},
+            {"        c", 1},
+            {"      e", 1, Arrays.asList("d")},
         });
   }
 
@@ -256,25 +258,25 @@ class CallTreeTest {
   void testDeactivationBeforeEnd() throws Exception {
     assertCallTree(
         new String[] {
-          "   dd      ",
-          "   cccc c  ",
-          "   bbbb bb ", // <- deactivation for span 2 happens before b and c ends
-          " a aaaa aa ", //    that means b and c must have started before 2 has been activated
-          "1 2    2  1" //    but we saw the first stack trace of b only after the activation of 2
+            "   dd      ",
+            "   cccc c  ",
+            "   bbbb bb ", // <- deactivation for span 2 happens before b and c ends
+            " a aaaa aa ", //    that means b and c must have started before 2 has been activated
+            "1 2    2  1" //    but we saw the first stack trace of b only after the activation of 2
         },
         new Object[][] {
-          {"a", 7},
-          {"  b", 6},
-          {"    c", 5},
-          {"      d", 2},
+            {"a", 7},
+            {"  b", 6},
+            {"    c", 5},
+            {"      d", 2},
         },
         new Object[][] {
-          {"1", 10},
-          {"  a", 8},
-          {"    b", 7},
-          {"      c", 6},
-          {"        2", 5},
-          {"          d", 1},
+            {"1", 10},
+            {"  a", 8},
+            {"    b", 7},
+            {"      c", 6},
+            {"        2", 5},
+            {"          d", 1},
         });
   }
 
@@ -289,15 +291,15 @@ class CallTreeTest {
     assertCallTree(
         new String[] {"   bbbb b     ", " a aaaa a a a ", "1 2    2 3 3 1"},
         new Object[][] {
-          {"a", 8},
-          {"  b", 5},
+            {"a", 8},
+            {"  b", 5},
         },
         new Object[][] {
-          {"1", 13},
-          {"  a", 11},
-          {"    b", 6},
-          {"      2", 5},
-          {"    3", 2},
+            {"1", 13},
+            {"  a", 11},
+            {"    b", 6},
+            {"      2", 5},
+            {"    3", 2},
         });
   }
 
@@ -314,15 +316,15 @@ class CallTreeTest {
         assertCallTree(
             new String[] {"      c c ", "      b b ", "a   a a aa", " 1 1 2 2  "},
             new Object[][] {
-              {"a", 5},
-              {"  b", 2},
-              {"    c", 2},
+                {"a", 5},
+                {"  b", 2},
+                {"    c", 2},
             },
             new Object[][] {
-              {"a", 9},
-              {"  1", 2},
-              {"  c", 3, Arrays.asList("b")},
-              {"    2", 2},
+                {"a", 9},
+                {"  1", 2},
+                {"  c", 3, Arrays.asList("b")},
+                {"    2", 2},
             });
     assertThat(spans.get("a").getLinks())
         .hasSize(1)
@@ -347,16 +349,16 @@ class CallTreeTest {
         assertCallTree(
             new String[] {"       c  c ", "       b  b ", "a   a  a  aa", " 1 1 23 32  "},
             new Object[][] {
-              {"a", 5},
-              {"  b", 2},
-              {"    c", 2},
+                {"a", 5},
+                {"  b", 2},
+                {"    c", 2},
             },
             new Object[][] {
-              {"a", 11},
-              {"  1", 2},
-              {"  c", 4, Arrays.asList("b")},
-              {"    2", 4},
-              {"      3", 2},
+                {"a", 11},
+                {"  1", 2},
+                {"  c", 4, Arrays.asList("b")},
+                {"    2", 4},
+                {"      3", 2},
             });
     assertThat(spans.get("a").getLinks())
         .hasSize(1)
@@ -377,13 +379,13 @@ class CallTreeTest {
     assertCallTree(
         new String[] {"bb   ", "aa a ", "  1 1"},
         new Object[][] {
-          {"a", 3},
-          {"  b", 2},
+            {"a", 3},
+            {"  b", 2},
         },
         new Object[][] {
-          {"a", 3},
-          {"  b", 1},
-          {"  1", 2}
+            {"a", 3},
+            {"  b", 1},
+            {"  1", 2}
         });
   }
 
@@ -396,13 +398,13 @@ class CallTreeTest {
     assertCallTree(
         new String[] {"bb   ", "aa  a", "  11 "},
         new Object[][] {
-          {"a", 3},
-          {"  b", 2},
+            {"a", 3},
+            {"  b", 2},
         },
         new Object[][] {
-          {"a", 4},
-          {"  b", 1},
-          {"  1", 1},
+            {"a", 4},
+            {"  b", 1},
+            {"  1", 1},
         });
   }
 
@@ -416,13 +418,13 @@ class CallTreeTest {
     assertCallTree(
         new String[] {" c   ", "bb   ", "aa  a", "  11 "},
         new Object[][] {
-          {"a", 3},
-          {"  b", 2},
+            {"a", 3},
+            {"  b", 2},
         },
         new Object[][] {
-          {"a", 4},
-          {"  b", 1},
-          {"  1", 1},
+            {"a", 4},
+            {"  b", 1},
+            {"  1", 1},
         });
   }
 
@@ -436,14 +438,14 @@ class CallTreeTest {
     assertCallTree(
         new String[] {"c  d   ", "b  b   ", "a  a  a", " 11 22 "},
         new Object[][] {
-          {"a", 3},
-          {"  b", 2},
+            {"a", 3},
+            {"  b", 2},
         },
         new Object[][] {
-          {"a", 6},
-          {"  b", 3},
-          {"    1", 1},
-          {"  2", 1},
+            {"a", 6},
+            {"  b", 3},
+            {"    1", 1},
+            {"  2", 1},
         });
   }
 
@@ -484,12 +486,12 @@ class CallTreeTest {
     assertCallTree(
         new String[] {"a  a  a", " 12 21 "},
         new Object[][] {
-          {"a", 3},
+            {"a", 3},
         },
         new Object[][] {
-          {"a", 6},
-          {"  1", 4},
-          {"    2", 2},
+            {"a", 6},
+            {"  1", 4},
+            {"    2", 2},
         });
   }
 
@@ -505,16 +507,16 @@ class CallTreeTest {
         assertCallTree(
             new String[] {" bbb        ", " aaa  ccc   ", "1   23   321"},
             new Object[][] {
-              {"a", 3},
-              {"  b", 3},
-              {"c", 3},
+                {"a", 3},
+                {"  b", 3},
+                {"c", 3},
             },
             new Object[][] {
-              {"1", 11},
-              {"  b", 2, Arrays.asList("a")},
-              {"  2", 6},
-              {"    3", 4},
-              {"      c", 2}
+                {"1", 11},
+                {"  b", 2, Arrays.asList("a")},
+                {"  2", 6},
+                {"    3", 4},
+                {"      c", 2}
             });
 
     assertThat(spans.get("b").getLinks()).isEmpty();
@@ -531,17 +533,17 @@ class CallTreeTest {
     assertCallTree(
         new String[] {"   d          ", " b b b        ", " a a a  ccc   ", "1 2 2 34   431"},
         new Object[][] {
-          {"a", 3},
-          {"  b", 3},
-          {"c", 3},
+            {"a", 3},
+            {"  b", 3},
+            {"c", 3},
         },
         new Object[][] {
-          {"1", 13},
-          {"  b", 4, Arrays.asList("a")},
-          {"    2", 2},
-          {"  3", 6},
-          {"    4", 4},
-          {"      c", 2}
+            {"1", 13},
+            {"  b", 4, Arrays.asList("a")},
+            {"    2", 2},
+            {"  3", 6},
+            {"    4", 4},
+            {"      c", 2}
         });
   }
 
@@ -558,18 +560,18 @@ class CallTreeTest {
         assertCallTree(
             new String[] {"  b b b  ccc    ", " aa a a  aaa  a ", "1  2 2 34   43 1"},
             new Object[][] {
-              {"a", 8},
-              {"  b", 3},
-              {"  c", 3},
+                {"a", 8},
+                {"  b", 3},
+                {"  c", 3},
             },
             new Object[][] {
-              {"1", 15},
-              {"  a", 13},
-              {"    b", 4},
-              {"      2", 2},
-              {"    3", 6},
-              {"      4", 4},
-              {"        c", 2}
+                {"1", 15},
+                {"  a", 13},
+                {"    b", 4},
+                {"      2", 2},
+                {"    3", 6},
+                {"      4", 4},
+                {"        c", 2}
             });
 
     assertThat(spans.get("b").getLinks())
@@ -607,15 +609,15 @@ class CallTreeTest {
     assertCallTree(
         new String[] {"     ccc  ", " aaa bbb  ", "1   2   21"},
         new Object[][] {
-          {"a", 3},
-          {"b", 3},
-          {"  c", 3},
+            {"a", 3},
+            {"b", 3},
+            {"  c", 3},
         },
         new Object[][] {
-          {"1", 9},
-          {"  a", 2},
-          {"  2", 4},
-          {"    c", 2, Arrays.asList("b")}
+            {"1", 9},
+            {"  a", 2},
+            {"  2", 4},
+            {"    c", 2, Arrays.asList("b")}
         });
   }
 
@@ -630,14 +632,14 @@ class CallTreeTest {
     assertCallTree(
         new String[] {" aaa bbb  ", "1   2   21"},
         new Object[][] {
-          {"a", 3},
-          {"b", 3},
+            {"a", 3},
+            {"b", 3},
         },
         new Object[][] {
-          {"1", 9},
-          {"  a", 2},
-          {"  2", 4},
-          {"    b", 2}
+            {"1", 9},
+            {"  a", 2},
+            {"  2", 4},
+            {"    b", 2}
         });
   }
 
@@ -669,14 +671,14 @@ class CallTreeTest {
     assertCallTree(
         new String[] {"     ccc  ", " aaa aaa  ", "1   2   21"},
         new Object[][] {
-          {"a", 6},
-          {"  c", 3},
+            {"a", 6},
+            {"  c", 3},
         },
         new Object[][] {
-          {"1", 9},
-          {"  a", 6},
-          {"    2", 4},
-          {"      c", 2}
+            {"1", 9},
+            {"  a", 6},
+            {"    2", 4},
+            {"      c", 2}
         });
   }
 
@@ -691,14 +693,14 @@ class CallTreeTest {
     assertCallTree(
         new String[] {"   bbb   ", " a aaa a ", "1 2   2 1"},
         new Object[][] {
-          {"a", 5},
-          {"  b", 3},
+            {"a", 5},
+            {"  b", 3},
         },
         new Object[][] {
-          {"1", 8},
-          {"  a", 6},
-          {"    2", 4},
-          {"      b", 2}
+            {"1", 8},
+            {"  a", 6},
+            {"    2", 4},
+            {"      b", 2}
         });
   }
 
@@ -714,25 +716,25 @@ class CallTreeTest {
   void testDectivationAfterEnd() throws Exception {
     assertCallTree(
         new String[] {
-          "     dd     ",
-          "   c ccc    ",
-          "  bb bbb    ", // <- deactivation for span 2 happens after b ends
-          " aaa aaa aa ", //    that means b must have ended after 2 has been deactivated
-          "1   2   2  1" //    but we saw the last stack trace of b before the deactivation of 2
+            "     dd     ",
+            "   c ccc    ",
+            "  bb bbb    ", // <- deactivation for span 2 happens after b ends
+            " aaa aaa aa ", //    that means b must have ended after 2 has been deactivated
+            "1   2   2  1" //    but we saw the last stack trace of b before the deactivation of 2
         },
         new Object[][] {
-          {"a", 8},
-          {"  b", 5},
-          {"    c", 4},
-          {"      d", 2},
+            {"a", 8},
+            {"  b", 5},
+            {"    c", 4},
+            {"      d", 2},
         },
         new Object[][] {
-          {"1", 11},
-          {"  a", 9},
-          {"    b", 6},
-          {"      c", 5},
-          {"        2", 4},
-          {"          d", 1},
+            {"1", 11},
+            {"  a", 9},
+            {"    b", 6},
+            {"      c", 5},
+            {"        2", 4},
+            {"          d", 1},
         });
   }
 
@@ -742,9 +744,9 @@ class CallTreeTest {
         new String[] {"    b    ", " aa a aa ", "1  2 2  1"},
         new Object[][] {{"a", 5}},
         new Object[][] {
-          {"1", 8},
-          {"  a", 6},
-          {"    2", 2},
+            {"1", 8},
+            {"  a", 6},
+            {"    2", 2},
         });
   }
 
@@ -763,9 +765,9 @@ class CallTreeTest {
         new String[] {"   c  c   ", "   b  b   ", " aaa  aaa ", "1   22   1"},
         new Object[][] {{"a", 6}},
         new Object[][] {
-          {"1", 9},
-          {"  a", 7},
-          {"    2", 1},
+            {"1", 9},
+            {"  a", 7},
+            {"    2", 1},
         });
   }
 
@@ -775,9 +777,9 @@ class CallTreeTest {
         new String[] {" aa  aa ", "1  22  1"},
         new Object[][] {{"a", 4}},
         new Object[][] {
-          {"1", 7},
-          {"  a", 5},
-          {"    2", 1},
+            {"1", 7},
+            {"  a", 5},
+            {"    2", 1},
         });
   }
 
@@ -787,10 +789,10 @@ class CallTreeTest {
         new String[] {" aa  aaa  aa ", "1  22   33  1"},
         new Object[][] {{"a", 7}},
         new Object[][] {
-          {"1", 12},
-          {"  a", 10},
-          {"    2", 1},
-          {"    3", 1},
+            {"1", 12},
+            {"  a", 10},
+            {"    2", 1},
+            {"    3", 1},
         });
   }
 
@@ -810,10 +812,10 @@ class CallTreeTest {
         new String[] {"  b  b c  c  ", " aa  aaa  aa ", "1  22   33  1"},
         new Object[][] {{"a", 7}},
         new Object[][] {
-          {"1", 12},
-          {"  a", 10},
-          {"    2", 1},
-          {"    3", 1},
+            {"1", 12},
+            {"  a", 10},
+            {"    2", 1},
+            {"    3", 1},
         });
   }
 
@@ -822,15 +824,15 @@ class CallTreeTest {
     assertCallTree(
         new String[] {"         bb    ", " aa  aaa aa aa ", "1  22   3  3  1"},
         new Object[][] {
-          {"a", 9},
-          {"  b", 2}
+            {"a", 9},
+            {"  b", 2}
         },
         new Object[][] {
-          {"1", 14},
-          {"  a", 12},
-          {"    2", 1},
-          {"    3", 3},
-          {"      b", 1},
+            {"1", 14},
+            {"  a", 12},
+            {"    2", 1},
+            {"    3", 3},
+            {"      b", 1},
         });
   }
 
@@ -847,12 +849,12 @@ class CallTreeTest {
     assertCallTree(
         new String[] {"  aaa ", "12 2 1"},
         new Object[][] {
-          {"a", 3},
+            {"a", 3},
         },
         new Object[][] {
-          {"1", 5},
-          {"  a", 3}, // a is actually a child of the transaction
-          {"    2", 2}, // 2 is not within the child_ids of a
+            {"1", 5},
+            {"  a", 3}, // a is actually a child of the transaction
+            {"    2", 2}, // 2 is not within the child_ids of a
         });
   }
 

--- a/inferred-spans/src/test/java/co/elastic/otel/profiler/InferredSpansAutoConfigTest.java
+++ b/inferred-spans/src/test/java/co/elastic/otel/profiler/InferredSpansAutoConfigTest.java
@@ -25,6 +25,7 @@ import co.elastic.otel.profiler.config.WildcardMatcher;
 import co.elastic.otel.testing.AutoConfigTestProperties;
 import co.elastic.otel.testing.AutoConfiguredDataCapture;
 import co.elastic.otel.testing.DisabledOnAppleSilicon;
+import co.elastic.otel.testing.DisabledOnOpenJ9;
 import co.elastic.otel.testing.OtelReflectionUtils;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
@@ -103,6 +104,7 @@ public class InferredSpansAutoConfigTest {
   }
 
   @DisabledOnAppleSilicon
+  @DisabledOnOpenJ9
   @DisabledOnOs(OS.WINDOWS)
   @Test
   public void checkProfilerWorking() {

--- a/inferred-spans/src/test/java/co/elastic/otel/profiler/SamplingProfilerQueueTest.java
+++ b/inferred-spans/src/test/java/co/elastic/otel/profiler/SamplingProfilerQueueTest.java
@@ -21,6 +21,7 @@ package co.elastic.otel.profiler;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import co.elastic.otel.testing.DisabledOnAppleSilicon;
+import co.elastic.otel.testing.DisabledOnOpenJ9;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.TraceFlags;
@@ -34,6 +35,7 @@ public class SamplingProfilerQueueTest {
   @Test
   @DisabledOnOs(OS.WINDOWS)
   @DisabledOnAppleSilicon
+  @DisabledOnOpenJ9
   void testFillQueue() throws Exception {
 
     try (ProfilerTestSetup setup =

--- a/inferred-spans/src/test/java/co/elastic/otel/profiler/SamplingProfilerTest.java
+++ b/inferred-spans/src/test/java/co/elastic/otel/profiler/SamplingProfilerTest.java
@@ -22,6 +22,7 @@ import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.asser
 import static org.awaitility.Awaitility.await;
 
 import co.elastic.otel.testing.DisabledOnAppleSilicon;
+import co.elastic.otel.testing.DisabledOnOpenJ9;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Scope;
@@ -51,6 +52,7 @@ import org.junit.jupiter.api.condition.OS;
 // async-profiler doesn't work on Windows
 @DisabledOnOs(OS.WINDOWS)
 @DisabledOnAppleSilicon
+@DisabledOnOpenJ9
 class SamplingProfilerTest {
 
   private ProfilerTestSetup setup;

--- a/inferred-spans/src/test/java/co/elastic/otel/profiler/ThreadMatcherTest.java
+++ b/inferred-spans/src/test/java/co/elastic/otel/profiler/ThreadMatcherTest.java
@@ -21,6 +21,7 @@ package co.elastic.otel.profiler;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
@@ -46,6 +47,6 @@ class ThreadMatcherTest {
           }
         },
         threads);
-    assertThat(threads).isEqualTo(List.of(Thread.currentThread()));
+    assertThat(threads).isEqualTo(Arrays.asList(Thread.currentThread()));
   }
 }

--- a/inferred-spans/src/test/java/co/elastic/otel/profiler/asyncprofiler/AsyncProfilerTest.java
+++ b/inferred-spans/src/test/java/co/elastic/otel/profiler/asyncprofiler/AsyncProfilerTest.java
@@ -22,6 +22,7 @@ import static co.elastic.otel.profiler.asyncprofiler.AsyncProfiler.SAFEMODE_SYST
 import static org.assertj.core.api.Assertions.assertThat;
 
 import co.elastic.otel.testing.DisabledOnAppleSilicon;
+import co.elastic.otel.testing.DisabledOnOpenJ9;
 import java.io.File;
 import java.io.FilenameFilter;
 import org.junit.jupiter.api.BeforeEach;
@@ -32,6 +33,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 @DisabledOnOs(OS.WINDOWS)
 @DisabledOnAppleSilicon
+@DisabledOnOpenJ9
 public class AsyncProfilerTest {
 
   @BeforeEach

--- a/inferred-spans/src/test/java/co/elastic/otel/profiler/asyncprofiler/JfrParserTest.java
+++ b/inferred-spans/src/test/java/co/elastic/otel/profiler/asyncprofiler/JfrParserTest.java
@@ -26,7 +26,7 @@ import java.io.File;
 import java.nio.ByteBuffer;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.List;
+import java.util.Collections;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 
@@ -44,7 +44,10 @@ class JfrParserTest {
         Paths.get(JfrParserTest.class.getClassLoader().getResource("recording.jfr").toURI())
             .toFile();
 
-    jfrParser.parse(file, List.of(), List.of(caseSensitiveMatcher("co.elastic.apm.*")));
+    jfrParser.parse(
+        file,
+        Collections.emptyList(),
+        Collections.singletonList(caseSensitiveMatcher("co.elastic.apm.*")));
     AtomicInteger stackTraces = new AtomicInteger();
     ArrayList<StackFrame> stackFrames = new ArrayList<>();
     jfrParser.consumeStackTraces(

--- a/jvmti-access/build.gradle.kts
+++ b/jvmti-access/build.gradle.kts
@@ -8,8 +8,8 @@ import java.io.IOException
 import java.util.*
 
 plugins {
-    id("java-library")
-    id("com.bmuschko.docker-java-application") version "9.4.0"
+  id("elastic-otel.library-packaging-conventions")
+  id("com.bmuschko.docker-java-application") version "9.4.0"
 }
 
 dependencies {

--- a/jvmti-access/src/test/java/co/elastic/otel/ResourceExtractionUtilTest.java
+++ b/jvmti-access/src/test/java/co/elastic/otel/ResourceExtractionUtilTest.java
@@ -22,6 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -65,7 +66,7 @@ public class ResourceExtractionUtilTest {
   void testContentDoesNotMatch(@TempDir Path tmpDir) throws Exception {
     Path tmp =
         ResourceExtractionUtil.extractResourceToDirectory("test.txt", "test", ".tmp", tmpDir);
-    Files.writeString(tmp, "changed");
+    Files.write(tmp, "changed".getBytes(StandardCharsets.UTF_8));
     assertThatThrownBy(
             () ->
                 ResourceExtractionUtil.extractResourceToDirectory(

--- a/jvmti-access/src/test/java/co/elastic/otel/UniversalProfilingCorrelationTest.java
+++ b/jvmti-access/src/test/java/co/elastic/otel/UniversalProfilingCorrelationTest.java
@@ -63,7 +63,7 @@ public class UniversalProfilingCorrelationTest {
     public void testProcessStorage() {
       ByteBuffer buffer = ByteBuffer.allocateDirect(100);
       buffer.order(ByteOrder.nativeOrder());
-      buffer.asCharBuffer().put(0, "Hello World".toCharArray());
+      buffer.asCharBuffer().put("Hello World".toCharArray());
 
       UniversalProfilingCorrelation.setProcessStorage(buffer);
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -38,3 +38,7 @@ dependencyResolutionManagement {
         }
     }
 }
+
+plugins {
+  id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0" //for resolving testing JVMs
+}

--- a/smoke-tests/build.gradle
+++ b/smoke-tests/build.gradle
@@ -2,7 +2,7 @@ import jdk.internal.joptsimple.internal.Strings
 
 // TODO : convert to kotlin for consistency
 plugins {
-  id "java"
+  id("elastic-otel.java-conventions")
   alias catalog.plugins.taskinfo
 }
 
@@ -12,6 +12,10 @@ configurations {
     canBeResolved = true
     canBeConsumed = false
   }
+}
+
+compileTestJava {
+  options.release.set(17)
 }
 
 dependencies {

--- a/testing-common/src/main/java/co/elastic/otel/testing/DisabledOnOpenJ9.java
+++ b/testing-common/src/main/java/co/elastic/otel/testing/DisabledOnOpenJ9.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.otel.testing;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@ExtendWith(DisabledOnOpenJ9Condition.class)
+public @interface DisabledOnOpenJ9 {
+
+  /** The reason this annotated test class or test method is disabled. */
+  String value() default "";
+}

--- a/testing-common/src/main/java/co/elastic/otel/testing/DisabledOnOpenJ9Condition.java
+++ b/testing-common/src/main/java/co/elastic/otel/testing/DisabledOnOpenJ9Condition.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.otel.testing;
+
+import static org.junit.jupiter.api.extension.ConditionEvaluationResult.disabled;
+import static org.junit.jupiter.api.extension.ConditionEvaluationResult.enabled;
+import static org.junit.platform.commons.util.AnnotationUtils.findAnnotation;
+
+import java.lang.reflect.AnnotatedElement;
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+public class DisabledOnOpenJ9Condition implements ExecutionCondition {
+
+  @Override
+  public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+    AnnotatedElement element = context.getElement().orElse(null);
+    return findAnnotation(element, DisabledOnOpenJ9.class)
+        .map(
+            annotation ->
+                isOnOpenJ9()
+                    ? disabled(element + " is @DisabledOnOpenJ9", annotation.value())
+                    : enabled("Not running on OpenJ9 JVM"))
+        .orElse(enabled("@DisabledOnOpenJ9 is not present"));
+  }
+
+  public boolean isOnOpenJ9() {
+    return System.getProperty("java.vm.name").contains("J9");
+  }
+}

--- a/testing/integration-tests/inferred-spans-test/src/test/java/InferredSpansTest.java
+++ b/testing/integration-tests/inferred-spans-test/src/test/java/InferredSpansTest.java
@@ -21,6 +21,7 @@ import static org.awaitility.Awaitility.await;
 
 import co.elastic.otel.common.ElasticAttributes;
 import co.elastic.otel.testing.DisabledOnAppleSilicon;
+import co.elastic.otel.testing.DisabledOnOpenJ9;
 import io.opentelemetry.instrumentation.annotations.WithSpan;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.sdk.trace.data.SpanData;
@@ -33,6 +34,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 @DisabledOnOs(OS.WINDOWS)
 @DisabledOnAppleSilicon
+@DisabledOnOpenJ9
 public class InferredSpansTest {
 
   @RegisterExtension

--- a/universal-profiling-integration/build.gradle.kts
+++ b/universal-profiling-integration/build.gradle.kts
@@ -1,8 +1,7 @@
 plugins {
-    id("java-library")
+    id("elastic-otel.library-packaging-conventions")
     alias(libs.plugins.jmh)
 }
-
 
 jmh {
   fork = 1


### PR DESCRIPTION
Closes #180 .

I've intentionally used the same approach and property names like the upstream agent, so that we don't get confused when working on both:
https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/9d94b4fd7e5ebcf227e29a6d4e1c343621c46438/conventions/src/main/kotlin/otel.java-conventions.gradle.kts#L375