### PR TITLE
Fix remote span handling in LocalRootSpan utility

### DIFF
--- a/common/src/main/java/co/elastic/otel/common/LocalRootSpan.java
+++ b/common/src/main/java/co/elastic/otel/common/LocalRootSpan.java
@@ -103,10 +103,14 @@ public class LocalRootSpan {
    *       parents
    *   <li>The provided span or one if its parents is a delayed inferred span where the parent was
    *       provided as a remote span
+   *   <li>The provided span is a remote span
    * </ul>
    */
   @Nullable
   public static ReadableSpan getFor(Span span) {
+    if (span.getSpanContext().isRemote()) {
+      return null;
+    }
     return getFor((ReadableSpan) span);
   }
 

--- a/common/src/test/java/co/elastic/otel/common/LocalRootSpanTest.java
+++ b/common/src/test/java/co/elastic/otel/common/LocalRootSpanTest.java
@@ -97,6 +97,19 @@ public class LocalRootSpanTest {
     assertThat(LocalRootSpan.getFor((ReadableSpan) span)).isSameAs(span);
   }
 
+
+  @Test
+  public void checkRemoteSpan() {
+    Map<String, String> headers = new HashMap<>();
+    headers.put("traceparent", "00-0af7651916cd43dd8448eb211c80319c-00f067aa0ba902b7-01");
+    Context remoteParent =
+        sdk.getPropagators()
+            .getTextMapPropagator()
+            .extract(Context.root(), headers, new MapGetter());
+
+    assertThat(LocalRootSpan.getFor(Span.fromContext(remoteParent))).isNull();
+  }
+
   @Test
   public void checkInferredSpanDetected() {
     Map<String, String> headers = new HashMap<>();


### PR DESCRIPTION
Relates to #236, even though this fix likely won't fix that issue. Nonetheless, it uncovered a potential problem is `LocalRootSpan`.