### PR TITLE
ci(update-license): for renovate PRs

### DIFF
--- a/.github/workflows/update-renovate-pr.yml
+++ b/.github/workflows/update-renovate-pr.yml
@@ -1,0 +1,48 @@
+---
+# Renovate Pull Requests are not updating the license files in the licenses folder.
+# This workflow will checkout the renovate PR, update the license files, and push the changes back to the PR.
+name: update-renovate-pr
+
+on:
+  push:
+    branches:
+      - renovate/**
+    paths-ignore:
+      - licenses/**
+
+permissions:
+  contents: read
+
+jobs:
+  update-renovate-pr:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/workflows/gradle-goal
+        with:
+          command: "./gradlew updateLicensesAndNotice"
+
+      - name: Debug diff
+        run: git status --porcelain
+
+      - name: Check if NOTICE.txt has changed
+        id: check-notice-diff
+        run: |
+          changed=false
+          if git status --porcelain | grep -q 'NOTICE.txt'; then
+            changed=true
+          fi
+          echo "changed=$changed" >> "$GITHUB_OUTPUT"
+
+      - name: Debug output
+        run: |-
+          echo 'changed: ${{ steps.check-notice-diff.outputs.changed }}'
+
+      - name: Commit changes (TBD)
+        if: ${{ steps.check-notice-diff.outputs.changed == 'true' }}
+        run: |
+           git status
+           git --no-pager diff

--- a/.github/workflows/update-renovate-pr.yml
+++ b/.github/workflows/update-renovate-pr.yml
@@ -32,7 +32,7 @@ jobs:
         id: check-notice-diff
         run: |
           changed=false
-          if git status --porcelain | grep -q 'licenses/'; then
+          if git status --porcelain | grep -q '^licenses/'; then
             changed=true
           fi
           echo "changed=$changed" >> "$GITHUB_OUTPUT"
@@ -41,8 +41,21 @@ jobs:
         run: |-
           echo 'changed: ${{ steps.check-notice-diff.outputs.changed }}'
 
-      - name: Commit changes (TBD)
+      - name: Commit changes
         if: ${{ steps.check-notice-diff.outputs.changed == 'true' }}
         run: |
-           git status
-           git --no-pager diff
+          git status
+          git --no-pager diff
+          changed_files=$(git status --porcelain | grep -E '^(M|\?\?)' | awk '{print $2}' | grep '^licenses/')
+          for file in $changed_files; do
+            export BRANCH=${GITHUB_REF#refs/heads/}
+            export SHA=$(git rev-parse "$BRANCH:$file")
+            gh api --method PUT "/repos/${REPO}/contents/$file" \
+              --field message="Update $file" \
+              --field content=@<(base64 -i $file) \
+              --field sha="${SHA}" \
+              --field branch="${BRANCH}"
+          done
+        env:
+          REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/update-renovate-pr.yml
+++ b/.github/workflows/update-renovate-pr.yml
@@ -32,7 +32,7 @@ jobs:
         id: check-notice-diff
         run: |
           changed=false
-          if git status --porcelain | grep -q '^licenses/'; then
+          if git status --porcelain | grep -q 'licenses/'; then
             changed=true
           fi
           echo "changed=$changed" >> "$GITHUB_OUTPUT"
@@ -41,13 +41,20 @@ jobs:
         run: |-
           echo 'changed: ${{ steps.check-notice-diff.outputs.changed }}'
 
-      - name: Commit changes
+      ## this should help with of multiple files in a new folder.
+      - name: Add changes
+        if: ${{ steps.check-notice-diff.outputs.changed == 'true' }}
+        run: git add licenses
+
+      - name: Push changes
         if: ${{ steps.check-notice-diff.outputs.changed == 'true' }}
         run: |
-          git status
-          git --no-pager diff
-          changed_files=$(git status --porcelain | grep -E '^(M|\?\?)' | awk '{print $2}' | grep '^licenses/')
+          changed_files=$(git status --porcelain | grep -E '^(M|A)' | awk '{print $2}' | grep -E '^licenses/')
+          echo "::notice::changed files: $(echo $changed_files | tr '\n' '')"
           for file in $changed_files; do
+            if [ -d "$file" ]; then
+              continue
+            fi
             export BRANCH=${GITHUB_REF#refs/heads/}
             export SHA=$(git rev-parse "$BRANCH:$file")
             gh api --method PUT "/repos/${REPO}/contents/$file" \

--- a/.github/workflows/update-renovate-pr.yml
+++ b/.github/workflows/update-renovate-pr.yml
@@ -28,11 +28,11 @@ jobs:
       - name: Debug diff
         run: git status --porcelain
 
-      - name: Check if NOTICE.txt has changed
+      - name: Check if licenses folder has changed
         id: check-notice-diff
         run: |
           changed=false
-          if git status --porcelain | grep -q 'NOTICE.txt'; then
+          if git status --porcelain | grep -q 'licenses/'; then
             changed=true
           fi
           echo "changed=$changed" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
#### What

Update the licenses for the Renovate PRs using the gradle task.

Part of https://github.com/elastic/elastic-otel-java/issues/386

I partially took some bits and pieces from https://github.com/elastic/apm-server/blob/main/.github/workflows/update-dependabot-pr.yml?rgh-link-date=2024-08-29T14%3A33%3A13Z

#### Why

Temporary workaround to remove the burden for now when renovate creates PRs, but the licenses need to be updated too.

#### Test
I tested a similar workflow and https://github.com/elastic/observability-robots-playground/pull/55 is the outcome (only accessible for Elastic Employees)