### PR TITLE
ci(release-github-token): use GitHub secrets

### DIFF
--- a/.github/workflows/pre-post-release.yml
+++ b/.github/workflows/pre-post-release.yml
@@ -54,24 +54,18 @@ jobs:
       - validate-tag
     permissions:
       contents: write
+    env:
+      GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
     steps:
-      - uses: elastic/apm-pipeline-library/.github/actions/github-token@current
-        with:
-          url: ${{ secrets.VAULT_ADDR }}
-          roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secretId: ${{ secrets.VAULT_SECRET_ID }}
-  
-      - uses: elastic/apm-pipeline-library/.github/actions/setup-git@current
-        with:
-          username: ${{ env.GIT_USER }}
-          email: ${{ env.GIT_EMAIL }}
-          token: ${{ env.GITHUB_TOKEN }}
-  
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
           token: ${{ env.GITHUB_TOKEN }}
-  
+
+      - uses: elastic/oblt-actions/git/setup@v1
+        with:
+          github-token: ${{ env.GITHUB_TOKEN }}
+
       - name: Create the release tag (post phase)
         if: inputs.phase == 'post'
         run: |


### PR DESCRIPTION
Use GitHub secret `RELEASE_GITHUB_TOKEN` to run releases. No more need to use the apm-pipeline-library but oblt-actions.


Need to create the token