### PR TITLE
Fix test reporting

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,7 +94,8 @@ jobs:
           command: "./gradlew test -x compileJni -PtestJavaVersion=${{ matrix.version }} -PtestJavaVM=${{ matrix.vm }}"
       - name: Store test results
         if: success() || failure()
-        uses: actions/upload-artifact@v4
+        # The test reporting workflow only supports the @v3 artifact mechanism
+        uses: actions/upload-artifact@v3
         with:
           name: test-results-${{ matrix.version }}-${{ matrix.vm }}
           path: '**/build/test-results/test/TEST-*.xml'


### PR DESCRIPTION
Looks like #187 broke the test reporting workflow:
```
Error: Response code 400 (Authentication information is not given in the correct format. Check the value of Authorization header.)
```
https://github.com/elastic/elastic-otel-java/actions/runs/8453636169/job/23156761898#step:2:42

I assume it is due to the change of the `upload-artifact` action from `@v3` to `@v4`.