### PR TITLE
Add support for OpenAI client 0.22 to 0.31

### DIFF
--- a/CHANGELOG.next-release.md
+++ b/CHANGELOG.next-release.md
@@ -1,2 +1,2 @@
-* Add support for OpenAI client 0.14+ - #531
+* Add support for OpenAI client 0.14 to 0.31 - #531, #564
 * Add support for OpenAI developer messages and raise minimum supported version to 0.8.0 - #539

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -77,7 +77,7 @@ ant = "org.apache.ant:ant:1.10.15"
 asm = "org.ow2.asm:asm:9.7"
 
 # Instrumented libraries
-openaiClient = "com.openai:openai-java:0.21.0"
+openaiClient = "com.openai:openai-java:0.24.1"
 
 [bundles]
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -77,7 +77,7 @@ ant = "org.apache.ant:ant:1.10.15"
 asm = "org.ow2.asm:asm:9.7"
 
 # Instrumented libraries
-openaiClient = "com.openai:openai-java:0.24.1"
+openaiClient = "com.openai:openai-java:0.25.0"
 
 [bundles]
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -77,7 +77,7 @@ ant = "org.apache.ant:ant:1.10.15"
 asm = "org.ow2.asm:asm:9.7"
 
 # Instrumented libraries
-openaiClient = "com.openai:openai-java:0.25.0"
+openaiClient = "com.openai:openai-java:0.31.0"
 
 [bundles]
 

--- a/instrumentation/openai-client-instrumentation/common/src/main/java/co/elastic/otel/openai/wrappers/EventLoggingStreamedResponse.java
+++ b/instrumentation/openai-client-instrumentation/common/src/main/java/co/elastic/otel/openai/wrappers/EventLoggingStreamedResponse.java
@@ -74,7 +74,7 @@ public class EventLoggingStreamedResponse implements StreamResponse<ChatCompleti
   }
 
   @Override
-  public void close() throws Exception {
+  public void close() {
     delegate.close();
   }
 }

--- a/instrumentation/openai-client-instrumentation/common/src/main/java/co/elastic/otel/openai/wrappers/InstrumentedChatService.java
+++ b/instrumentation/openai-client-instrumentation/common/src/main/java/co/elastic/otel/openai/wrappers/InstrumentedChatService.java
@@ -41,7 +41,7 @@ public class InstrumentedChatService
     String methodName = method.getName();
     Class<?>[] parameterTypes = method.getParameterTypes();
     if (methodName.equals("completions") && parameterTypes.length == 0) {
-      return new InstrumentedChatCompletionService(delegate.completions(), settings);
+      return new InstrumentedChatCompletionService(delegate.completions(), settings).createProxy();
     }
     return super.invoke(proxy, method, args);
   }

--- a/instrumentation/openai-client-instrumentation/common/src/main/java/co/elastic/otel/openai/wrappers/InstrumentedOpenAiClient.java
+++ b/instrumentation/openai-client-instrumentation/common/src/main/java/co/elastic/otel/openai/wrappers/InstrumentedOpenAiClient.java
@@ -115,7 +115,7 @@ public class InstrumentedOpenAiClient
       return new InstrumentedChatService(delegate.chat(), settings).createProxy();
     }
     if (methodName.equals("embeddings") && parameterTypes.length == 0) {
-      return new InstrumentedEmbeddingsService(delegate.embeddings(), settings);
+      return new InstrumentedEmbeddingsService(delegate.embeddings(), settings).createProxy();
     }
     return super.invoke(proxy, method, args);
   }

--- a/instrumentation/openai-client-instrumentation/common/src/main/java/co/elastic/otel/openai/wrappers/TracingStreamedResponse.java
+++ b/instrumentation/openai-client-instrumentation/common/src/main/java/co/elastic/otel/openai/wrappers/TracingStreamedResponse.java
@@ -94,7 +94,7 @@ public class TracingStreamedResponse implements StreamResponse<ChatCompletionChu
   }
 
   @Override
-  public void close() throws Exception {
+  public void close() {
     endSpan();
     delegate.close();
   }

--- a/instrumentation/openai-client-instrumentation/instrumentation-0.14/src/main/java/co/elastic/otel/openai/v0_14/OpenAiClientInstrumentationModule.java
+++ b/instrumentation/openai-client-instrumentation/instrumentation-0.14/src/main/java/co/elastic/otel/openai/v0_14/OpenAiClientInstrumentationModule.java
@@ -40,7 +40,9 @@ public class OpenAiClientInstrumentationModule extends InstrumentationModule {
     // HandlerReferencingAsyncStreamResponse was added in 0.14.1,
     // which is the next release after 0.13.0
     // 0.14.0 was a broken release which doesn't exist on maven central
-    return hasClassesNamed("com.openai.core.http.HandlerReferencingAsyncStreamResponse");
+    // HandlerReferencingAsyncStreamResponse was removed in 0.23.0 and replaced with TrackedHandler
+    return hasClassesNamed("com.openai.core.http.HandlerReferencingAsyncStreamResponse")
+        .or(hasClassesNamed("com.openai.core.http.TrackedHandler"));
   }
 
   @Override


### PR DESCRIPTION
These versions
 * added some new methods in the chat-completion and embeddings API which we don't trace for now, but therefore require dynamic proxying
 * removed the `Exception` from the `close()` signature, which fortunately for us is a bytecode-backwards compatible change
 
 I don't think we need to check and add those new methods to our instrumentation now, we should revisit when the OpenAI client is out of beta. Currently there are almost weekly releases changing things, which would just cause too much of an overhead for us.