### PR TITLE
Bump upload-artifact to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,8 +101,7 @@ jobs:
           command: "./gradlew test -x compileJni -PtestJavaVersion=${{ matrix.version }} -PtestJavaVM=${{ matrix.vm }}"
       - name: Store test results
         if: success() || failure()
-        # The test reporting workflow only supports the @v3 artifact mechanism
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-results-${{ matrix.version }}-${{ matrix.vm }}
           path: '**/build/test-results/test/TEST-*.xml'


### PR DESCRIPTION
The test-reporter.yml workflow, which consumes these artifacts, is currently disabled.
The fix for the test-reporter will be handled in a follow-up.
