### PR TITLE
Add task for printing relative paths of published code artifacts

### DIFF
--- a/buildSrc/src/main/kotlin/elastic-otel.sign-and-publish-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/elastic-otel.sign-and-publish-conventions.gradle.kts
@@ -1,5 +1,3 @@
-import gradle.kotlin.dsl.accessors._2a2fda20f7c0d5ad930aaa9c8e47b6e1.jar
-
 plugins {
   `maven-publish`
   publishing
@@ -32,7 +30,7 @@ afterEvaluate {
       doLast {
         var artifactTasks = publishingConventions.artifactTasks.get()
         if (artifactTasks.isEmpty()) {
-          artifactTasks = listOf(tasks.jar.get());
+          artifactTasks = listOf(tasks.getByName("jar"));
         }
         for (task in artifactTasks) {
           if (task is Jar) {


### PR DESCRIPTION
Feature for #223 : Adds a task to print out the paths to all code jars to be published to maven central.

Running `./gradlew printPublishedCodeArtifacts -q` will output the following to the console:
```  
agent/build/libs/elastic-otel-javaagent-0.1.1-SNAPSHOT.jar
agentextension/build/libs/elastic-otel-agentextension-0.1.1-SNAPSHOT.jar
common/build/libs/common-0.1.1-SNAPSHOT.jar
inferred-spans/build/libs/inferred-spans-0.1.1-SNAPSHOT.jar

```