### PR TITLE
add missing legacy config option

### DIFF
--- a/custom/src/main/java/co/elastic/otel/config/LegacyConfigurations.java
+++ b/custom/src/main/java/co/elastic/otel/config/LegacyConfigurations.java
@@ -191,5 +191,6 @@ public class LegacyConfigurations {
     addUnspecifiedOption("rabbitmq_naming_mode");
     addUnspecifiedOption("jmx_failed_retry_interval");
     addUnspecifiedOption("safe_exceptions");
+    addUnspecifiedOption("exclude_from_getting_username");
   }
 }


### PR DESCRIPTION
fixes failing build on `main`.