### PR TITLE
Don't label renovate PRs and disable dependabot for java deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,18 +15,3 @@ updates:
       github-actions:
         patterns:
           - "*"
-
-  # Gradle
-  - package-ecosystem: "gradle"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10
-    ignore:
-      # upstream dependencies that need to be updated in sync and with manual control
-      - dependency-name: "io.opentelemetry.javaagent:*"
-      - dependency-name: "io.opentelemetry.instrumentation:*"
-      - dependency-name: "io.opentelemetry.contrib:*"
-      - dependency-name: "io.opentelemetry:*"
-      # Newer Mockito versions don't support java 8 anymore
-      - dependency-name: "org.mockito:mockito-core"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -30,7 +30,7 @@ jobs:
         username: ${{ github.actor }}
         token: ${{ secrets.APM_TECH_USER_TOKEN }}
     - name: Add community and triage lables
-      if: contains(steps.is_elastic_member.outputs.result, 'false') && github.actor != 'dependabot[bot]'
+      if: contains(steps.is_elastic_member.outputs.result, 'false') && github.actor != 'dependabot[bot]' && github.actor != 'elastic-renovate-prod[bot]'
       uses: actions/github-script@v7
       with:
         script: |
@@ -41,7 +41,7 @@ jobs:
             labels: ["community", "triage"]
           })
     - name: Add comment for community PR
-      if: contains(steps.is_elastic_member.outputs.result, 'false') && github.actor != 'dependabot[bot]'
+      if: contains(steps.is_elastic_member.outputs.result, 'false') && github.actor != 'dependabot[bot]' && github.actor != 'elastic-renovate-prod[bot]'
       uses: wow-actions/auto-comment@v1
       with:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Disable the community issue/PR labeles for renovate PRs and reconfigure dependabot to not receive duplicate PRs