### PR TITLE
github-action: run buildkite action with GH secrets and slack notifications

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,26 +79,24 @@ jobs:
     env:
       TARBALL_FILE: artifacts.tar
     steps:
-      - id: buildkite
+      - id: buildkite-run
         name: Run Release
-        uses: elastic/apm-pipeline-library/.github/actions/buildkite@current
+        uses: elastic/oblt-actions/buildkite/run@v1.5.0
         with:
-          vaultUrl: ${{ secrets.VAULT_ADDR }}
-          vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
-          vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
-          pipeline: elastic-otel-java-release
-          waitFor: true
-          printBuildLogs: false
-          artifactName: releases
-          artifactPath: ${{ env.TARBALL_FILE }}
-          buildEnvVars: |
+          pipeline: "elastic-otel-java-release"
+          token: ${{ secrets.BUILDKITE_TOKEN }}
+          wait-for: true
+          env-vars: |
             ref=${{ inputs.ref }}
             dry_run=${{ inputs.dry_run || 'false' }}
             TARBALL_FILE=${{ env.TARBALL_FILE }}
 
-      - uses: actions/download-artifact@v3
+      - uses: elastic/oblt-actions/buildkite/download-artifact@v1.5.0
         with:
-          name: releases
+          build-number: ${{ steps.buildkite-run.outputs.number }}
+          path: ${{ env.TARBALL_FILE }}
+          pipeline: ${{ steps.buildkite-run.outputs.pipeline }}
+          token: ${{ secrets.BUILDKITE_TOKEN }}
 
       - name: untar the buildkite tarball
         run: tar xvf ${{ env.TARBALL_FILE }}
@@ -109,22 +107,18 @@ jobs:
           subject-path: "${{ github.workspace }}/**/*.jar"
 
       - if: ${{ success() && ! inputs.dry_run }}
-        uses: elastic/apm-pipeline-library/.github/actions/slack-message@current
+        uses: elastic/oblt-actions/slack/send@v1.5.0
         with:
-          url: ${{ secrets.VAULT_ADDR }}
-          roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secretId: ${{ secrets.VAULT_SECRET_ID }}
-          channel: "#apm-agent-java"
+          bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
+          channel-id: "#apm-agent-java"
           message: |
-            :runner: [${{ github.repository }}] Release *${{ github.ref_name }}* has been triggered in Buildkite: (<${{ steps.buildkite.outputs.build }}|build>)
+            :runner: [${{ github.repository }}] Release *${{ github.ref_name }}* has been triggered in Buildkite: (<${{ steps.buildkite-run.outputs.build }}|build>)
 
       - if: ${{ failure() && ! inputs.dry_run }}
-        uses: elastic/apm-pipeline-library/.github/actions/slack-message@current
+        uses: elastic/oblt-actions/slack/send@v1.5.0
         with:
-          url: ${{ secrets.VAULT_ADDR }}
-          roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secretId: ${{ secrets.VAULT_SECRET_ID }}
-          channel: "#apm-agent-java"
+          bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
+          channel-id: "#apm-agent-java"
           message: |
             :ghost: [${{ github.repository }}] Release *${{ github.ref_name }}* didn't get triggered in Buildkite.
             Build: (<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>)

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -50,26 +50,25 @@ jobs:
       TARBALL_FILE: artifacts.tar
     if: ${{ contains(needs.validate.outputs.is-snapshot, 'true') }}
     steps:
-      - id: buildkite
+
+      - id: buildkite-run
         name: Run Deploy
-        uses: elastic/apm-pipeline-library/.github/actions/buildkite@current
+        uses: elastic/oblt-actions/buildkite/run@v1.5.0
         with:
-          vaultUrl: ${{ secrets.VAULT_ADDR }}
-          vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
-          vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
-          pipeline: elastic-otel-java-snapshot
-          pipelineCommit: ${{ github.ref_name }}
-          waitFor: true
-          printBuildLogs: false
-          artifactName: snapshots
-          artifactPath: ${{ env.TARBALL_FILE }}
-          buildEnvVars: |
+          commit: ${{ github.ref_name }}
+          pipeline: "elastic-otel-java-snapshot"
+          token: ${{ secrets.BUILDKITE_TOKEN }}
+          wait-for: true
+          env-vars: |
             dry_run=${{ inputs.dry_run || 'false' }}
             TARBALL_FILE=${{ env.TARBALL_FILE }}
 
-      - uses: actions/download-artifact@v3
+      - uses: elastic/oblt-actions/buildkite/download-artifact@v1.5.0
         with:
-          name: snapshots
+          build-number: ${{ steps.buildkite-run.outputs.number }}
+          path: ${{ env.TARBALL_FILE }}
+          pipeline: ${{ steps.buildkite-run.outputs.pipeline }}
+          token: ${{ secrets.BUILDKITE_TOKEN }}
 
       - name: untar the buildkite tarball
         run: tar xvf ${{ env.TARBALL_FILE }}
@@ -80,12 +79,10 @@ jobs:
           subject-path: "${{ github.workspace }}/**/*.jar"
 
       - if: ${{ failure() }}
-        uses: elastic/apm-pipeline-library/.github/actions/slack-message@current
+        uses: elastic/oblt-actions/slack/send@v1.5.0
         with:
-          url: ${{ secrets.VAULT_ADDR }}
-          roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secretId: ${{ secrets.VAULT_SECRET_ID }}
-          channel: "#apm-agent-java"
+          bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
+          channel-id: "#apm-agent-java"
           message: |
             :ghost: [${{ github.repository }}] Snapshot *${{ github.ref_name }}* didn't get triggered in Buildkite.
             Build: (<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>)


### PR DESCRIPTION
Use GitHub secrets to run the Buildkite release/snapshot and notify status in Slack.

No more Vault secrets access. 

There is a pending task to replace the GitHub token user.

## Test

I created a feature branch called `test/buildkite-tokens` and ran:
- https://github.com/elastic/elastic-otel-java/actions/runs/9365639057