### PR TITLE
Fix ClassCastException in inferred spans

### DIFF
--- a/common/src/main/java/co/elastic/otel/common/LocalRootSpan.java
+++ b/common/src/main/java/co/elastic/otel/common/LocalRootSpan.java
@@ -108,10 +108,12 @@ public class LocalRootSpan {
    */
   @Nullable
   public static ReadableSpan getFor(Span span) {
-    if (span.getSpanContext().isRemote()) {
+    if (span instanceof ReadableSpan) {
+      return getFor((ReadableSpan) span);
+    } else {
+      //This can happen when invoked for a PropagatedSpan (e.g. Span.fromContext())
       return null;
     }
-    return getFor((ReadableSpan) span);
   }
 
   /** See {@link LocalRootSpan#getFor(Span)}. */

--- a/common/src/main/java/co/elastic/otel/common/LocalRootSpan.java
+++ b/common/src/main/java/co/elastic/otel/common/LocalRootSpan.java
@@ -111,7 +111,7 @@ public class LocalRootSpan {
     if (span instanceof ReadableSpan) {
       return getFor((ReadableSpan) span);
     } else {
-      //This can happen when invoked for a PropagatedSpan (e.g. Span.fromContext())
+      // This can happen when invoked for a PropagatedSpan (e.g. Span.fromContext())
       return null;
     }
   }

--- a/testing/integration-tests/inferred-spans-test/build.gradle.kts
+++ b/testing/integration-tests/inferred-spans-test/build.gradle.kts
@@ -11,6 +11,7 @@ dependencies {
 tasks.withType<Test>() {
   jvmArgs(
     //"-Dotel.javaagent.debug=true",
+    "-Dotel.service.name=testing",
     "-Delastic.otel.inferred.spans.enabled=true",
     "-Delastic.otel.inferred.spans.duration=2000ms",
     "-Delastic.otel.inferred.spans.interval=2000ms",


### PR DESCRIPTION
Fixes #236.

The reason this was not caught by our integration tests is that for the inferred spans test there was no service-name configured. This in turn caused the universal profiling integration to not be active, which triggers the problematic `LocalRootSpan`.

Configuring the `service.name` in the integration test reproduced the issue.

@jackshirazi would still be great if you could do a quick manual test in your scenario where you uncovered the problem to make sure nothing else breaks.