### PR TITLE
Hide statically linked libstdc++ symbols and enable compiler to remove unused code.

### DIFF
--- a/jvmti-access/build.gradle.kts
+++ b/jvmti-access/build.gradle.kts
@@ -48,7 +48,7 @@ sourceSets {
   }
 }
 
-val sharedCompilerArgs = "-std=c++17 -fno-rtti -fno-exceptions -O2 -ftls-model=global-dynamic -fPIC -Wall -Werror -Wextra -shared"
+val sharedCompilerArgs = "-std=c++17 -fno-rtti -fno-exceptions -O2 -ftls-model=global-dynamic -fPIC -fdata-sections -ffunction-sections -Wall -Werror -Wextra -shared"
 val nativeTargets = listOf(
   NativeTarget(
     "darwin-arm64.so",
@@ -64,12 +64,12 @@ val nativeTargets = listOf(
   NativeTarget(
     "linux-arm64.so",
     "jni_linux_arm64.Dockerfile",
-    "-static-libstdc++ -static-libgcc -mtls-dialect=desc $sharedCompilerArgs"
+    "-static-libstdc++ -static-libgcc -mtls-dialect=desc -Wl,--exclude-libs,ALL -Wl,--gc-sections $sharedCompilerArgs"
   ),
   NativeTarget(
     "linux-x64.so",
     "jni_linux_x64.Dockerfile",
-    "-static-libstdc++ -static-libgcc -mtls-dialect=gnu2 $sharedCompilerArgs"
+    "-static-libstdc++ -static-libgcc -mtls-dialect=gnu2 -Wl,--exclude-libs,ALL -Wl,--gc-sections $sharedCompilerArgs"
   )
 )
 


### PR DESCRIPTION
These changes should make the binaries safer to use (preventing symbol-clashing) and also make them slightly smaller. Stumbled across this in [this comment](https://github.com/async-profiler/async-profiler/issues/872#issuecomment-1909977286).