### PR TITLE
[ci] add missing artifacts in buildkite

### DIFF
--- a/.buildkite/release.yml
+++ b/.buildkite/release.yml
@@ -9,6 +9,9 @@ steps:
     artifact_paths:
       - "release.txt"
       - "agent/build/libs/elastic-otel-javaagent-*.jar"
+      - "agentextension/build/libs/elastic-otel-agentextension-.*.jar"
+      - "common/build/libs/common-.*.jar"
+      - "inferred-spans/build/libs/inferred-spans-.*.jar"
       - "build/dry-run-maven-repo.tgz"
 
 notify:

--- a/.buildkite/snapshot.yml
+++ b/.buildkite/snapshot.yml
@@ -9,6 +9,9 @@ steps:
     artifact_paths:
       - "snapshot.txt"
       - "agent/build/libs/elastic-otel-javaagent-*.jar"
+      - "agentextension/build/libs/elastic-otel-agentextension-.*.jar"
+      - "common/build/libs/common-.*.jar"
+      - "inferred-spans/build/libs/inferred-spans-.*.jar"
       - "build/dry-run-maven-repo.tgz"
 
 notify:


### PR DESCRIPTION
Not all the published artifacts were included in the buildkite result, thus this PR fixes that.

Finding which gradle modules/projects needs to be used here is quite straightforward by using the following command:

```
find . -name 'build.gradle.kts'|xargs grep 'sign-and-publish-conventions'|column -t
```

Which here provides:
```
./inferred-spans/build.gradle.kts:  id("elastic-otel.sign-and-publish-conventions")
./common/build.gradle.kts:          id("elastic-otel.sign-and-publish-conventions")
./agentextension/build.gradle.kts:  id("elastic-otel.sign-and-publish-conventions")
./agent/build.gradle.kts:           id("elastic-otel.sign-and-publish-conventions")
```