### PR TITLE
Fix handling of remote spans for inferred spans

### DIFF
--- a/inferred-spans/src/test/java/co/elastic/otel/profiler/SamplingProfilerTest.java
+++ b/inferred-spans/src/test/java/co/elastic/otel/profiler/SamplingProfilerTest.java
@@ -284,15 +284,15 @@ class SamplingProfilerTest {
     setupProfiler(true);
     awaitProfilerStarted(setup.profiler);
 
-    SpanContext dummyParentCtx = SpanContext.createFromRemoteParent(
-        "a1a2a3a4a5a6a7a8b1b2b3b4b5b6b7b8",
-        "c1c2c3c4c5c6c7c8",
-        TraceFlags.getSampled(),
-        TraceState.getDefault()
-    );
+    SpanContext dummyParentCtx =
+        SpanContext.createFromRemoteParent(
+            "a1a2a3a4a5a6a7a8b1b2b3b4b5b6b7b8",
+            "c1c2c3c4c5c6c7c8",
+            TraceFlags.getSampled(),
+            TraceState.getDefault());
     Span remoteParent = Span.wrap(dummyParentCtx);
     try (Scope scope = remoteParent.makeCurrent()) {
-      //ensure that a remote span activation does not trigger profiling
+      // ensure that a remote span activation does not trigger profiling
       assertThat(setup.profiler.isProfilingActiveOnThread(Thread.currentThread())).isFalse();
 
       Tracer tracer = setup.sdk.getTracer("manual-spans");
@@ -315,10 +315,11 @@ class SamplingProfilerTest {
     assertThat(localRoot.get()).hasParentSpanId("c1c2c3c4c5c6c7c8");
 
     assertThat(spans)
-        .anySatisfy(span -> {
-          assertThat(span).hasParent(localRoot.get());
-          assertThat(span).hasAttribute(ElasticAttributes.IS_INFERRED, true);
-        });
+        .anySatisfy(
+            span -> {
+              assertThat(span).hasParent(localRoot.get());
+              assertThat(span).hasAttribute(ElasticAttributes.IS_INFERRED, true);
+            });
   }
 
   @Test

--- a/inferred-spans/src/test/java/co/elastic/otel/profiler/SamplingProfilerTest.java
+++ b/inferred-spans/src/test/java/co/elastic/otel/profiler/SamplingProfilerTest.java
@@ -21,8 +21,12 @@ package co.elastic.otel.profiler;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
+import co.elastic.otel.common.ElasticAttributes;
 import co.elastic.otel.testing.DisabledOnOpenJ9;
 import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.TraceFlags;
+import io.opentelemetry.api.trace.TraceState;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
@@ -273,6 +277,48 @@ class SamplingProfilerTest {
     virtual.join();
 
     assertThat(profilingActive.get()).isFalse();
+  }
+
+  @Test
+  void testTransactionWithRemoteParent() throws Exception {
+    setupProfiler(true);
+    awaitProfilerStarted(setup.profiler);
+
+    SpanContext dummyParentCtx = SpanContext.createFromRemoteParent(
+        "a1a2a3a4a5a6a7a8b1b2b3b4b5b6b7b8",
+        "c1c2c3c4c5c6c7c8",
+        TraceFlags.getSampled(),
+        TraceState.getDefault()
+    );
+    Span remoteParent = Span.wrap(dummyParentCtx);
+    try (Scope scope = remoteParent.makeCurrent()) {
+      //ensure that a remote span activation does not trigger profiling
+      assertThat(setup.profiler.isProfilingActiveOnThread(Thread.currentThread())).isFalse();
+
+      Tracer tracer = setup.sdk.getTracer("manual-spans");
+      Span localRoot = tracer.spanBuilder("local-root").startSpan();
+      try (Scope scope2 = localRoot.makeCurrent()) {
+        Thread.sleep(500);
+      }
+      localRoot.end();
+    }
+
+    await()
+        .pollDelay(10, TimeUnit.MILLISECONDS)
+        .timeout(5000, TimeUnit.MILLISECONDS)
+        .untilAsserted(() -> assertThat(setup.getSpans()).hasSizeGreaterThanOrEqualTo(2));
+
+    List<SpanData> spans = setup.getSpans();
+    Optional<SpanData> localRoot =
+        spans.stream().filter(s -> s.getName().equals("local-root")).findAny();
+    assertThat(localRoot).isPresent();
+    assertThat(localRoot.get()).hasParentSpanId("c1c2c3c4c5c6c7c8");
+
+    assertThat(spans)
+        .anySatisfy(span -> {
+          assertThat(span).hasParent(localRoot.get());
+          assertThat(span).hasAttribute(ElasticAttributes.IS_INFERRED, true);
+        });
   }
 
   @Test


### PR DESCRIPTION
Closes #250.

Activations of remote spans wil lbe effectively ignored:
 * If a remote span is activated as first span on a thread (typical case), it won't start a profiling session. Only when an actual server-span (child of the remote span) is started, the profiling will be started.
 * If a remote span is activated while a profiling session is already active (=it replace a local span), this activation is effectively ignored. This means inferred spans on the given thread will continue to be children of the previously active span.
 
 @AlexanderWert you observed some strange behaviour of invalid parent/child relationships with a GRPC use-case. Would be great if you find the time to check with the snapshot from this PR if it fixes the issue.