### PR TITLE
Allow full disabling of the span-stacktrace feature

### DIFF
--- a/custom/src/main/java/co/elastic/otel/SpanStackTraceProcessorAutoConfig.java
+++ b/custom/src/main/java/co/elastic/otel/SpanStackTraceProcessorAutoConfig.java
@@ -36,6 +36,9 @@ public class SpanStackTraceProcessorAutoConfig implements ChainingSpanProcessorA
       ConfigProperties properties, ChainingSpanProcessorRegisterer registerer) {
 
     Duration minDuration = properties.getDuration(MIN_DURATION_CONFIG_OPTION, Duration.ofMillis(5));
+    if (minDuration.isNegative()) {
+      return;
+    }
     registerer.register(
         next ->
             new StackTraceSpanProcessor(

--- a/custom/src/test/java/co/elastic/otel/SpanStackTraceProcessorAutoConfigTest.java
+++ b/custom/src/test/java/co/elastic/otel/SpanStackTraceProcessorAutoConfigTest.java
@@ -27,6 +27,7 @@ import co.elastic.otel.testing.OtelReflectionUtils;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.contrib.stacktrace.StackTraceSpanProcessor;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.semconv.incubating.CodeIncubatingAttributes;
 import java.util.List;
@@ -62,6 +63,18 @@ public class SpanStackTraceProcessorAutoConfigTest {
           .hasName("my-span")
           .hasAttribute(
               satisfies(CodeIncubatingAttributes.CODE_STACKTRACE, att -> att.isNotBlank()));
+    }
+  }
+
+  @Test
+  void featureCanBeDisabled() {
+    try (AutoConfigTestProperties testProps =
+        new AutoConfigTestProperties()
+            .put(SpanStackTraceProcessorAutoConfig.MIN_DURATION_CONFIG_OPTION, "-1")) {
+      OpenTelemetry otel = GlobalOpenTelemetry.get();
+
+      assertThat(OtelReflectionUtils.getSpanProcessors(otel))
+          .noneSatisfy(proc -> assertThat(proc).isInstanceOf(StackTraceSpanProcessor.class));
     }
   }
 

--- a/custom/src/test/java/co/elastic/otel/SpanStackTraceProcessorAutoConfigTest.java
+++ b/custom/src/test/java/co/elastic/otel/SpanStackTraceProcessorAutoConfigTest.java
@@ -93,7 +93,9 @@ public class SpanStackTraceProcessorAutoConfigTest {
       tracer.spanBuilder("my-span").startSpan().end();
 
       List<SpanData> spans = AutoConfiguredDataCapture.getSpans();
-      assertThat(spans).hasSize(0);
+      assertThat(spans).hasSize(1);
+      assertThat(spans.get(0).getAttributes().get(CodeIncubatingAttributes.CODE_STACKTRACE))
+          .isNull();
     }
   }
 }

--- a/testing-common/src/main/java/co/elastic/otel/testing/AutoConfiguredDataCapture.java
+++ b/testing-common/src/main/java/co/elastic/otel/testing/AutoConfiguredDataCapture.java
@@ -30,7 +30,7 @@ import java.util.List;
 @AutoService(AutoConfigurationCustomizerProvider.class)
 public class AutoConfiguredDataCapture implements AutoConfigurationCustomizerProvider {
 
-  private static final InMemorySpanExporter inMemorySpanExporter = InMemorySpanExporter.create();
+  private static volatile InMemorySpanExporter inMemorySpanExporter = InMemorySpanExporter.create();
 
   /*
    Returns the spans which have been exported by the autoconfigured global OpenTelemetry SDK.
@@ -46,7 +46,7 @@ public class AutoConfiguredDataCapture implements AutoConfigurationCustomizerPro
           // we piggy-back onto the autoconfigured logging exporter for now,
           // because that one uses a SimpleSpanProcessor which does not impose a batching delay
           if (spanExporter instanceof LoggingSpanExporter) {
-            inMemorySpanExporter.reset();
+            inMemorySpanExporter = InMemorySpanExporter.create();
             return SpanExporter.composite(inMemorySpanExporter, spanExporter);
           }
           return spanExporter;


### PR DESCRIPTION
Currently, we'll always install the processor for adding span stacktraces. This PR allows users to fully disable the feature by providing a negative min-duration.

This is especially relevant for our benchmarks where we want to test features in isolation.