### PR TITLE
Force monotonic clock when starting async-profiler

### DIFF
--- a/inferred-spans/src/main/java/co/elastic/otel/profiler/SamplingProfiler.java
+++ b/inferred-spans/src/main/java/co/elastic/otel/profiler/SamplingProfiler.java
@@ -441,7 +441,7 @@ class SamplingProfiler implements Runnable {
 
   String createStartCommand() {
     StringBuilder startCommand =
-        new StringBuilder("start,jfr,event=wall,cstack=n,interval=")
+        new StringBuilder("start,jfr,clock=m,event=wall,cstack=n,interval=")
             .append(config.getSamplingInterval().toMillis())
             .append("ms,filter,file=")
             .append(jfrFile)

--- a/inferred-spans/src/test/java/co/elastic/otel/profiler/SamplingProfilerTest.java
+++ b/inferred-spans/src/test/java/co/elastic/otel/profiler/SamplingProfilerTest.java
@@ -156,13 +156,14 @@ class SamplingProfilerTest {
   void testStartCommand() {
     setupProfiler(false);
     assertThat(setup.profiler.createStartCommand())
-        .isEqualTo("start,jfr,event=wall,cstack=n,interval=5ms,filter,file=null,safemode=0");
+        .isEqualTo(
+            "start,jfr,clock=m,event=wall,cstack=n,interval=5ms,filter,file=null,safemode=0");
 
     setup.close();
     setupProfiler(config -> config.startScheduledProfiling(false).profilerLoggingEnabled(false));
     assertThat(setup.profiler.createStartCommand())
         .isEqualTo(
-            "start,jfr,event=wall,cstack=n,interval=5ms,filter,file=null,safemode=0,loglevel=none");
+            "start,jfr,clock=m,event=wall,cstack=n,interval=5ms,filter,file=null,safemode=0,loglevel=none");
 
     setup.close();
     setupProfiler(
@@ -174,7 +175,7 @@ class SamplingProfilerTest {
                 .asyncProfilerSafeMode(14));
     assertThat(setup.profiler.createStartCommand())
         .isEqualTo(
-            "start,jfr,event=wall,cstack=n,interval=10ms,filter,file=null,safemode=14,loglevel=none");
+            "start,jfr,clock=m,event=wall,cstack=n,interval=10ms,filter,file=null,safemode=14,loglevel=none");
   }
 
   @Test


### PR DESCRIPTION
We had a user report that the `inferred-spans` feature fails to generate spans even though it should.
After analyzing the diagnostic files, turns out that the profiling data was using a different clock than `System.nanoTime`, which is required for correlation.

Async-profiler 3.0 by default tries to use `TSC` only falls back to `System.nanoTime` if `TSC` is not available on the current CPU/System. The `clock=m` startup argument should force the monotonic clock (=`System.nanoTime`) to be always used. 