### PR TITLE
Ignore upstream dependencies which need to be kept in sync

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,17 @@
   "extends": [
     "local>elastic/renovate-config"
   ],
+  "packageRules": [
+    {
+      "description": "Upstream agent dependencies are kept in sync via the gradle/update-upstream.sh script",
+      "matchPackageNames": [
+        "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha",
+        "io.opentelemetry.semconv:**",
+        "io.opentelemetry.contrib:**"
+      ],
+      "enabled": false
+    }
+  ],
   "ignorePaths": [
     ".github/**",
     ".buildkite/**",


### PR DESCRIPTION
These dependencies are updated via a PR from updatecli instead.