### PR TITLE
DRY: Move autoservice and common test dependencies to convention

### DIFF
--- a/buildSrc/src/main/kotlin/elastic-otel.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/elastic-otel.java-conventions.gradle.kts
@@ -23,6 +23,15 @@ dependencies {
 
   implementation(platform(catalog.findLibrary("opentelemetryInstrumentationAlphaBom").get()))
 
+  annotationProcessor(catalog.findLibrary("autoservice.processor").get())
+  compileOnly(catalog.findLibrary("autoservice.annotations").get())
+  compileOnly(catalog.findLibrary("findbugs.jsr305").get())
+
+  testAnnotationProcessor(catalog.findLibrary("autoservice.processor").get())
+  testCompileOnly(catalog.findLibrary("autoservice.annotations").get())
+  testCompileOnly(catalog.findLibrary("findbugs.jsr305").get())
+  testImplementation(catalog.findLibrary("assertj.core").get())
+  testImplementation(catalog.findLibrary("awaitility").get())
   testImplementation(catalog.findLibrary("mockito").get())
   testImplementation(enforcedPlatform(catalog.findLibrary("junitBom").get()))
   testImplementation("org.junit.jupiter:junit-jupiter")

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -7,20 +7,14 @@ plugins {
 description = "Elastic common utilities for OpenTelemetry Java"
 
 dependencies {
-    annotationProcessor(libs.autoservice.processor)
     api("com.blogspot.mydailyjava:weak-lock-free:0.18")
-    compileOnly(libs.autoservice.annotations)
     compileOnly("io.opentelemetry:opentelemetry-sdk")
-    compileOnly(libs.findbugs.jsr305)
     compileOnly("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi")
     implementation(libs.bundles.semconv)
 
     compileOnly(libs.contribSpanStacktrace)
     testImplementation(libs.contribSpanStacktrace)
 
-    testAnnotationProcessor(libs.autoservice.processor)
-    testCompileOnly(libs.autoservice.annotations)
-    testCompileOnly(libs.findbugs.jsr305)
     testImplementation("io.opentelemetry:opentelemetry-sdk")
     testImplementation("io.opentelemetry:opentelemetry-sdk-testing")
     testImplementation("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure")
@@ -28,5 +22,4 @@ dependencies {
     testImplementation("io.opentelemetry:opentelemetry-exporter-otlp")
     testImplementation("io.opentelemetry:opentelemetry-exporter-logging")
     testImplementation("io.opentelemetry:opentelemetry-api-incubator")
-    testImplementation(libs.assertj.core)
 }

--- a/custom/build.gradle.kts
+++ b/custom/build.gradle.kts
@@ -19,9 +19,6 @@ dependencies {
   }
   testImplementation(libs.contribSpanStacktrace)
 
-  annotationProcessor(libs.autoservice.processor)
-  compileOnly(libs.autoservice.annotations)
-
   // needs to be added in order to allow access to AgentListener interface
   // this is currently required because autoconfigure is currently not exposed to the extension API.
   compileOnly("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure")
@@ -36,12 +33,8 @@ dependencies {
   }
   testImplementation(libs.bundles.semconv)
 
-  testAnnotationProcessor(libs.autoservice.processor)
-  testCompileOnly(libs.autoservice.annotations)
-
   testImplementation("io.opentelemetry.javaagent:opentelemetry-testing-common")
   testImplementation("io.opentelemetry:opentelemetry-sdk-testing")
-  testImplementation(libs.assertj.core)
   testImplementation(libs.freemarker)
 }
 tasks.withType<Test> {

--- a/inferred-spans/build.gradle.kts
+++ b/inferred-spans/build.gradle.kts
@@ -6,24 +6,17 @@ plugins {
 description = "Elastic Inferred Spans extension for OpenTelemetry Java"
 
 dependencies {
-  annotationProcessor(libs.autoservice.processor)
-  compileOnly(libs.autoservice.annotations)
   compileOnly("io.opentelemetry:opentelemetry-sdk")
   compileOnly("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi")
-  compileOnly(libs.findbugs.jsr305)
   implementation(libs.lmax.disruptor)
   implementation(libs.jctools)
   implementation(libs.asyncprofiler)
   implementation(libs.bundles.semconv)
   implementation(project(":common"))
 
-  testAnnotationProcessor(libs.autoservice.processor)
-  testCompileOnly(libs.autoservice.annotations)
-  testCompileOnly(libs.findbugs.jsr305)
   testImplementation(project(":testing-common"))
   testImplementation("io.opentelemetry:opentelemetry-sdk")
   testImplementation("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure")
-  testImplementation(libs.awaitility)
   testImplementation(libs.github.api)
   testImplementation(libs.apachecommons.compress)
   testImplementation(libs.bundles.semconv)

--- a/jvmti-access/build.gradle.kts
+++ b/jvmti-access/build.gradle.kts
@@ -13,12 +13,6 @@ plugins {
   alias(catalog.plugins.dockerJavaApplication)
 }
 
-dependencies {
-  testImplementation(libs.assertj.core)
-  testImplementation(libs.awaitility)
-  compileOnly(libs.findbugs.jsr305)
-}
-
 description = "Library for exposing JVMTI and JNI functionality to Java"
 
 

--- a/resources/build.gradle.kts
+++ b/resources/build.gradle.kts
@@ -4,16 +4,9 @@ plugins {
 }
 
 dependencies {
-
   compileOnly("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure")
   testImplementation("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure")
 
-  // auto-service
-  annotationProcessor(libs.autoservice.processor)
-  compileOnly(libs.autoservice.annotations)
-
   // not included in the upstream agent
   implementation(catalog.contribResources)
-
-  testImplementation(libs.assertj.core)
 }

--- a/testing-common/build.gradle.kts
+++ b/testing-common/build.gradle.kts
@@ -4,17 +4,12 @@ plugins {
 }
 
 dependencies {
-  annotationProcessor(libs.autoservice.processor)
-  compileOnly(libs.autoservice.annotations)
-
-  api(libs.assertj.core)
   api("io.opentelemetry:opentelemetry-sdk-testing")
   implementation("io.opentelemetry:opentelemetry-api-incubator")
   implementation("io.opentelemetry:opentelemetry-exporter-logging")
   implementation(enforcedPlatform(catalog.junitBom))
   implementation("org.junit.jupiter:junit-jupiter")
 
-  compileOnly(libs.findbugs.jsr305)
   compileOnly("io.opentelemetry:opentelemetry-sdk")
   compileOnly("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi")
   compileOnly("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure")

--- a/universal-profiling-integration/build.gradle.kts
+++ b/universal-profiling-integration/build.gradle.kts
@@ -14,8 +14,6 @@ jmh {
 description = "OpenTelemetry SDK extension to enable correlation of traces with elastic universal profiling"
 
 dependencies {
-  annotationProcessor(libs.autoservice.processor)
-  compileOnly(libs.autoservice.annotations)
   implementation(project(":jvmti-access"))
   implementation(project(":common"))
   implementation("io.opentelemetry.semconv:opentelemetry-semconv")
@@ -25,13 +23,9 @@ dependencies {
   implementation(libs.hdrhistogram) //only used for the WriterReaderPhaser
 
   compileOnly("io.opentelemetry:opentelemetry-sdk")
-  compileOnly(libs.findbugs.jsr305)
 
-  testCompileOnly(libs.findbugs.jsr305)
   testImplementation(project(":testing-common"))
   testImplementation("io.opentelemetry:opentelemetry-sdk")
   testImplementation("io.opentelemetry:opentelemetry-sdk-testing")
   testImplementation("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure")
-  testImplementation(libs.assertj.core)
-  testImplementation(libs.awaitility)
 }


### PR DESCRIPTION
Keeps the dependency declarations of the individual projects less cluttered