### PR TITLE
Fix release process, manually bump to next snapshot version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,7 +158,7 @@ jobs:
   create-github-release:
     name: "Create GitHub Release"
     needs:
-      - await-maven-central-artifact
+      - post-release
     runs-on: ubuntu-latest
     if: ${{ ! inputs.dry_run }}
     permissions:
@@ -172,5 +172,6 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh release create ${{ env.RELEASE_VERSION_TAG }} \
+            --verify-tag \
             --title="Release ${{ env.RELEASE_VERSION }}" \
             --notes=""

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-version=0.3.1
+version=0.3.2-SNAPSHOT


### PR DESCRIPTION
The previous release failed because the `gh release create` was executed before the post-release task published the tag.
This caused the tag to be created by the `gh release create`, making the post-release step fail.