### PR TITLE
Fix missing transitive dependencies when using universal profiling integration

### DIFF
--- a/universal-profiling-integration/build.gradle.kts
+++ b/universal-profiling-integration/build.gradle.kts
@@ -15,7 +15,7 @@ description = "OpenTelemetry SDK extension to enable correlation of traces with 
 
 dependencies {
   implementation(project(":jvmti-access"))
-  implementation(project(":common"))
+  api(project(":common"))
   implementation("io.opentelemetry.semconv:opentelemetry-semconv")
   compileOnly("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi")
   compileOnly("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure")


### PR DESCRIPTION
There is currently a problem when using the universal-profling-integration with manual SDK setup:

The type `UniversalProfilingProcessor` cannot be used because it's supertype `AbstractChainingSpanProcessor` is missing. The latter comes from our `common` project as a transitive dependency which is only pulled in with `runtime` scope.

This PR fixes this ensuring that the type is available at compile time too.

A workaround for now is to add an explicit dependency on the `elastic-otel-java:common` project in client code.