### PR TITLE
Remove illegal hyphen in span stacktrace config option

### DIFF
--- a/custom/src/main/java/co/elastic/otel/SpanStackTraceProcessorAutoConfig.java
+++ b/custom/src/main/java/co/elastic/otel/SpanStackTraceProcessorAutoConfig.java
@@ -29,6 +29,7 @@ import java.time.Duration;
 @AutoService(ChainingSpanProcessorAutoConfiguration.class)
 public class SpanStackTraceProcessorAutoConfig implements ChainingSpanProcessorAutoConfiguration {
 
+  static final String LEGACY_DURATION_CONFIG_OPTION = "elastic.otel.java.span-stacktrace.min.duration";
   // TODO replace this with upstream config once it's stable
   static final String MIN_DURATION_CONFIG_OPTION = "elastic.otel.java.span.stacktrace.min.duration";
 
@@ -36,7 +37,9 @@ public class SpanStackTraceProcessorAutoConfig implements ChainingSpanProcessorA
   public void registerSpanProcessors(
       ConfigProperties properties, ChainingSpanProcessorRegisterer registerer) {
 
-    Duration minDuration = properties.getDuration(MIN_DURATION_CONFIG_OPTION, Duration.ofMillis(5));
+    Duration legacyMinDuration = properties.getDuration(LEGACY_DURATION_CONFIG_OPTION,
+        Duration.ofMillis(5));
+    Duration minDuration = properties.getDuration(MIN_DURATION_CONFIG_OPTION, legacyMinDuration);
     if (minDuration.isNegative()) {
       return;
     }

--- a/custom/src/main/java/co/elastic/otel/SpanStackTraceProcessorAutoConfig.java
+++ b/custom/src/main/java/co/elastic/otel/SpanStackTraceProcessorAutoConfig.java
@@ -29,7 +29,8 @@ import java.time.Duration;
 @AutoService(ChainingSpanProcessorAutoConfiguration.class)
 public class SpanStackTraceProcessorAutoConfig implements ChainingSpanProcessorAutoConfiguration {
 
-  static final String LEGACY_DURATION_CONFIG_OPTION = "elastic.otel.java.span-stacktrace.min.duration";
+  static final String LEGACY_DURATION_CONFIG_OPTION =
+      "elastic.otel.java.span-stacktrace.min.duration";
   // TODO replace this with upstream config once it's stable
   static final String MIN_DURATION_CONFIG_OPTION = "elastic.otel.java.span.stacktrace.min.duration";
 
@@ -37,8 +38,8 @@ public class SpanStackTraceProcessorAutoConfig implements ChainingSpanProcessorA
   public void registerSpanProcessors(
       ConfigProperties properties, ChainingSpanProcessorRegisterer registerer) {
 
-    Duration legacyMinDuration = properties.getDuration(LEGACY_DURATION_CONFIG_OPTION,
-        Duration.ofMillis(5));
+    Duration legacyMinDuration =
+        properties.getDuration(LEGACY_DURATION_CONFIG_OPTION, Duration.ofMillis(5));
     Duration minDuration = properties.getDuration(MIN_DURATION_CONFIG_OPTION, legacyMinDuration);
     if (minDuration.isNegative()) {
       return;

--- a/custom/src/main/java/co/elastic/otel/SpanStackTraceProcessorAutoConfig.java
+++ b/custom/src/main/java/co/elastic/otel/SpanStackTraceProcessorAutoConfig.java
@@ -30,7 +30,7 @@ import java.time.Duration;
 public class SpanStackTraceProcessorAutoConfig implements ChainingSpanProcessorAutoConfiguration {
 
   // TODO replace this with upstream config once it's stable
-  static final String MIN_DURATION_CONFIG_OPTION = "elastic.otel.java.span-stacktrace.min.duration";
+  static final String MIN_DURATION_CONFIG_OPTION = "elastic.otel.java.span.stacktrace.min.duration";
 
   @Override
   public void registerSpanProcessors(

--- a/custom/src/test/java/co/elastic/otel/SpanStackTraceProcessorAutoConfigTest.java
+++ b/custom/src/test/java/co/elastic/otel/SpanStackTraceProcessorAutoConfigTest.java
@@ -102,7 +102,6 @@ public class SpanStackTraceProcessorAutoConfigTest {
     }
   }
 
-
   @Test
   void checkMinDurationRespected() {
     try (AutoConfigTestProperties testProps =

--- a/custom/src/test/java/co/elastic/otel/SpanStackTraceProcessorAutoConfigTest.java
+++ b/custom/src/test/java/co/elastic/otel/SpanStackTraceProcessorAutoConfigTest.java
@@ -79,6 +79,31 @@ public class SpanStackTraceProcessorAutoConfigTest {
   }
 
   @Test
+  void legacyConfigOptionSupported() {
+    try (AutoConfigTestProperties testProps =
+        new AutoConfigTestProperties()
+            .put(SpanStackTraceProcessorAutoConfig.LEGACY_DURATION_CONFIG_OPTION, "0ms")) {
+      OpenTelemetry otel = GlobalOpenTelemetry.get();
+
+      // TODO: cleanup other extensions (Breakdown) so that this is not required:
+      ElasticExtension.INSTANCE.registerOpenTelemetry(otel);
+
+      Tracer tracer = otel.getTracer("test-tracer");
+
+      tracer.spanBuilder("my-span").startSpan().end();
+
+      List<SpanData> spans = AutoConfiguredDataCapture.getSpans();
+
+      assertThat(spans).hasSize(1);
+      assertThat(spans.get(0))
+          .hasName("my-span")
+          .hasAttribute(
+              satisfies(CodeIncubatingAttributes.CODE_STACKTRACE, att -> att.isNotBlank()));
+    }
+  }
+
+
+  @Test
   void checkMinDurationRespected() {
     try (AutoConfigTestProperties testProps =
         new AutoConfigTestProperties()


### PR DESCRIPTION
The hyphen in the config option makes it impossible to specify the option via environment variables.