### PR TITLE
Added portable musl build for jvmti-library

### DIFF
--- a/jvmti-access/build.gradle.kts
+++ b/jvmti-access/build.gradle.kts
@@ -74,6 +74,16 @@ val nativeTargets = listOf(
     "linux-x64.so",
     "jni_linux_x64.Dockerfile",
     "-static-libstdc++ -static-libgcc -mtls-dialect=gnu2 $sharedCompilerArgs"
+  ),
+  NativeTarget(
+    "linux-musl-arm64.so",
+    "jni_linux_musl_arm64.Dockerfile",
+    "-static-libstdc++ -static-libgcc -mtls-dialect=desc $sharedCompilerArgs"
+  ),
+  NativeTarget(
+    "linux-musl-x64.so",
+    "jni_linux_musl_x64.Dockerfile",
+    "-static-libstdc++ -static-libgcc -mtls-dialect=gnu2 $sharedCompilerArgs"
   )
 )
 

--- a/jvmti-access/jni-build/jni_linux_musl_arm64.Dockerfile
+++ b/jvmti-access/jni-build/jni_linux_musl_arm64.Dockerfile
@@ -1,0 +1,6 @@
+FROM elastic_jni_build_java_includes:latest AS java_includes
+
+FROM dockcross/linux-arm64-musl@sha256:b3b564d2696217bb41a08228d7a0683aa8ee5f62f3cc1d4e635b35d02dbd9870
+COPY --from=java_includes /java_linux /java_linux
+
+CMD $CXX -I /java_linux/include -I /java_linux/include/linux $BUILD_ARGS

--- a/jvmti-access/jni-build/jni_linux_musl_x64.Dockerfile
+++ b/jvmti-access/jni-build/jni_linux_musl_x64.Dockerfile
@@ -9,7 +9,7 @@ ENV CROSS_TRIPLE x86_64-linux-musl
 ENV CROSS_ROOT ${XCC_PREFIX}/${CROSS_TRIPLE}-cross
 
 RUN mkdir -p ${XCC_PREFIX}
-RUN curl --max-time 15 --retry 5 -LO http://musl.cc/${CROSS_TRIPLE}-cross.tgz
+RUN curl --max-time 60 --retry 5 -LO http://musl.cc/${CROSS_TRIPLE}-cross.tgz
 
 # Verify that the downloaded file has not been altered via sha256 checksum
 RUN test "$(sha256sum -b ${CROSS_TRIPLE}-cross.tgz)" = "c5d410d9f82a4f24c549fe5d24f988f85b2679b452413a9f7e5f7b956f2fe7ea *${CROSS_TRIPLE}-cross.tgz"

--- a/jvmti-access/jni-build/jni_linux_musl_x64.Dockerfile
+++ b/jvmti-access/jni-build/jni_linux_musl_x64.Dockerfile
@@ -1,0 +1,26 @@
+FROM elastic_jni_build_java_includes:latest AS java_includes
+
+# This image is based on the corresponding linux-musl-arm64 image definition:
+# https://github.com/dockcross/dockcross/blob/master/linux-arm64-musl/Dockerfile.in
+FROM dockcross/base@sha256:f319badff9234699e1f83b7b032deada5c69b54fc526cd848edac4b377547356
+
+ENV XCC_PREFIX /usr/xcc
+ENV CROSS_TRIPLE x86_64-linux-musl
+ENV CROSS_ROOT ${XCC_PREFIX}/${CROSS_TRIPLE}-cross
+
+RUN mkdir -p ${XCC_PREFIX}
+RUN curl --max-time 15 --retry 5 -LO http://musl.cc/${CROSS_TRIPLE}-cross.tgz
+
+# Verify that the downloaded file has not been altered via sha256 checksum
+RUN test "$(sha256sum -b ${CROSS_TRIPLE}-cross.tgz)" = "c5d410d9f82a4f24c549fe5d24f988f85b2679b452413a9f7e5f7b956f2fe7ea *${CROSS_TRIPLE}-cross.tgz"
+
+RUN tar -C ${XCC_PREFIX} -xvf ${CROSS_TRIPLE}-cross.tgz
+
+ENV CXX=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-g++
+
+# Linux kernel cross compilation variables
+ENV PATH ${PATH}:${CROSS_ROOT}/bin
+
+COPY --from=java_includes /java_linux /java_linux
+
+CMD $CXX -I /java_linux/include -I /java_linux/include/linux $BUILD_ARGS

--- a/jvmti-access/src/main/java/co/elastic/otel/JvmtiAccess.java
+++ b/jvmti-access/src/main/java/co/elastic/otel/JvmtiAccess.java
@@ -173,15 +173,16 @@ public class JvmtiAccess {
     String os = System.getProperty("os.name").toLowerCase();
     String arch = System.getProperty("os.arch").toLowerCase();
     if (os.contains("linux")) {
+      String linuxVariant = "linux";
       if (isMusl()) {
-        return LibraryLookupResult.failure("Musl Linux is not supported yet");
+        linuxVariant = "linux-musl";
       }
       if (arch.contains("arm") || arch.contains("aarch32")) {
         return LibraryLookupResult.failure("Unsupported architecture for Linux: " + arch);
       } else if (arch.contains("aarch")) {
-        return LibraryLookupResult.success("linux-arm64");
+        return LibraryLookupResult.success(linuxVariant + "-arm64");
       } else if (arch.contains("64")) {
-        return LibraryLookupResult.success("linux-x64");
+        return LibraryLookupResult.success(linuxVariant + "-x64");
       } else {
         return LibraryLookupResult.failure("Unsupported architecture for Linux: " + arch);
       }

--- a/jvmti-access/src/main/jni/ProfilerSocket.cpp
+++ b/jvmti-access/src/main/jni/ProfilerSocket.cpp
@@ -3,6 +3,7 @@
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <fcntl.h>
+#include <cstring>
 
 namespace elastic {
     namespace jvmti_agent {


### PR DESCRIPTION
Fixes #228 , but needs some more investigation:
It looks like the UP integration is partly broken on musl. The profiling data will contain the service name, but the trace/span-id correlation seems to not work.