### PR TITLE
add docker file

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,6 @@
+FROM docker.elastic.co/wolfi/chainguard-base@sha256:9f940409f96296ef56140bcc4665c204dd499af4c32c96cc00e792558097c3f1
+ARG JAR_FILE
+ARG EXTENSION_JAR_FILE
+COPY ${JAR_FILE} /javaagent.jar
+COPY ${EXTENSION_JAR_FILE} /extensions/elastic-otel-agentextension.jar 
+RUN chmod go+r /javaagent.jar /extensions

--- a/docker/build_docker.sh
+++ b/docker/build_docker.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+
+# See full documentation in the "Creating and publishing Docker images" section
+# of CONTRIBUTING.md
+
+set -euxo pipefail
+
+if ! command -v docker
+then
+  echo "ERROR: Building Docker image requires Docker binary to be installed" && exit 1
+elif ! docker version
+then
+  echo "ERROR: Building Docker image requires Docker daemon to be running" && exit 1
+fi
+readonly RELEASE_VERSION=${1}
+
+readonly SCRIPT_PATH="$( cd "$(dirname "$0")" ; pwd -P )"
+readonly PROJECT_ROOT=$SCRIPT_PATH/../
+readonly NAMESPACE="observability"
+
+FILE=$(ls -A ${PROJECT_ROOT}agent/build/libs/*.jar | grep -E "elastic-otel-javaagent-[0-9]+.[0-9]+.[0-9]+(-SNAPSHOT)?.jar" )
+EXTENSION_FILE=$(ls -A ${PROJECT_ROOT}agentextension/build/libs/*.jar | grep -E "elastic-otel-agentextension-[0-9]+.[0-9]+.[0-9]+(-SNAPSHOT)?.jar" )
+
+if [ -n "${FILE}" ]
+then
+  # We have build files to use
+  echo "INFO: Found local build artifact agent jar. Using locally built for Docker build"
+  cp "${FILE}" "${PROJECT_ROOT}elastic-otel-javaagent.jar" || echo "INFO: No locally built image found"
+elif [ ! -z ${SONATYPE_FALLBACK+x} ]
+then
+  echo "INFO: No local build artifact and SONATYPE_FALLBACK. Falling back to downloading artifact from Sonatype Nexus repository for version $RELEASE_VERSION"
+  if ! command -v curl
+  then
+      echo "ERROR: Pulling images from Sonatype Nexus repo requires cURL to be installed" && exit 1
+  fi
+  curl -L -s -o elastic-otel-javaagent.jar \
+    "https://oss.sonatype.org/service/local/artifact/maven/redirect?r=releases&g=co.elastic.otel&a=elastic-otel-javaagent&v=$RELEASE_VERSION"
+  else
+    echo "ERROR: No suitable build artifact was found. Re-running this script with the SONATYPE_FALLBACK variable set to true will try to use the Sonatype artifact for the latest tag"
+    exit 1
+fi
+
+if [ -n "${EXTENSION_FILE}" ]
+then
+  # We have build files to use
+  echo "INFO: Found local build artifact extension jar. Using locally built for Docker build"
+  cp "${EXTENSION_FILE}" "${PROJECT_ROOT}elastic-otel-agentextension.jar" || echo "INFO: No locally built image found"
+elif [ ! -z ${SONATYPE_FALLBACK+x} ]
+then
+  echo "INFO: No local build artifact and SONATYPE_FALLBACK. Falling back to downloading artifact from Sonatype Nexus repository for version $RELEASE_VERSION"
+  if ! command -v curl
+  then
+      echo "ERROR: Pulling images from Sonatype Nexus repo requires cURL to be installed" && exit 1
+  fi
+  curl -L -s -o elastic-otel-agentextension.jar \
+    "https://oss.sonatype.org/service/local/artifact/maven/redirect?r=releases&g=co.elastic.otel&a=elastic-otel-agentextension&v=$RELEASE_VERSION"
+  else
+    echo "ERROR: No suitable build artifact was found. Re-running this script with the SONATYPE_FALLBACK variable set to true will try to use the Sonatype artifact for the latest tag"
+    exit 1
+fi
+
+ls -l elastic-otel-javaagent.jar elastic-otel-agentextension.jar
+
+echo "INFO: Starting Docker build for version $RELEASE_VERSION"
+for DOCKERFILE in "${PROJECT_ROOT}docker/Dockerfile" ; do
+  DOCKER_TAG=$RELEASE_VERSION
+  docker build -t docker.elastic.co/$NAMESPACE/elastic-otel-javaagent:$DOCKER_TAG \
+    --platform linux/amd64 \
+    --build-arg JAR_FILE=elastic-otel-javaagent.jar \
+    --build-arg EXTENSION_JAR_FILE=elastic-otel-agentextension.jar \
+    --file $DOCKERFILE .
+
+  if [ $? -eq 0 ]
+  then
+    echo "INFO: Docker image built successfully"
+  else
+    echo "ERROR: Problem building Docker image!"
+  fi
+done
+
+function finish {
+
+  if [ -f elastic-otel-javaagent.jar ]
+  then
+    echo "INFO: Cleaning up downloaded artifact"
+    rm elastic-otel-javaagent.jar elastic-otel-agentextension.jar
+  fi
+}
+
+trap finish EXIT

--- a/docker/push_docker.sh
+++ b/docker/push_docker.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+# This script is present on workers but may not be present in a development
+# environment.
+
+if [ ${WORKSPACE+x} ]  # We are on a CI worker
+then
+  source /usr/local/bin/bash_standard_lib.sh
+fi
+
+readonly RETRIES=3
+
+# This script is intended to work in conjunction with the build_docker
+# script. It assumes that build_docker.sh has been run at least once, thereby
+# creating a Docker image to push. If this script does not detect an image
+# to be uploaded, it will fail.
+
+# Grab the tag we are working with
+
+readonly RELEASE_VERSION=${1}
+readonly DOCKER_REGISTRY_URL="docker.elastic.co"
+readonly DOCKER_IMAGE_NAME="observability/elastic-otel-javaagent"
+readonly DOCKER_PUSH_IMAGE="$DOCKER_REGISTRY_URL/$DOCKER_IMAGE_NAME:$RELEASE_VERSION"
+readonly DOCKER_PUSH_IMAGE_LATEST="$DOCKER_REGISTRY_URL/$DOCKER_IMAGE_NAME:latest"
+
+# Proceed with pushing to the registry
+echo "INFO: Pushing image $DOCKER_PUSH_IMAGE to $DOCKER_REGISTRY_URL"
+
+docker push $DOCKER_PUSH_IMAGE || { echo "You may need to run 'docker login' first and then re-run this script"; exit 1; }
+
+readonly LATEST_TAG=$(git tag --list --sort=version:refname "v*" | grep -v RC | sed s/^v// | tail -n 1)
+
+if [ "$RELEASE_VERSION" = "$LATEST_TAG" ]
+then
+  echo "INFO: Current version ($RELEASE_VERSION) is the latest version. Tagging and pushing $DOCKER_PUSH_IMAGE_LATEST ..."
+  docker tag $DOCKER_PUSH_IMAGE $DOCKER_PUSH_IMAGE_LATEST
+  docker push $DOCKER_PUSH_IMAGE_LATEST || { echo "You may need to run 'docker login' first and then re-run this script"; exit 1; }
+fi


### PR DESCRIPTION
Note
- We're only doing the wolfi dockerfile (the image needs `cp` for the otel k8s operator, so we can't start from scratch)
- The /javaagent.jar path is the path the otel k8s operator needs so that the image can be used for auto-instrumentation
- Including the extension jar means the docker image can alternatively be used by the otel k8s operator as an extension for the vanilla otel agent. This can be any path, using an `extensions` dir seems like a reasonable choice
