### PR TITLE
ci: use GitHub app for ephemeral tokens

### DIFF
--- a/.github/workflows/pre-post-release.yml
+++ b/.github/workflows/pre-post-release.yml
@@ -52,19 +52,30 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - validate-tag
-    permissions:
-      contents: write
-    env:
-      GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
     steps:
+
+      - name: Get token
+        id: get_token
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+        with:
+          app_id: ${{ secrets.OBS_AUTOMATION_APP_ID }}
+          private_key: ${{ secrets.OBS_AUTOMATION_APP_PEM }}
+          permissions: >-
+            {
+              "contents": "write",
+              "pull_requests": "write"
+            }
+          repositories: >-
+            ["elastic-otel-java"]
+
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
-          token: ${{ env.GITHUB_TOKEN }}
+          token: ${{ steps.get_token.outputs.token }}
 
       - uses: elastic/oblt-actions/git/setup@v1
         with:
-          github-token: ${{ env.GITHUB_TOKEN }}
+          github-token: ${{ steps.get_token.outputs.token }}
 
       - name: Create the release tag (post phase)
         if: inputs.phase == 'post'
@@ -96,4 +107,4 @@ jobs:
       - name: Create the ${{ inputs.phase }} release PR
         run: gh pr create --title="${{ inputs.pr_title }}" --base main --head ${{ env.BRANCH_NAME }} -b "${{ inputs.pr_body }}"
         env:
-          GH_TOKEN: ${{ env.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.get_token.outputs.token }}


### PR DESCRIPTION
## What does this PR do?

Use the GitHub app to generate the required ephemeral tokens with the least permissive principle.

#### Why

* Finer-grained tokens with Service Machine accounts are required to rotate the secrets manually.
* GitHub app to generate temporary tokens is the advanced approach to avoid the above
* Document what the GH workflow requires to run in terms of access
* GitHub Token with Permissions does not trigger GitHub builds 

#### Implementation details

Use `tibdex/github-app-token` with the required permissions and the repository scope
Remove the `permissions` configuration in the GH workflow.
Configure git checkout with the ephemeral token
Configure the GH_TOKEN with the ephemeral token
