### PR TITLE
deps: updates openai to latest and adjusts example

### DIFF
--- a/examples/openai/build.gradle.kts
+++ b/examples/openai/build.gradle.kts
@@ -14,7 +14,7 @@ repositories {
 
 dependencies {
     implementation(platform("org.slf4j:slf4j-bom:2.0.16"))
-    implementation("com.openai:openai-java:0.11.8")
+    implementation("com.openai:openai-java:0.13.0")
     implementation("org.slf4j:slf4j-simple")
 }
 

--- a/examples/openai/src/main/java/openai/example/Chat.java
+++ b/examples/openai/src/main/java/openai/example/Chat.java
@@ -14,10 +14,9 @@ final class Chat {
 
         String message = "Answer in up to 3 words: Which ocean contains Bouvet Island?";
         ChatCompletionCreateParams params = ChatCompletionCreateParams.builder()
-                .addMessage(ChatCompletionMessageParam.ofChatCompletionUserMessageParam(ChatCompletionUserMessageParam.builder()
-                        .role(ChatCompletionUserMessageParam.Role.USER)
-                        .content(ChatCompletionUserMessageParam.Content.ofTextContent(message))
-                        .build()))
+                .addMessage(ChatCompletionUserMessageParam.builder()
+                    .content(message)
+                    .build())
                 .model(chatModel)
                 .build();
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,7 +23,7 @@ opentelemetryContribAlpha = "1.42.0-alpha"
 opentelemetrySemconvAlpha = "1.29.0-alpha"
 
 # instrumented libraries
-openaiClient = "0.11.9"
+openaiClient = "0.13.0"
 
 [libraries]
 

--- a/instrumentation/openai-client-instrumentation/src/main/java/co/elastic/otel/openai/wrappers/ChatCompletionEventsHelper.java
+++ b/instrumentation/openai-client-instrumentation/src/main/java/co/elastic/otel/openai/wrappers/ChatCompletionEventsHelper.java
@@ -227,7 +227,7 @@ public class ChatCompletionEventsHelper {
   private static Value<?> buildToolCallEventObject(ChatCompletionMessageToolCall call) {
     Map<String, Value<?>> result = new HashMap<>();
     result.put("id", Value.of(call.id()));
-    result.put("type", Value.of(call.type().toString()));
+    result.put("type", Value.of(call._type().toString()));
     result.put("function", buildFunctionEventObject(call.function()));
     return Value.of(result);
   }

--- a/instrumentation/openai-client-instrumentation/src/main/java/co/elastic/otel/openai/wrappers/InstrumentedChatCompletionService.java
+++ b/instrumentation/openai-client-instrumentation/src/main/java/co/elastic/otel/openai/wrappers/InstrumentedChatCompletionService.java
@@ -140,7 +140,7 @@ public class InstrumentedChatCompletionService implements CompletionService {
                             if (val.isResponseFormatText()) {
                               attributes.put(
                                   GEN_AI_OPENAI_REQUEST_RESPONSE_FORMAT,
-                                  val.asResponseFormatText().type().toString());
+                                  val.asResponseFormatText()._type().toString());
                             }
                           });
                 }

--- a/instrumentation/openai-client-instrumentation/src/test/java/co/elastic/otel/openai/ChatTest.java
+++ b/instrumentation/openai-client-instrumentation/src/test/java/co/elastic/otel/openai/ChatTest.java
@@ -255,7 +255,7 @@ class ChatTest {
             .topP(1.0)
             .stopOfStrings(Collections.singletonList("foo"))
             .seed(100L)
-            .responseFormat(ResponseFormatText.builder().type(ResponseFormatText.Type.TEXT).build())
+            .responseFormat(ResponseFormatText.builder().build())
             .build();
 
     long startTimeNanos = System.nanoTime();
@@ -1374,7 +1374,7 @@ class ChatTest {
             .topP(1.0)
             .stopOfStrings(Collections.singletonList("foo"))
             .seed(100L)
-            .responseFormat(ResponseFormatText.builder().type(ResponseFormatText.Type.TEXT).build())
+            .responseFormat(ResponseFormatText.builder().build())
             .build();
 
     long startTimeNanos = System.nanoTime();
@@ -2048,7 +2048,6 @@ class ChatTest {
     ChatCompletionMessageParam assistantMessage =
         ChatCompletionMessageParam.ofChatCompletionAssistantMessageParam(
             ChatCompletionAssistantMessageParam.builder()
-                .role(ChatCompletionAssistantMessageParam.Role.ASSISTANT)
                 .content(ChatCompletionAssistantMessageParam.Content.ofTextContent(""))
                 .toolCalls(toolCalls)
                 .build());
@@ -2301,7 +2300,6 @@ class ChatTest {
     properties.put("location", JsonObject.of(location));
 
     return ChatCompletionTool.builder()
-        .type(ChatCompletionTool.Type.FUNCTION)
         .function(
             FunctionDefinition.builder()
                 .name("get_weather")
@@ -2326,7 +2324,6 @@ class ChatTest {
     properties.put("order_id", JsonObject.of(orderId));
 
     return ChatCompletionTool.builder()
-        .type(ChatCompletionTool.Type.FUNCTION)
         .function(
             FunctionDefinition.builder()
                 .name("get_delivery_date")
@@ -2349,7 +2346,6 @@ class ChatTest {
   private static ChatCompletionMessageParam createAssistantMessage(String content) {
     return ChatCompletionMessageParam.ofChatCompletionAssistantMessageParam(
         ChatCompletionAssistantMessageParam.builder()
-            .role(ChatCompletionAssistantMessageParam.Role.ASSISTANT)
             .content(ChatCompletionAssistantMessageParam.Content.ofTextContent(content))
             .build());
   }
@@ -2357,7 +2353,6 @@ class ChatTest {
   private static ChatCompletionMessageParam createUserMessage(String content) {
     return ChatCompletionMessageParam.ofChatCompletionUserMessageParam(
         ChatCompletionUserMessageParam.builder()
-            .role(ChatCompletionUserMessageParam.Role.USER)
             .content(ChatCompletionUserMessageParam.Content.ofTextContent(content))
             .build());
   }
@@ -2365,7 +2360,6 @@ class ChatTest {
   private static ChatCompletionMessageParam createSystemMessage(String content) {
     return ChatCompletionMessageParam.ofChatCompletionSystemMessageParam(
         ChatCompletionSystemMessageParam.builder()
-            .role(ChatCompletionSystemMessageParam.Role.SYSTEM)
             .content(ChatCompletionSystemMessageParam.Content.ofTextContent(content))
             .build());
   }
@@ -2373,7 +2367,6 @@ class ChatTest {
   private static ChatCompletionMessageParam createToolMessage(String response, String id) {
     return ChatCompletionMessageParam.ofChatCompletionToolMessageParam(
         ChatCompletionToolMessageParam.builder()
-            .role(ChatCompletionToolMessageParam.Role.TOOL)
             .toolCallId(id)
             .content(ChatCompletionToolMessageParam.Content.ofTextContent(response))
             .build());

--- a/instrumentation/openai-client-instrumentation/src/test/java/co/elastic/otel/openai/LiveAPIChatIntegrationTest.java
+++ b/instrumentation/openai-client-instrumentation/src/test/java/co/elastic/otel/openai/LiveAPIChatIntegrationTest.java
@@ -578,7 +578,6 @@ class LiveAPIChatIntegrationTest {
   private static ChatCompletionMessageParam createAssistantMessage(String content) {
     return ChatCompletionMessageParam.ofChatCompletionAssistantMessageParam(
         ChatCompletionAssistantMessageParam.builder()
-            .role(ChatCompletionAssistantMessageParam.Role.ASSISTANT)
             .content(ChatCompletionAssistantMessageParam.Content.ofTextContent(content))
             .build());
   }
@@ -586,7 +585,6 @@ class LiveAPIChatIntegrationTest {
   private static ChatCompletionMessageParam createUserMessage(String content) {
     return ChatCompletionMessageParam.ofChatCompletionUserMessageParam(
         ChatCompletionUserMessageParam.builder()
-            .role(ChatCompletionUserMessageParam.Role.USER)
             .content(ChatCompletionUserMessageParam.Content.ofTextContent(content))
             .build());
   }
@@ -594,7 +592,6 @@ class LiveAPIChatIntegrationTest {
   private static ChatCompletionMessageParam createSystemMessage(String content) {
     return ChatCompletionMessageParam.ofChatCompletionSystemMessageParam(
         ChatCompletionSystemMessageParam.builder()
-            .role(ChatCompletionSystemMessageParam.Role.SYSTEM)
             .content(ChatCompletionSystemMessageParam.Content.ofTextContent(content))
             .build());
   }
@@ -602,7 +599,6 @@ class LiveAPIChatIntegrationTest {
   private static ChatCompletionMessageParam createToolMessage(String response, String id) {
     return ChatCompletionMessageParam.ofChatCompletionToolMessageParam(
         ChatCompletionToolMessageParam.builder()
-            .role(ChatCompletionToolMessageParam.Role.TOOL)
             .toolCallId(id)
             .content(ChatCompletionToolMessageParam.Content.ofTextContent(response))
             .build());


### PR DESCRIPTION
<img width="1438" alt="Screenshot 2025-01-23 at 1 40 06 PM" src="https://github.com/user-attachments/assets/454b64c0-d78b-49bd-8195-7820b22dddbe" />


changes in the API are in the latest 0.13.0 version from [this issue](https://github.com/openai/openai-java/issues/53#issuecomment-2607619117)

Notes:

* `type()` -> `_type()` was an intentional change
* fields we set before which can be inferred are now automatically set.