### PR TITLE
Fix disabling of inferred spans tests with openJ9

### DIFF
--- a/buildSrc/src/main/kotlin/elastic-otel.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/elastic-otel.java-conventions.gradle.kts
@@ -2,6 +2,18 @@ plugins {
   id("java")
 }
 
+interface JavaVersionTestingExtension {
+  /**
+   * By default the convention will publish the artifacts and pom as libraries.
+   * To override the behaviour provide the tasks producing the artifacts as this property.
+   * This should only be required when publishing fat-jars with custom packaging.
+   */
+  val enableTestsOnOpenJ9: Property<Boolean>
+}
+
+val javaVersionTesting = project.extensions.create<JavaVersionTestingExtension>("javaVersionTesting")
+javaVersionTesting.enableTestsOnOpenJ9.convention(true)
+
 afterEvaluate {
   val testJavaVersion = gradle.startParameter.projectProperties["testJavaVersion"]?.let(JavaVersion::toVersion)
   val useJ9 = gradle.startParameter.projectProperties["testJavaVM"]?.run { this == "openj9" }
@@ -18,6 +30,8 @@ afterEvaluate {
       //only run tests which have a compatible bytecode version
       val compileVersion = JavaVersion.toVersion(project.tasks.compileTestJava.get().options.release.get())
       isEnabled = isEnabled && testJavaVersion.isCompatibleWith(compileVersion)
+      //Disable if the test does not support openJ9
+      isEnabled = isEnabled && (!useJ9 || javaVersionTesting.enableTestsOnOpenJ9.get())
     }
   }
 }

--- a/testing/integration-tests/inferred-spans-test/build.gradle.kts
+++ b/testing/integration-tests/inferred-spans-test/build.gradle.kts
@@ -8,6 +8,10 @@ dependencies {
   testImplementation("io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations")
 }
 
+javaVersionTesting {
+  enableTestsOnOpenJ9 = false
+}
+
 tasks.withType<Test>() {
   jvmArgs(
     //"-Dotel.javaagent.debug=true",

--- a/testing/integration-tests/inferred-spans-test/src/test/java/InferredSpansTest.java
+++ b/testing/integration-tests/inferred-spans-test/src/test/java/InferredSpansTest.java
@@ -20,7 +20,6 @@ import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.asser
 import static org.awaitility.Awaitility.await;
 
 import co.elastic.otel.common.ElasticAttributes;
-import co.elastic.otel.testing.DisabledOnOpenJ9;
 import io.opentelemetry.instrumentation.annotations.WithSpan;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.sdk.trace.data.SpanData;
@@ -32,7 +31,6 @@ import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 @DisabledOnOs(OS.WINDOWS)
-@DisabledOnOpenJ9
 public class InferredSpansTest {
 
   @RegisterExtension


### PR DESCRIPTION
The integration tests for inferred-spans would occasionally crash for openJ9: OpenJ9 support is experimental in async-profiler and seems to be a bit racy, making the JVM crash sometimes.

[here](https://github.com/elastic/elastic-otel-java/actions/runs/9642043462/job/26589205481) is an example of such a failed run. 

For that we reason, we already exclude openj9 from async-profiler tests. For the integration tests, the `@DisabledOnOpenj9` annotation isn't sufficient though, because there we start the agent via JVM parameters, which potentially can already crash the JVM before JUnit even gets to run.

This PR adds a config option to gradle to exclude projects from running with openJ9 for tests.