### PR TITLE
Renovate: Ignore examples folder

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,6 +17,7 @@
   "ignorePaths": [
     ".github/**",
     ".buildkite/**",
+    "examples/**",
     "jvmti-access/jni-build/*.Dockerfile"
   ]
 }

--- a/smoke-tests/src/test/java/com/example/javaagent/smoketest/DynamicConfigSmokeTest.java
+++ b/smoke-tests/src/test/java/com/example/javaagent/smoketest/DynamicConfigSmokeTest.java
@@ -54,7 +54,7 @@ class DynamicConfigSmokeTest extends TestAppSmokeTest {
   @AfterEach
   public void endTest() throws InterruptedException {
     doRequest(getUrl("/dynamicconfig/reset"), okResponseBody("reset"));
-    Thread.sleep(500L); // give the reset time to be applied
+    Thread.sleep(1500L); // give the reset time to be applied
   }
 
   @Test
@@ -68,14 +68,14 @@ class DynamicConfigSmokeTest extends TestAppSmokeTest {
         .containsOnly("GET /dynamicconfig/flipSending", "DynamicConfigController.flipSending");
     ByteString firstTraceID = spans.get(0).getTraceId();
 
-    Thread.sleep(1000L); // give the flip time to be applied
+    Thread.sleep(2000L); // give the flip time to be applied
 
     doRequest(getUrl("/dynamicconfig/flipSending"), okResponseBody("restarted"));
     traces = waitForTraces();
     spans = getSpans(traces).dropWhile(span -> span.getTraceId().equals(firstTraceID)).toList();
     assertThat(spans).hasSize(0);
 
-    Thread.sleep(1000L); // give the flip time to be applied
+    Thread.sleep(2000L); // give the flip time to be applied
 
     doRequest(getUrl("/dynamicconfig/flipSending"), okResponseBody("stopped"));
     traces = waitForTraces();


### PR DESCRIPTION
We don't have any CI checks on the examples, so we don't want unverified version bumps.