### PR TITLE
Fix agentextension publishing and LocalRootSpan bug in agentextension

### DIFF
--- a/agentextension/build.gradle.kts
+++ b/agentextension/build.gradle.kts
@@ -14,6 +14,11 @@ dependencies {
   shadowDependencies(project(":custom"))
 }
 
+publishingConventions {
+  artifactTasks.add(tasks.shadowJar)
+  artifactTasks.add(tasks.javadocJar)
+  artifactTasks.add(tasks.sourcesJar)
+}
 
 tasks {
 

--- a/common/src/main/java/co/elastic/otel/common/LocalRootSpan.java
+++ b/common/src/main/java/co/elastic/otel/common/LocalRootSpan.java
@@ -79,6 +79,19 @@ public class LocalRootSpan {
     }
   }
 
+  /** See {@link LocalRootSpan#getFor(Span)}. */
+  @Nullable
+  public static ReadableSpan getFor(ReadableSpan span) {
+    Object rootSpanVal = localRoot.get(span);
+    if (rootSpanVal == LOCAL_ROOT_MARKER) {
+      return span;
+    }
+    if (rootSpanVal == INFERRED_SPAN_UNKNOWN_ROOT_MARKER) {
+      return null;
+    }
+    return (ReadableSpan) rootSpanVal;
+  }
+
   /**
    * If the provided span is a local root span, itself is returned. Otherwise, returns the
    * (transitive) parent which is a local root.
@@ -93,31 +106,14 @@ public class LocalRootSpan {
    * </ul>
    */
   @Nullable
-  public static Span getFor(Span span) {
-    return resolveRoot(span, localRoot.get(span));
+  public static ReadableSpan getFor(Span span) {
+    return getFor((ReadableSpan) span);
   }
 
   /** See {@link LocalRootSpan#getFor(Span)}. */
   @Nullable
-  public static Span getFor(ReadableSpan span) {
-    return resolveRoot(span, localRoot.get(span));
-  }
-
-  /** See {@link LocalRootSpan#getFor(Span)}. */
-  @Nullable
-  public static Span getFor(ReadWriteSpan span) {
-    return resolveRoot(span, localRoot.get(span));
-  }
-
-  @Nullable
-  private static Span resolveRoot(Object span, Object rootSpanVal) {
-    if (rootSpanVal == LOCAL_ROOT_MARKER) {
-      return (Span) span;
-    }
-    if (rootSpanVal == INFERRED_SPAN_UNKNOWN_ROOT_MARKER) {
-      return null;
-    }
-    return (Span) rootSpanVal;
+  public static ReadableSpan getFor(ReadWriteSpan span) {
+    return getFor((ReadableSpan) span);
   }
 
   private LocalRootSpan() {}

--- a/universal-profiling-integration/src/main/java/co/elastic/otel/ProfilerSharedMemoryWriter.java
+++ b/universal-profiling-integration/src/main/java/co/elastic/otel/ProfilerSharedMemoryWriter.java
@@ -23,6 +23,7 @@ import co.elastic.otel.common.util.HexUtils;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.trace.ReadableSpan;
 import io.opentelemetry.semconv.ResourceAttributes;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -99,7 +100,7 @@ public class ProfilerSharedMemoryWriter {
 
       SpanContext spanCtx = newSpan.getSpanContext();
       if (spanCtx.isValid() && !spanCtx.isRemote()) {
-        Span localRoot = LocalRootSpan.getFor(newSpan);
+        ReadableSpan localRoot = LocalRootSpan.getFor(newSpan);
         if (localRoot != null) {
           String localRootSpanId = localRoot.getSpanContext().getSpanId();
           tls.put(TLS_TRACE_PRESENT_OFFSET, (byte) 1);


### PR DESCRIPTION
The release currently failed due to a gradle cautionary check, which is a false-positive in this case:
```
* What went wrong:
Execution failed for task ':agentextension:publishMavenPublicationToSonatypeRepository'.
> Failed to publish publication 'maven' to repository 'sonatype'
   > Artifact elastic-otel-agentextension-0.1.0.jar wasn't produced by this build.
```

I've fixed the issue by reusing the same logic for publishing a shadow-jar we use for publishing our distro agent.

Also this PR includes two bug-fixes I forgot about which are also included in #215 . Without those, the agent-extension will not work properly.