### PR TITLE
trigger license update with renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -18,5 +18,9 @@
     ".github/**",
     ".buildkite/**",
     "jvmti-access/jni-build/*.Dockerfile"
-  ]
+  ],
+  "postUpgradeTasks": {
+    "commands": ["./gradlew updateLicensesAndNotice"],
+    "fileFilters": ["licences/**/*"]
+  }
 }


### PR DESCRIPTION
Configure renovate to use `postUpgradeTasks` in order to automatically update license files when there are dependency updates.

This prevents obsolete license and PRs like #155, #281 and #381 

Requires to configure `allowedPostUpgradeCommands` in the global configuration.

