### PR TITLE
Change default metric temporality to delta

### DIFF
--- a/CHANGELOG.next-release.md
+++ b/CHANGELOG.next-release.md
@@ -1,1 +1,1 @@
-
+* Switched the default of `otel.exporter.otlp.metrics.temporality.preference` from `CUMULATIVE` to `DELTA` to improve dashboarding experience with Kibana. If you want to restore the previous behaviour, you can manually override `otel.exporter.otlp.metrics.temporality.preference` to `CUMULATIVE` via JVM-properties or environment variables. - #583

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Set `otel.instrumentation.runtime-telemetry.emit-experimental-telemetry` to `fal
 ### Metric Temporality
 
 Elasticsearch and Kibana work best with metrics provided in delta-temporality.
-Therefore, the EDOT Java changes sets the default value of `otel.exporter.otlp.metrics.temporality.preference` to `DELTA`.
+Therefore, the EDOT Java changes the default value of `otel.exporter.otlp.metrics.temporality.preference` to `DELTA`.
 You can override this default if needed, note though that some provided Kibana dashboards will not work correctly in this case.
 
 # License

--- a/README.md
+++ b/README.md
@@ -79,6 +79,13 @@ in the [`span-stacktrace`](https://github.com/open-telemetry/opentelemetry-java-
 Experimental runtime metrics are enabled by default.
 Set `otel.instrumentation.runtime-telemetry.emit-experimental-telemetry` to `false` to disable them.
 
+
+### Metric Temporality
+
+Elasticsearch and Kibana work best with metrics provided in delta-temporality.
+Therefore, the EDOT Java changes sets the default value of `otel.exporter.otlp.metrics.temporality.preference` to `DELTA`.
+You can override this default if needed, note though that some provided Kibana dashboards will not work correctly in this case.
+
 # License
 
 The Elastic Distribution of OpenTelemetry Java is licensed under [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.html).

--- a/custom/src/main/java/co/elastic/otel/ElasticAutoConfigurationCustomizerProvider.java
+++ b/custom/src/main/java/co/elastic/otel/ElasticAutoConfigurationCustomizerProvider.java
@@ -42,7 +42,6 @@ public class ElasticAutoConfigurationCustomizerProvider
   private static final String METRIC_TEMPORALITY_PREFERENCE =
       "otel.exporter.otlp.metrics.temporality.preference";
 
-
   // must match value in io.opentelemetry.contrib.stacktrace.StackTraceAutoConfig
   private static final String STACKTRACE_OTEL_FILTER =
       "otel.java.experimental.span-stacktrace.filter";

--- a/custom/src/main/java/co/elastic/otel/ElasticAutoConfigurationCustomizerProvider.java
+++ b/custom/src/main/java/co/elastic/otel/ElasticAutoConfigurationCustomizerProvider.java
@@ -39,6 +39,9 @@ public class ElasticAutoConfigurationCustomizerProvider
   private static final String DISABLED_RESOURCE_PROVIDERS = "otel.java.disabled.resource.providers";
   private static final String RUNTIME_EXPERIMENTAL_TELEMETRY =
       "otel.instrumentation.runtime-telemetry.emit-experimental-telemetry";
+  private static final String METRIC_TEMPORALITY_PREFERENCE =
+      "otel.exporter.otlp.metrics.temporality.preference";
+
 
   // must match value in io.opentelemetry.contrib.stacktrace.StackTraceAutoConfig
   private static final String STACKTRACE_OTEL_FILTER =
@@ -76,6 +79,7 @@ public class ElasticAutoConfigurationCustomizerProvider
     Map<String, String> config = new HashMap<>();
 
     experimentalTelemetry(config, configProperties);
+    deltaMetricsTemporality(config, configProperties);
     resourceProviders(config, configProperties);
     spanStackTrace(config, configProperties);
 
@@ -88,6 +92,14 @@ public class ElasticAutoConfigurationCustomizerProvider
     boolean experimentalTelemetry =
         configProperties.getBoolean(RUNTIME_EXPERIMENTAL_TELEMETRY, true);
     config.put(RUNTIME_EXPERIMENTAL_TELEMETRY, Boolean.toString(experimentalTelemetry));
+  }
+
+  private static void deltaMetricsTemporality(
+      Map<String, String> config, ConfigProperties configProperties) {
+    // enable experimental telemetry metrics by default if not explicitly disabled
+    String temporalityPreference =
+        configProperties.getString(METRIC_TEMPORALITY_PREFERENCE, "DELTA");
+    config.put(METRIC_TEMPORALITY_PREFERENCE, temporalityPreference);
   }
 
   private static void resourceProviders(

--- a/custom/src/test/java/co/elastic/otel/ElasticAutoConfigurationCustomizerProviderTest.java
+++ b/custom/src/test/java/co/elastic/otel/ElasticAutoConfigurationCustomizerProviderTest.java
@@ -67,4 +67,13 @@ class ElasticAutoConfigurationCustomizerProviderTest {
     String value = config.get("otel.instrumentation.runtime-telemetry.emit-experimental-telemetry");
     assertThat(value).isEqualTo("false");
   }
+
+  @Test
+  void customizeMetricTemporalityPreference() {
+    Map<String, String> userConfig = new HashMap<>();
+    userConfig.put("otel.exporter.otlp.metrics.temporality.preference", "LOWMEMORY");
+    Map<String, String> config = propertiesCustomizer(DefaultConfigProperties.create(userConfig));
+    String value = config.get("otel.exporter.otlp.metrics.temporality.preference");
+    assertThat(value).isEqualTo("LOWMEMORY");
+  }
 }

--- a/custom/src/test/java/co/elastic/otel/ElasticAutoConfigurationCustomizerProviderTest.java
+++ b/custom/src/test/java/co/elastic/otel/ElasticAutoConfigurationCustomizerProviderTest.java
@@ -69,6 +69,14 @@ class ElasticAutoConfigurationCustomizerProviderTest {
   }
 
   @Test
+  void ensureDefaultMetricTemporalityIsDelta() {
+    Map<String, String> config =
+        propertiesCustomizer(DefaultConfigProperties.create(new HashMap<>()));
+    String value = config.get("otel.exporter.otlp.metrics.temporality.preference");
+    assertThat(value).isEqualTo("DELTA");
+  }
+
+  @Test
   void customizeMetricTemporalityPreference() {
     Map<String, String> userConfig = new HashMap<>();
     userConfig.put("otel.exporter.otlp.metrics.temporality.preference", "LOWMEMORY");


### PR DESCRIPTION
Closes #446 .
I've manually verified that this change is backwards-compatible for our existing Kibana Dashboards: The runtime-metrics dashboard currently available when ingesting OTLP via apm-server only uses gauges and up-down-counters, which are not affected by this temporality change.