### PR TITLE
Add back accidentally removed nexus publishing plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,9 @@ import java.nio.file.Paths
 import java.nio.file.Files
 import java.nio.file.StandardCopyOption
 
+plugins {
+  alias(catalog.plugins.nexusPublish)
+}
 
 val versionProperties = java.util.Properties()
 versionProperties.load(FileInputStream(file("version.properties")))
@@ -16,6 +19,12 @@ defaultTasks("agent:assemble")
 subprojects {
   group = rootProject.group
   version = rootProject.version
+}
+
+nexusPublishing {
+  repositories {
+    sonatype()
+  }
 }
 
 tasks {


### PR DESCRIPTION
Fixes the publishing accidentally broken by #366. After merging #366, the snapshot build failed because the nexus publishing plugin was missing.