### PR TITLE
[ci] add GH release to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,7 @@ concurrency:
   
 env:
   RELEASE_VERSION: ${{ inputs.version }}
+  RELEASE_VERSION_TAG: v${{ inputs.version }}
   
 jobs:
   validate-tag:
@@ -50,7 +51,7 @@ jobs:
       - name: Validate release tag does not exist in repo
         uses: ./.github/workflows/validate-tag
         with:
-          tag: v${{ env.RELEASE_VERSION }}
+          tag: ${{ env.RELEASE_VERSION_TAG }}
       - name: Validate tag match current version
         run: |
           if [ "$(./gradlew -q currentVersion)" != "${{ env.RELEASE_VERSION }}" ]; then
@@ -152,3 +153,23 @@ jobs:
       version: ${{ inputs.version }}
       phase: 'post'
     secrets: inherit
+
+  create-github-release:
+    name: "Create GitHub Release"
+    needs:
+      - await-maven-central-artifact
+    runs-on: ubuntu-latest
+    if: ${{ ! inputs.dry_run }}
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create ${{ env.RELEASE_VERSION_TAG }} \
+            --title="Release ${{ env.RELEASE_VERSION }}" \
+            --notes=""


### PR DESCRIPTION
Automatically create a github release as one of the last steps of the release workflow.