### PR TITLE
Revert "Hide statically linked libstdc++ symbols and enable compiler to remove unused code. (#221)"

### DIFF
--- a/jvmti-access/build.gradle.kts
+++ b/jvmti-access/build.gradle.kts
@@ -52,7 +52,7 @@ sourceSets {
   }
 }
 
-val sharedCompilerArgs = "-std=c++17 -fno-rtti -fno-exceptions -O2 -ftls-model=global-dynamic -fPIC -fdata-sections -ffunction-sections -Wall -Werror -Wextra -shared"
+val sharedCompilerArgs = "-std=c++17 -fno-rtti -fno-exceptions -O2 -ftls-model=global-dynamic -fPIC -Wall -Werror -Wextra -shared"
 val nativeTargets = listOf(
   NativeTarget(
     "darwin-arm64.so",
@@ -68,12 +68,12 @@ val nativeTargets = listOf(
   NativeTarget(
     "linux-arm64.so",
     "jni_linux_arm64.Dockerfile",
-    "-static-libstdc++ -static-libgcc -mtls-dialect=desc -Wl,--exclude-libs,ALL -Wl,--gc-sections $sharedCompilerArgs"
+    "-static-libstdc++ -static-libgcc -mtls-dialect=desc $sharedCompilerArgs"
   ),
   NativeTarget(
     "linux-x64.so",
     "jni_linux_x64.Dockerfile",
-    "-static-libstdc++ -static-libgcc -mtls-dialect=gnu2 -Wl,--exclude-libs,ALL -Wl,--gc-sections $sharedCompilerArgs"
+    "-static-libstdc++ -static-libgcc -mtls-dialect=gnu2 $sharedCompilerArgs"
   )
 )
 


### PR DESCRIPTION
This reverts commit a793f19a64614a5ac229c5c0e6262c92d76a155a.

Unfortunately the changes to the compiler flags caused the universal-profiling host agent to fail at detecting the library. I'll contact the profiling team to investigate the root cause for the detection failure.