### PR TITLE
github-actions: enable provenance

### DIFF
--- a/.buildkite/release.yml
+++ b/.buildkite/release.yml
@@ -2,6 +2,9 @@ agents:
   provider: "gcp"
   image: "family/elastic-otel-java-ubuntu-2204"
 
+env:
+  TARBALL_FILE: ${TARBALL_FILE:-dist.tar}
+
 steps:
   - label: "Build and publish release"
     key: "release"
@@ -13,6 +16,7 @@ steps:
       - "common/build/libs/common-.*.jar"
       - "inferred-spans/build/libs/inferred-spans-.*.jar"
       - "build/dry-run-maven-repo.tgz"
+      - "${TARBALL_FILE}"
 
 notify:
   - slack: "#apm-agent-java"

--- a/.buildkite/release.yml
+++ b/.buildkite/release.yml
@@ -3,7 +3,7 @@ agents:
   image: "family/elastic-otel-java-ubuntu-2204"
 
 env:
-  TARBALL_FILE: ${TARBALL_FILE:-dist.tar}
+  TARBALL_FILE: ${TARBALL_FILE:-artifacts.tar}
 
 steps:
   - label: "Build and publish release"
@@ -11,12 +11,6 @@ steps:
     commands: .ci/release.sh
     artifact_paths:
       - "release.txt"
-      - "agent/build/libs/elastic-otel-javaagent-*.jar"
-      - "jvmti-access/build/libs/jvmti-access-.*.jar"
-      - "universal-profiling-integration/build/libs/universal-profiling-integration-.*.jar"
-      - "agentextension/build/libs/elastic-otel-agentextension-.*.jar"
-      - "common/build/libs/common-.*.jar"
-      - "inferred-spans/build/libs/inferred-spans-.*.jar"
       - "build/dry-run-maven-repo.tgz"
       - "${TARBALL_FILE}"
 

--- a/.buildkite/snapshot.yml
+++ b/.buildkite/snapshot.yml
@@ -2,6 +2,9 @@ agents:
   provider: "gcp"
   image: "family/elastic-otel-java-ubuntu-2204"
 
+env:
+  TARBALL_FILE: ${TARBALL_FILE:-dist.tar}
+
 steps:
   - label: "Build and publish snapshot"
     key: "release"
@@ -13,6 +16,7 @@ steps:
       - "common/build/libs/common-.*.jar"
       - "inferred-spans/build/libs/inferred-spans-.*.jar"
       - "build/dry-run-maven-repo.tgz"
+      - "${TARBALL_FILE}"
 
 notify:
   - slack: "#apm-agent-java"

--- a/.buildkite/snapshot.yml
+++ b/.buildkite/snapshot.yml
@@ -3,7 +3,7 @@ agents:
   image: "family/elastic-otel-java-ubuntu-2204"
 
 env:
-  TARBALL_FILE: ${TARBALL_FILE:-dist.tar}
+  TARBALL_FILE: ${TARBALL_FILE:-artifacts.tar}
 
 steps:
   - label: "Build and publish snapshot"
@@ -11,12 +11,6 @@ steps:
     commands: .ci/snapshot.sh
     artifact_paths:
       - "snapshot.txt"
-      - "agent/build/libs/elastic-otel-javaagent-*.jar"
-      - "jvmti-access/build/libs/jvmti-access-.*.jar"
-      - "universal-profiling-integration/build/libs/universal-profiling-integration-.*.jar"
-      - "agentextension/build/libs/elastic-otel-agentextension-.*.jar"
-      - "common/build/libs/common-.*.jar"
-      - "inferred-spans/build/libs/inferred-spans-.*.jar"
       - "build/dry-run-maven-repo.tgz"
       - "${TARBALL_FILE}"
 

--- a/.ci/release.sh
+++ b/.ci/release.sh
@@ -40,3 +40,6 @@ if [[ "$dry_run" == "true" ]] ; then
     echo "--- Archive the dry-run repository :package: (dry-run)"
     tar czvf ./build/dry-run-maven-repo.tgz -C ./build/dry-run-maven-repo/ . | tee release.txt
 fi
+
+echo "--- Archive the build folders with jar files"
+find . -type d -name build -exec find {} -name '*.jar' -print0 \; | xargs -0 tar -cvf "${TARBALL_FILE:-dist.tar}"

--- a/.ci/release.sh
+++ b/.ci/release.sh
@@ -42,4 +42,5 @@ if [[ "$dry_run" == "true" ]] ; then
 fi
 
 echo "--- Archive the build folders with jar files"
-find . -type d -name build -exec find {} -name '*.jar' -print0 \; | xargs -0 tar -cvf "${TARBALL_FILE:-dist.tar}"
+./gradlew printPublishedCodeArtifacts -q | tee artifacts.list
+tar -cvf "${TARBALL_FILE:-artifacts.tar}" -T artifacts.list

--- a/.ci/snapshot.sh
+++ b/.ci/snapshot.sh
@@ -40,3 +40,6 @@ if [[ "$dry_run" == "true" ]] ; then
     echo "--- Archive the dry-run repository :package: (dry-run)"
     tar czvf ./build/dry-run-maven-repo.tgz -C ./build/dry-run-maven-repo/ . | tee snapshot.txt
 fi
+
+echo "--- Archive the build folders with jar files"
+find . -type d -name build -exec find {} -name '*.jar' -print0 \; | xargs -0 tar -cvf "${TARBALL_FILE:-dist.tar}"

--- a/.ci/snapshot.sh
+++ b/.ci/snapshot.sh
@@ -42,4 +42,5 @@ if [[ "$dry_run" == "true" ]] ; then
 fi
 
 echo "--- Archive the build folders with jar files"
-find . -type d -name build -exec find {} -name '*.jar' -print0 \; | xargs -0 tar -cvf "${TARBALL_FILE:-dist.tar}"
+./gradlew printPublishedCodeArtifacts -q | tee artifacts.list
+tar -cvf "${TARBALL_FILE:-artifacts.tar}" -T artifacts.list

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,7 @@ jobs:
       contents: write
       id-token: write
     env:
-      TARBALL_FILE: dist.tar
+      TARBALL_FILE: artifacts.tar
     steps:
       - id: buildkite
         name: Run Release
@@ -91,7 +91,7 @@ jobs:
           buildEnvVars: |
             ref=${{ inputs.ref }}
             dry_run=${{ inputs.dry_run || 'false' }}
-            TARBALL_FILE=dist.tar
+            TARBALL_FILE=${{ env.TARBALL_FILE }}
 
       - uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,6 +73,8 @@ jobs:
     permissions:
       contents: write
       id-token: write
+    env:
+      TARBALL_FILE: dist.tar
     steps:
       - id: buildkite
         name: Run Release
@@ -85,19 +87,23 @@ jobs:
           waitFor: true
           printBuildLogs: false
           artifactName: releases
-          artifactPath: agent/build/libs/elastic-otel-javaagent-*.jar
+          artifactPath: ${{ env.TARBALL_FILE }}
           buildEnvVars: |
             ref=${{ inputs.ref }}
             dry_run=${{ inputs.dry_run || 'false' }}
+            TARBALL_FILE=dist.tar
 
       - uses: actions/download-artifact@v3
         with:
           name: releases
 
+      - name: untar the buildkite tarball
+        run: tar xvf ${{ env.TARBALL_FILE }}
+
       - name: generate build provenance
         uses: github-early-access/generate-build-provenance@main
         with:
-          subject-path: "${{ github.workspace }}/agent/build/libs/elastic-otel-javaagent-*.jar"
+          subject-path: "${{ github.workspace }}/**/*.jar"
 
       - if: ${{ success() && ! inputs.dry_run }}
         uses: elastic/apm-pipeline-library/.github/actions/slack-message@current

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,6 +70,9 @@ jobs:
     if: ${{ ! inputs.skip_maven_deploy }}
     needs:
       - validate-tag
+    permissions:
+      contents: write
+      id-token: write
     steps:
       - id: buildkite
         name: Run Release
@@ -81,9 +84,20 @@ jobs:
           pipeline: elastic-otel-java-release
           waitFor: true
           printBuildLogs: false
+          artifactName: releases
+          artifactPath: agent/build/libs/elastic-otel-javaagent-*.jar
           buildEnvVars: |
             ref=${{ inputs.ref }}
             dry_run=${{ inputs.dry_run || 'false' }}
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: releases
+
+      - name: generate build provenance
+        uses: github-early-access/generate-build-provenance@main
+        with:
+          subject-path: "${{ github.workspace }}/agent/build/libs/elastic-otel-javaagent-*.jar"
 
       - if: ${{ success() && ! inputs.dry_run }}
         uses: elastic/apm-pipeline-library/.github/actions/slack-message@current

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -45,6 +45,8 @@ jobs:
     permissions:
       contents: write
       id-token: write
+    env:
+      TARBALL_FILE: dist.tar
     if: ${{ contains(needs.validate.outputs.is-snapshot, 'true') }}
     steps:
       - id: buildkite
@@ -59,18 +61,22 @@ jobs:
           waitFor: true
           printBuildLogs: false
           artifactName: snapshots
-          artifactPath: agent/build/libs/elastic-otel-javaagent-*.jar
+          artifactPath: ${{ env.TARBALL_FILE }}
           buildEnvVars: |
             dry_run=${{ inputs.dry_run || 'false' }}
+            TARBALL_FILE=dist.tar
 
       - uses: actions/download-artifact@v3
         with:
           name: snapshots
 
+      - name: untar the buildkite tarball
+        run: tar xvf ${{ env.TARBALL_FILE }}
+
       - name: generate build provenance
         uses: github-early-access/generate-build-provenance@main
         with:
-          subject-path: "${{ github.workspace }}/agent/build/libs/elastic-otel-javaagent-*.jar"
+          subject-path: "${{ github.workspace }}/**/*.jar"
 
       - if: ${{ failure() }}
         uses: elastic/apm-pipeline-library/.github/actions/slack-message@current

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -46,7 +46,7 @@ jobs:
       contents: write
       id-token: write
     env:
-      TARBALL_FILE: dist.tar
+      TARBALL_FILE: artifacts.tar
     if: ${{ contains(needs.validate.outputs.is-snapshot, 'true') }}
     steps:
       - id: buildkite
@@ -64,7 +64,7 @@ jobs:
           artifactPath: ${{ env.TARBALL_FILE }}
           buildEnvVars: |
             dry_run=${{ inputs.dry_run || 'false' }}
-            TARBALL_FILE=dist.tar
+            TARBALL_FILE=${{ env.TARBALL_FILE }}
 
       - uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -42,6 +42,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: 
       - validate
+    permissions:
+      contents: write
+      id-token: write
     if: ${{ contains(needs.validate.outputs.is-snapshot, 'true') }}
     steps:
       - id: buildkite
@@ -53,10 +56,21 @@ jobs:
           vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
           pipeline: elastic-otel-java-snapshot
           pipelineCommit: ${{ github.ref_name }}
-          waitFor: false
+          waitFor: true
           printBuildLogs: false
+          artifactName: snapshots
+          artifactPath: agent/build/libs/elastic-otel-javaagent-*.jar
           buildEnvVars: |
             dry_run=${{ inputs.dry_run || 'false' }}
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: snapshots
+
+      - name: generate build provenance
+        uses: github-early-access/generate-build-provenance@main
+        with:
+          subject-path: "${{ github.workspace }}/agent/build/libs/elastic-otel-javaagent-*.jar"
 
       - if: ${{ failure() }}
         uses: elastic/apm-pipeline-library/.github/actions/slack-message@current


### PR DESCRIPTION
## What does this PR do?

Enable the provenance for the jar file generated in Buildkite using the [GitHub provenance action](https://github.com/github-early-access/generate-build-provenance).

User `artifacts.tar` to store all the artifacts that are produced (uses https://github.com/elastic/elastic-otel-java/pull/226)

## Test

I created a test feature branch and triggered the snapshot workflow:
- https://github.com/elastic/elastic-otel-java/actions/runs/8816874378

See https://github.com/elastic/elastic-otel-java/attestations 

## Issues

Similar to https://github.com/elastic/apm-agent-java/pull/3594

