### PR TITLE
Replace experimental with tech preview for the OpenAI client instrumentation, clarify reasoning

### DIFF
--- a/docs/configure.md
+++ b/docs/configure.md
@@ -124,7 +124,7 @@ It supports:
 
 Note that this instrumentation is currently in **tech preview**, because the OpenAI client itself is still in beta.
 Once the OpenAI client is stable, this instrumentation will be GAed, but we'll likely drop support for beta versions of the client after some time.
-The instrumentation is on by default and can by disabled by setting either the `OTEL_INSTRUMENTATION_OPENAI_CLIENT_ENABLED` environment variable or the `otel.instrumentation.openai-client.enabled` JVM property to `false`.
+The instrumentation is on by default and can be disabled by setting either the `OTEL_INSTRUMENTATION_OPENAI_CLIENT_ENABLED` environment variable or the `otel.instrumentation.openai-client.enabled` JVM property to `false`.
 
 In addition, this instrumentation provides the following configuration options:
 

--- a/docs/configure.md
+++ b/docs/configure.md
@@ -122,7 +122,9 @@ It supports:
  * Tracing for requests, including GenAI-specific attributes such as token usage
  * Opt-In logging of OpenAI request and response content payloads
 
-This instrumentation is currently **experimental**. It can by disabled by setting either the `OTEL_INSTRUMENTATION_OPENAI_CLIENT_ENABLED` environment variable or the `otel.instrumentation.openai-client.enabled` JVM property to `false`.
+Note that this instrumentation is currently in **tech preview**, because the OpenAI client itself is still in beta.
+Once the OpenAI client is stable, this instrumentation will be GAed, but we'll likely drop support for beta versions of the client after some time.
+The instrumentation is on by default and can by disabled by setting either the `OTEL_INSTRUMENTATION_OPENAI_CLIENT_ENABLED` environment variable or the `otel.instrumentation.openai-client.enabled` JVM property to `false`.
 
 In addition, this instrumentation provides the following configuration options:
 


### PR DESCRIPTION
Clarifies that the OpenAI client instrumentation is in tech preview because the client itself is still beta and therefore will often have breaking changes.
This will allow us to clean up and remove (and therefore not maintain) all the compatibility code for the breaking changes during beta eventually.