### PR TITLE
Handle profiler registration messages

### DIFF
--- a/universal-profiling-integration/src/main/java/co/elastic/otel/UniversalProfilingProcessor.java
+++ b/universal-profiling-integration/src/main/java/co/elastic/otel/UniversalProfilingProcessor.java
@@ -68,13 +68,13 @@ public class UniversalProfilingProcessor extends AbstractChainingSpanProcessor {
 
   private static final Logger log = Logger.getLogger(UniversalProfilingProcessor.class.getName());
 
-  private static final long INITIAL_SPAN_DELAY_NANOS = Duration.ofSeconds(5).toNanos();
+  private static final long INITIAL_SPAN_DELAY_NANOS = Duration.ofSeconds(1).toNanos();
 
   /**
    * The frequency at which the processor polls the unix domain socket for new messages from the
    * profiler.
    */
-  private static final long POLL_FREQUENCY_MS = 20;
+  static final long POLL_FREQUENCY_MS = 20;
 
   private static boolean anyInstanceActive = false;
 
@@ -107,10 +107,10 @@ public class UniversalProfilingProcessor extends AbstractChainingSpanProcessor {
 
       long initialSpanDelay;
       if (activeOnlyAfterProfilerRegistration) {
-        initialSpanDelay = 0; //do not buffer spans until we know that a profiler is running
+        initialSpanDelay = 0; // do not buffer spans until we know that a profiler is running
         tlsPropagationActive = false;
       } else {
-        initialSpanDelay = INITIAL_SPAN_DELAY_NANOS; //delay conservatively to not miss any data
+        initialSpanDelay = INITIAL_SPAN_DELAY_NANOS; // delay conservatively to not miss any data
         tlsPropagationActive = true;
       }
 
@@ -269,13 +269,14 @@ public class UniversalProfilingProcessor extends AbstractChainingSpanProcessor {
   }
 
   private void handleMessage(ProfilerRegistrationMessage message) {
-    log.log(Level.FINE,
+    log.log(
+        Level.FINE,
         "Received profiler registration message! host.id is {0} and the span delay is {1} ms",
         new Object[] {message.getHostId(), message.getSamplesDelayMillis()});
 
     tlsPropagationActive = true;
-    long spanDelayNanos = Duration.ofMillis(message.getSamplesDelayMillis() + POLL_FREQUENCY_MS)
-        .toNanos();
+    long spanDelayNanos =
+        Duration.ofMillis(message.getSamplesDelayMillis() + POLL_FREQUENCY_MS).toNanos();
     correlator.setSpanDelayNanos(spanDelayNanos);
 
     ProfilerProvidedHostId.set(message.getHostId());

--- a/universal-profiling-integration/src/main/java/co/elastic/otel/UniversalProfilingProcessorBuilder.java
+++ b/universal-profiling-integration/src/main/java/co/elastic/otel/UniversalProfilingProcessorBuilder.java
@@ -41,7 +41,11 @@ public class UniversalProfilingProcessorBuilder {
 
   public UniversalProfilingProcessor build() {
     return new UniversalProfilingProcessor(
-        nextProcessor, resource, bufferSize, activeOnlyAfterProfilerRegistration, socketDir,
+        nextProcessor,
+        resource,
+        bufferSize,
+        activeOnlyAfterProfilerRegistration,
+        socketDir,
         nanoClock);
   }
 

--- a/universal-profiling-integration/src/main/java/co/elastic/otel/UniversalProfilingProcessorBuilder.java
+++ b/universal-profiling-integration/src/main/java/co/elastic/otel/UniversalProfilingProcessorBuilder.java
@@ -20,14 +20,13 @@ package co.elastic.otel;
 
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.SpanProcessor;
-import java.time.Duration;
 import java.util.function.LongSupplier;
 
 public class UniversalProfilingProcessorBuilder {
 
   private final Resource resource;
   private final SpanProcessor nextProcessor;
-  private Duration spanDelay = Duration.ofSeconds(10);
+  private boolean activeOnlyAfterProfilerRegistration = false;
 
   private LongSupplier nanoClock = System::nanoTime;
 
@@ -42,7 +41,8 @@ public class UniversalProfilingProcessorBuilder {
 
   public UniversalProfilingProcessor build() {
     return new UniversalProfilingProcessor(
-        nextProcessor, resource, bufferSize, spanDelay, socketDir, nanoClock);
+        nextProcessor, resource, bufferSize, activeOnlyAfterProfilerRegistration, socketDir,
+        nanoClock);
   }
 
   UniversalProfilingProcessorBuilder clock(LongSupplier nanoClock) {
@@ -50,8 +50,8 @@ public class UniversalProfilingProcessorBuilder {
     return this;
   }
 
-  public UniversalProfilingProcessorBuilder spanDelay(Duration delay) {
-    this.spanDelay = delay;
+  public UniversalProfilingProcessorBuilder activeOnlyAfterProfilerRegistration(boolean value) {
+    this.activeOnlyAfterProfilerRegistration = value;
     return this;
   }
 

--- a/universal-profiling-integration/src/main/java/co/elastic/otel/UniversalProfilingProcessorBuilder.java
+++ b/universal-profiling-integration/src/main/java/co/elastic/otel/UniversalProfilingProcessorBuilder.java
@@ -26,7 +26,7 @@ public class UniversalProfilingProcessorBuilder {
 
   private final Resource resource;
   private final SpanProcessor nextProcessor;
-  private boolean activeOnlyAfterProfilerRegistration = false;
+  private boolean delayActivationAfterProfilerRegistration = true;
 
   private LongSupplier nanoClock = System::nanoTime;
 
@@ -44,7 +44,7 @@ public class UniversalProfilingProcessorBuilder {
         nextProcessor,
         resource,
         bufferSize,
-        activeOnlyAfterProfilerRegistration,
+        delayActivationAfterProfilerRegistration,
         socketDir,
         nanoClock);
   }
@@ -54,8 +54,19 @@ public class UniversalProfilingProcessorBuilder {
     return this;
   }
 
-  public UniversalProfilingProcessorBuilder activeOnlyAfterProfilerRegistration(boolean value) {
-    this.activeOnlyAfterProfilerRegistration = value;
+  /**
+   * If enabled, the profiling integration will remain inactive until the presence of a profiler is
+   * actually detected. This safes a bit of overhead in the case no profiler is there.
+   *
+   * <p>The downside is if the application starts a span immediately after startup, the profiler
+   * might not be detected in time and therefore this first span might not be correlated correctly.
+   * This can be avoided by setting this option to {@code false}. In this case the {@link
+   * UniversalProfilingProcessor} will assume a profiler will be eventually running and start the
+   * correlation eagerly.
+   */
+  public UniversalProfilingProcessorBuilder delayActivationAfterProfilerRegistration(
+      boolean value) {
+    this.delayActivationAfterProfilerRegistration = value;
     return this;
   }
 

--- a/universal-profiling-integration/src/main/java/co/elastic/otel/hostid/ProfilerHostIdApplyingSpanExporter.java
+++ b/universal-profiling-integration/src/main/java/co/elastic/otel/hostid/ProfilerHostIdApplyingSpanExporter.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.otel.hostid;
+
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.trace.data.DelegatingSpanData;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
+import java.util.Collection;
+import java.util.stream.Collectors;
+
+public class ProfilerHostIdApplyingSpanExporter implements SpanExporter {
+
+  private final SpanExporter delegate;
+
+  public ProfilerHostIdApplyingSpanExporter(SpanExporter delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public CompletableResultCode export(Collection<SpanData> collection) {
+    // do a pre-check to avoid unnecessary allocations
+    boolean anyUpdatesRequired =
+        collection.stream()
+            .anyMatch(
+                data ->
+                    data.getResource()
+                        != ProfilerHostIdResourceUpdater.applyHostId(data.getResource()));
+    Collection<SpanData> updatedSpanData = collection;
+    if (anyUpdatesRequired) {
+      updatedSpanData =
+          collection.stream()
+              .map(
+                  data -> {
+                    Resource original = data.getResource();
+                    Resource updated = ProfilerHostIdResourceUpdater.applyHostId(original);
+                    if (original != updated) {
+                      return new DelegatingSpanData(data) {
+                        @Override
+                        public Resource getResource() {
+                          return updated;
+                        }
+                      };
+                    } else {
+                      return data;
+                    }
+                  })
+              .collect(Collectors.toList());
+    }
+    return delegate.export(updatedSpanData);
+  }
+
+  @Override
+  public CompletableResultCode flush() {
+    return delegate.flush();
+  }
+
+  @Override
+  public CompletableResultCode shutdown() {
+    return delegate.flush();
+  }
+}

--- a/universal-profiling-integration/src/main/java/co/elastic/otel/hostid/ProfilerHostIdResourceUpdater.java
+++ b/universal-profiling-integration/src/main/java/co/elastic/otel/hostid/ProfilerHostIdResourceUpdater.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.otel.hostid;
+
+import co.elastic.otel.common.WeakConcurrent;
+import com.blogspot.mydailyjava.weaklockfree.WeakConcurrentMap;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.semconv.ResourceAttributes;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class ProfilerHostIdResourceUpdater {
+
+  private static final Logger log = Logger.getLogger(ProfilerHostIdResourceUpdater.class.getName());
+
+  private static volatile HostIdApplicationCache applierCache;
+
+  public static Resource applyHostId(Resource resource) {
+    String profilerProvidedHostId = ProfilerProvidedHostId.get();
+    if (profilerProvidedHostId == null) {
+      return resource;
+    }
+
+    HostIdApplicationCache applier = applierCache;
+    if (applier == null || !applier.profilerProvidedHostId.equals(profilerProvidedHostId)) {
+      applier = new HostIdApplicationCache(profilerProvidedHostId);
+      applierCache = applier;
+    }
+    return applierCache.applyHostId(resource);
+  }
+
+  private static class HostIdApplicationCache {
+    private final String profilerProvidedHostId;
+    private final WeakConcurrentMap<Resource, Resource> cachedUpdates = WeakConcurrent.createMap();
+
+    private HostIdApplicationCache(String profilerProvidedHostId) {
+      this.profilerProvidedHostId = profilerProvidedHostId;
+    }
+
+    public Resource applyHostId(Resource resource) {
+      Resource cached = cachedUpdates.get(resource);
+      if (cached == null) {
+        cached = doApplyHostId(resource);
+        cachedUpdates.putIfAbsent(resource, cached);
+        cached = cachedUpdates.get(resource);
+      }
+      return cached;
+    }
+
+    private Resource doApplyHostId(Resource resource) {
+      String existingId = resource.getAttribute(ResourceAttributes.HOST_ID);
+      if (existingId == null) {
+        return resource.merge(
+            Resource.builder().put(ResourceAttributes.HOST_ID, profilerProvidedHostId).build());
+      } else {
+        if (!profilerProvidedHostId.equals(existingId)) {
+          log.log(
+              Level.WARNING,
+              "The used host.id resource attribute ( {0} ) differs from the host.id used for profiling data ( {1} )."
+                  + " This will result in the correlation not working correctly!",
+              new Object[] {existingId, profilerProvidedHostId});
+        }
+        return resource;
+      }
+    }
+  }
+}

--- a/universal-profiling-integration/src/main/java/co/elastic/otel/hostid/ProfilerProvidedHostId.java
+++ b/universal-profiling-integration/src/main/java/co/elastic/otel/hostid/ProfilerProvidedHostId.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.otel.hostid;
+
+import javax.annotation.Nullable;
+
+public class ProfilerProvidedHostId {
+
+  @Nullable private static String hostId = null;
+
+  public static void set(@Nullable String host) {
+    if (host == null || host.isEmpty()) {
+      hostId = null;
+    } else {
+      hostId = host;
+    }
+  }
+
+  @Nullable
+  public static String get() {
+    return hostId;
+  }
+}

--- a/universal-profiling-integration/src/test/java/co/elastic/otel/UniversalProfilingProcessorTest.java
+++ b/universal-profiling-integration/src/test/java/co/elastic/otel/UniversalProfilingProcessorTest.java
@@ -88,8 +88,7 @@ public class UniversalProfilingProcessorTest {
   }
 
   private OpenTelemetrySdk initSdk() {
-    return initSdk(builder -> {
-    });
+    return initSdk(builder -> {});
   }
 
   private OpenTelemetrySdk initSdk(Consumer<UniversalProfilingProcessorBuilder> customizer) {
@@ -219,15 +218,13 @@ public class UniversalProfilingProcessorTest {
               .put(ResourceAttributes.SERVICE_NAME, "service Ä 1")
               .put(ResourceAttributes.SERVICE_NAMESPACE, "my nameßspace")
               .build();
-      try (OpenTelemetrySdk sdk = initSdk(withNamespace, b -> {
-      }, Sampler.alwaysOn())) {
+      try (OpenTelemetrySdk sdk = initSdk(withNamespace, b -> {}, Sampler.alwaysOn())) {
         checkProcessStorage("service Ä 1", "my nameßspace");
       }
 
       Resource withoutNamespace =
           Resource.builder().put(ResourceAttributes.SERVICE_NAME, "service Ä 2").build();
-      try (OpenTelemetrySdk sdk = initSdk(withoutNamespace, b -> {
-      }, Sampler.alwaysOn())) {
+      try (OpenTelemetrySdk sdk = initSdk(withoutNamespace, b -> {}, Sampler.alwaysOn())) {
         checkProcessStorage("service Ä 2", "");
       }
     }
@@ -341,7 +338,7 @@ public class UniversalProfilingProcessorTest {
                           .findFirst()
                           .get();
                   assertThat(
-                      sp1Data.getAttributes().get(ElasticAttributes.PROFILER_STACK_TRACE_IDS))
+                          sp1Data.getAttributes().get(ElasticAttributes.PROFILER_STACK_TRACE_IDS))
                       .containsExactlyInAnyOrder(base64(st1), base64(st3), base64(st3));
 
                   SpanData sp2Data =
@@ -350,7 +347,7 @@ public class UniversalProfilingProcessorTest {
                           .findFirst()
                           .get();
                   assertThat(
-                      sp2Data.getAttributes().get(ElasticAttributes.PROFILER_STACK_TRACE_IDS))
+                          sp2Data.getAttributes().get(ElasticAttributes.PROFILER_STACK_TRACE_IDS))
                       .containsExactlyInAnyOrder(
                           base64(st2), base64(st2), base64(st2), base64(st3));
                 });
@@ -566,10 +563,9 @@ public class UniversalProfilingProcessorTest {
       String absPath = notADir.toAbsolutePath().toString();
 
       assertThatThrownBy(
-          () -> {
-            try (OpenTelemetrySdk sdk = initSdk(builder -> builder.socketDir(absPath))) {
-            }
-          })
+              () -> {
+                try (OpenTelemetrySdk sdk = initSdk(builder -> builder.socketDir(absPath))) {}
+              })
           .hasMessageContaining("socket");
 
       // Ensure no garbage is left behind, we can cleanly start again with good settings

--- a/universal-profiling-integration/src/test/java/co/elastic/otel/UniversalProfilingProcessorTest.java
+++ b/universal-profiling-integration/src/test/java/co/elastic/otel/UniversalProfilingProcessorTest.java
@@ -253,15 +253,15 @@ public class UniversalProfilingProcessorTest {
     ByteBuffer tls = JvmtiAccessImpl.createThreadProfilingCorrelationBufferAlias(TLS_STORAGE_SIZE);
     if (tls != null) {
       tls.order(ByteOrder.nativeOrder());
-      assertThat(tls.getChar(0)).isEqualTo((char) 1); // layout-minor-version
-      assertThat(tls.get(2)).isEqualTo((byte) 1); // valid byte
+      assertThat(tls.getChar(0)).describedAs("layout-minor-version").isEqualTo((char) 1);
+      assertThat(tls.get(2)).describedAs("valid byte").isEqualTo((byte) 1);
     }
 
     SpanContext ctx = span.getSpanContext();
     if (ctx.isValid()) {
       assertThat(tls).isNotNull();
-      assertThat(tls.get(3)).isEqualTo((byte) 1); // trace-present-flag
-      assertThat(tls.get(4)).isEqualTo(ctx.getTraceFlags().asByte()); // trace-flags
+      assertThat(tls.get(3)).describedAs("trace-present-flag").isEqualTo((byte) 1);
+      assertThat(tls.get(4)).describedAs("trace-flags").isEqualTo(ctx.getTraceFlags().asByte());
 
       byte[] traceId = new byte[16];
       byte[] spanId = new byte[8];
@@ -276,7 +276,7 @@ public class UniversalProfilingProcessorTest {
       tls.get(localRootSpanId);
       assertThat(localRootSpanId).containsExactly(localRoot.getSpanContext().getSpanIdBytes());
     } else if (tls != null) {
-      assertThat(tls.get(3)).isEqualTo((byte) 0); // trace-present-flag
+      assertThat(tls.get(3)).describedAs("trace-present-flag").isEqualTo((byte) 0);
     }
   }
 

--- a/universal-profiling-integration/src/test/java/co/elastic/otel/UniversalProfilingProcessorTest.java
+++ b/universal-profiling-integration/src/test/java/co/elastic/otel/UniversalProfilingProcessorTest.java
@@ -19,11 +19,13 @@
 package co.elastic.otel;
 
 import static co.elastic.otel.ProfilerSharedMemoryWriter.TLS_STORAGE_SIZE;
+import static co.elastic.otel.UniversalProfilingProcessor.POLL_FREQUENCY_MS;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
 
 import co.elastic.otel.common.ElasticAttributes;
+import co.elastic.otel.hostid.ProfilerHostIdApplyingSpanExporter;
 import co.elastic.otel.testing.MapGetter;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.Span;
@@ -68,6 +70,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 @DisabledOnOs(OS.WINDOWS)
 public class UniversalProfilingProcessorTest {
@@ -123,7 +127,9 @@ public class UniversalProfilingProcessorTest {
         };
 
     SpanProcessor exporter =
-        SimpleSpanProcessor.builder(ignoreShutdown).setExportUnsampledSpans(true).build();
+        SimpleSpanProcessor.builder(new ProfilerHostIdApplyingSpanExporter(ignoreShutdown))
+            .setExportUnsampledSpans(true)
+            .build();
 
     UniversalProfilingProcessorBuilder builder =
         UniversalProfilingProcessor.builder(exporter, res).socketDir(tempDir.toString());
@@ -239,37 +245,36 @@ public class UniversalProfilingProcessorTest {
       buffer.get(serviceUtf8);
       return new String(serviceUtf8, StandardCharsets.UTF_8);
     }
+  }
 
-    private void checkTlsIs(Span span, Span localRoot) {
-      ByteBuffer tls =
-          JvmtiAccessImpl.createThreadProfilingCorrelationBufferAlias(TLS_STORAGE_SIZE);
-      if (tls != null) {
-        tls.order(ByteOrder.nativeOrder());
-        assertThat(tls.getChar(0)).isEqualTo((char) 1); // layout-minor-version
-        assertThat(tls.get(2)).isEqualTo((byte) 1); // valid byte
-      }
+  static void checkTlsIs(Span span, Span localRoot) {
+    ByteBuffer tls = JvmtiAccessImpl.createThreadProfilingCorrelationBufferAlias(TLS_STORAGE_SIZE);
+    if (tls != null) {
+      tls.order(ByteOrder.nativeOrder());
+      assertThat(tls.getChar(0)).isEqualTo((char) 1); // layout-minor-version
+      assertThat(tls.get(2)).isEqualTo((byte) 1); // valid byte
+    }
 
-      SpanContext ctx = span.getSpanContext();
-      if (ctx.isValid()) {
-        assertThat(tls).isNotNull();
-        assertThat(tls.get(3)).isEqualTo((byte) 1); // trace-present-flag
-        assertThat(tls.get(4)).isEqualTo(ctx.getTraceFlags().asByte()); // trace-flags
+    SpanContext ctx = span.getSpanContext();
+    if (ctx.isValid()) {
+      assertThat(tls).isNotNull();
+      assertThat(tls.get(3)).isEqualTo((byte) 1); // trace-present-flag
+      assertThat(tls.get(4)).isEqualTo(ctx.getTraceFlags().asByte()); // trace-flags
 
-        byte[] traceId = new byte[16];
-        byte[] spanId = new byte[8];
-        byte[] localRootSpanId = new byte[8];
-        tls.position(5);
-        tls.get(traceId);
-        assertThat(traceId).containsExactly(ctx.getTraceIdBytes());
-        tls.position(21);
-        tls.get(spanId);
-        assertThat(spanId).containsExactly(ctx.getSpanIdBytes());
-        tls.position(29);
-        tls.get(localRootSpanId);
-        assertThat(localRootSpanId).containsExactly(localRoot.getSpanContext().getSpanIdBytes());
-      } else if (tls != null) {
-        assertThat(tls.get(3)).isEqualTo((byte) 0); // trace-present-flag
-      }
+      byte[] traceId = new byte[16];
+      byte[] spanId = new byte[8];
+      byte[] localRootSpanId = new byte[8];
+      tls.position(5);
+      tls.get(traceId);
+      assertThat(traceId).containsExactly(ctx.getTraceIdBytes());
+      tls.position(21);
+      tls.get(spanId);
+      assertThat(spanId).containsExactly(ctx.getSpanIdBytes());
+      tls.position(29);
+      tls.get(localRootSpanId);
+      assertThat(localRootSpanId).containsExactly(localRoot.getSpanContext().getSpanIdBytes());
+    } else if (tls != null) {
+      assertThat(tls.get(3)).isEqualTo((byte) 0); // trace-present-flag
     }
   }
 
@@ -282,20 +287,22 @@ public class UniversalProfilingProcessorTest {
       AtomicLong clock = new AtomicLong(0L);
 
       try (OpenTelemetrySdk sdk =
-          initSdk(builder -> builder.clock(clock::get).spanDelay(Duration.ofNanos(1)))) {
+          initSdk(builder -> builder.clock(() -> clock.get() * 1_000_0000L))) {
+        sendProfilerRegistrationMsg(1, "hostid");
+
         Tracer tracer = sdk.getTracer("test-tracer");
 
         Span span1 = tracer.spanBuilder("span1").startSpan();
         Span span2 = tracer.spanBuilder("span2").startSpan();
 
         byte[] st1 = randomStackTraceId(1);
-        sendMsg(span1, st1, 1);
+        sendSampleMsg(span1, st1, 1);
 
         // Send some garbage which should not affect our processing
         JvmtiAccessImpl.sendToProfilerReturnChannelSocket0(new byte[] {1, 2, 3});
 
         byte[] st2 = randomStackTraceId(2);
-        sendMsg(span2, st2, 2);
+        sendSampleMsg(span2, st2, 2);
 
         // ensure that the messages are processed now
         processor.pollMessagesAndFlushPendingSpans();
@@ -307,11 +314,11 @@ public class UniversalProfilingProcessorTest {
         assertThat(spans.getFinishedSpanItems()).isEmpty();
 
         byte[] st3 = randomStackTraceId(3);
-        sendMsg(span2, st2, 1);
-        sendMsg(span1, st3, 2);
-        sendMsg(span2, st3, 1);
+        sendSampleMsg(span2, st2, 1);
+        sendSampleMsg(span1, st3, 2);
+        sendSampleMsg(span2, st3, 1);
 
-        clock.set(1L);
+        clock.set(1L + POLL_FREQUENCY_MS);
         // now the background thread should consume those messages and flush the spans
         await()
             .atMost(Duration.ofSeconds(10))
@@ -345,6 +352,88 @@ public class UniversalProfilingProcessorTest {
       }
     }
 
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void checkAwaitProfilerRegistrationSetting(boolean activeOnlyAfterRegistration) {
+
+      AtomicLong clock = new AtomicLong(0L);
+
+      try (OpenTelemetrySdk sdk =
+          initSdk(
+              builder ->
+                  builder
+                      .clock(() -> clock.get() * 1_000_0000L)
+                      .activeOnlyAfterProfilerRegistration(activeOnlyAfterRegistration))) {
+        Tracer tracer = sdk.getTracer("test-tracer");
+
+        Span span1 = tracer.spanBuilder("span1").startSpan();
+
+        try (Scope scope = span1.makeCurrent()) {
+          Span expected = activeOnlyAfterRegistration ? Span.getInvalid() : span1;
+          checkTlsIs(expected, expected);
+        }
+
+        span1.end();
+        processor.pollMessagesAndFlushPendingSpans();
+
+        if (activeOnlyAfterRegistration) {
+          assertThat(spans.getFinishedSpanItems()).hasSize(1);
+        } else {
+          assertThat(spans.getFinishedSpanItems()).hasSize(0);
+        }
+
+        clock.addAndGet(10000);
+        processor.pollMessagesAndFlushPendingSpans();
+        // now the span should be sent even if we do not wait for profiler data
+        assertThat(spans.getFinishedSpanItems()).hasSize(1);
+        spans.reset();
+
+        // check that the processor updates the span delay and host-id
+        sendProfilerRegistrationMsg(1, "host1");
+        processor.pollMessagesAndFlushPendingSpans();
+
+        Span span2 = tracer.spanBuilder("span2").startSpan();
+        try (Scope scope = span2.makeCurrent()) {
+          checkTlsIs(span2, span2);
+        }
+        span2.end();
+
+        processor.pollMessagesAndFlushPendingSpans();
+
+        clock.addAndGet(1 + POLL_FREQUENCY_MS);
+        processor.pollMessagesAndFlushPendingSpans();
+        assertThat(spans.getFinishedSpanItems())
+            .hasSize(1)
+            .first()
+            .satisfies(
+                span -> {
+                  assertThat(span.getResource().getAttributes())
+                      .containsEntry(ResourceAttributes.HOST_ID, "host1");
+                });
+        spans.reset();
+
+        // check that the processor also reacts to subsequent registrations, e.g. due to profiler
+        // restart
+        sendProfilerRegistrationMsg(100, "host1");
+        processor.pollMessagesAndFlushPendingSpans();
+
+        Span span3 = tracer.spanBuilder("span2").startSpan();
+        span3.end();
+        processor.pollMessagesAndFlushPendingSpans();
+
+        clock.addAndGet(100 + POLL_FREQUENCY_MS);
+        processor.pollMessagesAndFlushPendingSpans();
+        assertThat(spans.getFinishedSpanItems())
+            .hasSize(1)
+            .first()
+            .satisfies(
+                span -> {
+                  assertThat(span.getResource().getAttributes())
+                      .containsEntry(ResourceAttributes.HOST_ID, "host1");
+                });
+      }
+    }
+
     @Test
     void unsampledSpansNotCorrelated() {
       Sampler sampler =
@@ -365,15 +454,15 @@ public class UniversalProfilingProcessorTest {
               return "";
             }
           };
-      try (OpenTelemetrySdk sdk =
-          initSdk(builder -> builder.clock(() -> 0L).spanDelay(Duration.ofNanos(1)), sampler)) {
+      try (OpenTelemetrySdk sdk = initSdk(builder -> builder.clock(() -> 0L), sampler)) {
+        sendProfilerRegistrationMsg(1, "hostid");
         Tracer tracer = sdk.getTracer("test-tracer");
 
         Span span1 = tracer.spanBuilder("span1").startSpan();
         assertThat(span1.getSpanContext().isSampled()).isFalse();
 
         // Still send a stacktrace to make sure it is actually ignored
-        sendMsg(span1, randomStackTraceId(1), 1);
+        sendSampleMsg(span1, randomStackTraceId(1), 1);
 
         // ensure that the messages are processed now
         processor.pollMessagesAndFlushPendingSpans();
@@ -392,15 +481,15 @@ public class UniversalProfilingProcessorTest {
 
     @Test
     void nonLocalRootSpansNotDelayed() {
-      try (OpenTelemetrySdk sdk =
-          initSdk(builder -> builder.clock(() -> 0L).spanDelay(Duration.ofNanos(1)))) {
+      try (OpenTelemetrySdk sdk = initSdk(builder -> builder.clock(() -> 0L))) {
+        sendProfilerRegistrationMsg(1, "hostid");
         Tracer tracer = sdk.getTracer("test-tracer");
 
         Span root = tracer.spanBuilder("root").startSpan();
         Span child = tracer.spanBuilder("child").setParent(Context.root().with(root)).startSpan();
 
         // Still send a stacktrace to make sure it is actually ignored
-        sendMsg(child, randomStackTraceId(1), 1);
+        sendSampleMsg(child, randomStackTraceId(1), 1);
 
         // ensure that the messages are processed now
         processor.pollMessagesAndFlushPendingSpans();
@@ -421,8 +510,8 @@ public class UniversalProfilingProcessorTest {
     void shutdownFlushesBufferedSpans() {
       byte[] st1 = randomStackTraceId(1);
 
-      try (OpenTelemetrySdk sdk =
-          initSdk(builder -> builder.clock(() -> 0L).spanDelay(Duration.ofNanos(1)))) {
+      try (OpenTelemetrySdk sdk = initSdk(builder -> builder.clock(() -> 0L))) {
+        sendProfilerRegistrationMsg(1, "hostid");
         Tracer tracer = sdk.getTracer("test-tracer");
 
         Span root = tracer.spanBuilder("root").startSpan();
@@ -430,7 +519,7 @@ public class UniversalProfilingProcessorTest {
 
         assertThat(spans.getFinishedSpanItems()).isEmpty();
 
-        sendMsg(root, st1, 1);
+        sendSampleMsg(root, st1, 1);
       }
 
       assertThat(spans.getFinishedSpanItems())
@@ -445,9 +534,9 @@ public class UniversalProfilingProcessorTest {
 
     @Test
     void bufferCapacityExceeded() {
-      try (OpenTelemetrySdk sdk =
-          initSdk(
-              builder -> builder.clock(() -> 0L).spanDelay(Duration.ofNanos(1)).bufferSize(2))) {
+      try (OpenTelemetrySdk sdk = initSdk(builder -> builder.clock(() -> 0L).bufferSize(2))) {
+
+        sendProfilerRegistrationMsg(1, "hostid");
 
         Tracer tracer = sdk.getTracer("test-tracer");
 
@@ -524,7 +613,7 @@ public class UniversalProfilingProcessorTest {
       return Base64.getUrlEncoder().withoutPadding().encodeToString(data);
     }
 
-    void sendMsg(Span localRoot, byte[] stackTraceId, int count) {
+    void sendSampleMsg(Span localRoot, byte[] stackTraceId, int count) {
       byte[] traceId = localRoot.getSpanContext().getTraceIdBytes();
       byte[] rootSpanId = localRoot.getSpanContext().getSpanIdBytes();
 
@@ -536,6 +625,20 @@ public class UniversalProfilingProcessorTest {
       message.put(rootSpanId);
       message.put(stackTraceId);
       message.putShort((short) count);
+
+      JvmtiAccessImpl.sendToProfilerReturnChannelSocket0(message.array());
+    }
+
+    void sendProfilerRegistrationMsg(int sampleDelayMillis, String hostId) {
+      byte[] hostIdUtf8 = hostId.getBytes(StandardCharsets.UTF_8);
+
+      ByteBuffer message = ByteBuffer.allocate(12 + hostIdUtf8.length);
+      message.order(ByteOrder.nativeOrder());
+      message.putShort((short) 2); // message-type = registration message
+      message.putShort((short) 1); // message-version
+      message.putInt(sampleDelayMillis);
+      message.putInt(hostIdUtf8.length);
+      message.put(hostIdUtf8);
 
       JvmtiAccessImpl.sendToProfilerReturnChannelSocket0(message.array());
     }

--- a/universal-profiling-integration/src/test/java/co/elastic/otel/hostid/ProfilerHostIdApplyingSpanExporterTest.java
+++ b/universal-profiling-integration/src/test/java/co/elastic/otel/hostid/ProfilerHostIdApplyingSpanExporterTest.java
@@ -26,9 +26,17 @@ import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import io.opentelemetry.semconv.ResourceAttributes;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class ProfilerHostIdApplyingSpanExporterTest {
+
+  @BeforeEach
+  @AfterEach
+  public void resetProfilerProvidedHostId() {
+    ProfilerProvidedHostId.set(null);
+  }
 
   @Test
   public void checkHostIdUpdated() {

--- a/universal-profiling-integration/src/test/java/co/elastic/otel/hostid/ProfilerHostIdApplyingSpanExporterTest.java
+++ b/universal-profiling-integration/src/test/java/co/elastic/otel/hostid/ProfilerHostIdApplyingSpanExporterTest.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.otel.hostid;
+
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+import io.opentelemetry.semconv.ResourceAttributes;
+import org.junit.jupiter.api.Test;
+
+public class ProfilerHostIdApplyingSpanExporterTest {
+
+  @Test
+  public void checkHostIdUpdated() {
+    Resource originalResource = Resource.builder().put("custom", "foobar").build();
+    InMemorySpanExporter exporter = InMemorySpanExporter.create();
+    try (SdkTracerProvider tracerProvider =
+        SdkTracerProvider.builder()
+            .setResource(originalResource)
+            .addSpanProcessor(
+                SimpleSpanProcessor.create(new ProfilerHostIdApplyingSpanExporter(exporter)))
+            .build()) {
+
+      Tracer tracer = tracerProvider.get("dummy");
+
+      tracer.spanBuilder("s1").startSpan().end();
+      assertThat(exporter.getFinishedSpanItems())
+          .hasSize(1)
+          .first()
+          .satisfies(data -> assertThat(data.getResource()).isSameAs(originalResource));
+
+      ProfilerProvidedHostId.set("hooray");
+
+      exporter.reset();
+      tracer.spanBuilder("s2").startSpan().end();
+      assertThat(exporter.getFinishedSpanItems())
+          .hasSize(1)
+          .first()
+          .satisfies(
+              data ->
+                  assertThat(data.getResource().getAttributes())
+                      .containsEntry("custom", "foobar")
+                      .containsEntry(ResourceAttributes.HOST_ID, "hooray"));
+
+      Resource updated = exporter.getFinishedSpanItems().get(0).getResource();
+
+      // ensure caching works
+      exporter.reset();
+      tracer.spanBuilder("s3").startSpan().end();
+      assertThat(exporter.getFinishedSpanItems())
+          .hasSize(1)
+          .first()
+          .satisfies(data -> assertThat(data.getResource()).isSameAs(updated));
+
+      // ensure a second update works
+      ProfilerProvidedHostId.set("changed!");
+      exporter.reset();
+      tracer.spanBuilder("s4").startSpan().end();
+      assertThat(exporter.getFinishedSpanItems())
+          .hasSize(1)
+          .first()
+          .satisfies(
+              data ->
+                  assertThat(data.getResource().getAttributes())
+                      .containsEntry("custom", "foobar")
+                      .containsEntry(ResourceAttributes.HOST_ID, "changed!"));
+
+      // and finally a reset
+      ProfilerProvidedHostId.set("");
+      exporter.reset();
+      tracer.spanBuilder("s5").startSpan().end();
+      assertThat(exporter.getFinishedSpanItems())
+          .hasSize(1)
+          .first()
+          .satisfies(data -> assertThat(data.getResource()).isSameAs(originalResource));
+    }
+  }
+
+  @Test
+  public void ensureApplicationProvidedHostIdTakesPrecedence() {
+    Resource originalResource =
+        Resource.builder()
+            .put("custom", "foobar")
+            .put(ResourceAttributes.HOST_ID, "app-provided")
+            .build();
+    InMemorySpanExporter exporter = InMemorySpanExporter.create();
+    try (SdkTracerProvider tracerProvider =
+        SdkTracerProvider.builder()
+            .setResource(originalResource)
+            .addSpanProcessor(
+                SimpleSpanProcessor.create(new ProfilerHostIdApplyingSpanExporter(exporter)))
+            .build()) {
+
+      Tracer tracer = tracerProvider.get("dummy");
+
+      ProfilerProvidedHostId.set("profiler-provided");
+
+      tracer.spanBuilder("s1").startSpan().end();
+      assertThat(exporter.getFinishedSpanItems())
+          .hasSize(1)
+          .first()
+          .satisfies(data -> assertThat(data.getResource()).isSameAs(originalResource));
+    }
+  }
+}


### PR DESCRIPTION
Implements https://github.com/elastic/apm/pull/853:
 * If the profiler provides a `host.id` it will be added to the spans
 * The profiler can now tell the extension how long to wait for the stacktraces for spans to arrive
 * Added option for the extension to remain inactive until a profiler is actually detected 