### PR TITLE
Generate class exposing version for libraries

### DIFF
--- a/buildSrc/src/main/kotlin/elastic-otel.library-packaging-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/elastic-otel.library-packaging-conventions.gradle.kts
@@ -1,3 +1,5 @@
+import java.util.stream.Collectors
+
 plugins {
   `java-library`
   id("elastic-otel.java-conventions")
@@ -15,4 +17,42 @@ tasks {
     }
   }
 
+  // Generates a Java class exposing the project version
+  val generateVersionProviderSource by registering() {
+    val packageName = "co.elastic.otel";
+    val className = kebapToCamelCase(project.name)+"Version";
+
+    val outputDir = layout.buildDirectory.dir("generated/version-provider-source")
+    outputs.dir(outputDir)
+    doLast {
+      val packageDir = outputDir.get().asFile.resolve(packageName.replace('.', '/'))
+      packageDir.mkdirs()
+      val source = """
+        package $packageName;
+        
+        /**
+         * This class is generated.
+        */
+        public class $className {
+          public static final String VERSION = "${project.version}";
+        }
+      """.trimIndent()
+      packageDir.resolve("$className.java").writeText(source)
+    }
+  }
+}
+
+sourceSets {
+  main {
+    java {
+      srcDir(tasks.getByName("generateVersionProviderSource"));
+    }
+  }
+}
+
+fun kebapToCamelCase(name : String) : String {
+  val words = name.split("-");
+  return words.stream()
+    .map { w -> Character.toUpperCase(w[0]) + w.substring(1) }
+    .collect(Collectors.joining())
 }

--- a/inferred-spans/build.gradle.kts
+++ b/inferred-spans/build.gradle.kts
@@ -37,15 +37,6 @@ tasks.javadoc {
   options.encoding = "UTF-8"
 }
 
-tasks.processResources {
-  doLast {
-    val resourcesDir = sourceSets.main.get().output.resourcesDir
-    val packageDir = resourcesDir!!.resolve("co/elastic/otel/profiler");
-    packageDir.mkdirs();
-    packageDir.resolve("inferred-spans-version.txt").writeText(project.version.toString())
-  }
-}
-
 tasks.withType<Test>().all {
   jvmArgs("-Djava.util.logging.config.file="+sourceSets.test.get().output.resourcesDir+"/logging.properties")
 }

--- a/inferred-spans/src/main/java/co/elastic/otel/profiler/InferredSpansProcessor.java
+++ b/inferred-spans/src/main/java/co/elastic/otel/profiler/InferredSpansProcessor.java
@@ -18,6 +18,7 @@
  */
 package co.elastic.otel.profiler;
 
+import co.elastic.otel.InferredSpansVersion;
 import co.elastic.otel.common.util.ExecutorUtils;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.trace.Tracer;
@@ -27,11 +28,7 @@ import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.trace.ReadWriteSpan;
 import io.opentelemetry.sdk.trace.ReadableSpan;
 import io.opentelemetry.sdk.trace.SpanProcessor;
-import java.io.BufferedReader;
 import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import java.util.logging.Level;
@@ -43,8 +40,6 @@ public class InferredSpansProcessor implements SpanProcessor {
   private static final Logger logger = Logger.getLogger(InferredSpansProcessor.class.getName());
 
   public static final String TRACER_NAME = "elastic-inferred-spans";
-
-  private static final String TRACER_VERSION = readInferredSpansVersion();
 
   // Visible for testing
   final SamplingProfiler profiler;
@@ -72,7 +67,7 @@ public class InferredSpansProcessor implements SpanProcessor {
    *     lazily.
    */
   public synchronized void setTracerProvider(TracerProvider provider) {
-    tracer = provider.get(TRACER_NAME, TRACER_VERSION);
+    tracer = provider.get(TRACER_NAME, InferredSpansVersion.VERSION);
   }
 
   @Override
@@ -121,14 +116,5 @@ public class InferredSpansProcessor implements SpanProcessor {
       }
     }
     return tracer;
-  }
-
-  private static String readInferredSpansVersion() {
-    try (InputStream is =
-        InferredSpansProcessor.class.getResourceAsStream("inferred-spans-version.txt")) {
-      return new BufferedReader(new InputStreamReader(is)).readLine();
-    } catch (IOException e) {
-      throw new IllegalStateException("Failed to read version", e);
-    }
   }
 }


### PR DESCRIPTION
Because we publish our extensions as standalone extensions, it theoretically is possible to end up with different versions of the individual libraries on the classpath. Therefore it is useful to log (or somehow expose, e.g. as the tracer version) the exact library version used.

This was already implemented for `inferred-spans` by generating a textual resource containing the version. The way this was implemented was brittle though, as I broke it by removing all other resources while upgrading to async-profiler 3.

This PR makes accessing the version simpler to use by letting gradle generate a java source exposing the project version.
I've added this functionality to our `library-packaging-convetions` to make it available to all our libraries.