### PR TITLE
dependabot: for github actions and composite actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,9 +2,11 @@
 version: 2
 
 updates:
-  # GitHub actions
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - '/'
+      - '/.github/actions/*'
+      - '/.github/workflows/*'
     schedule:
       interval: "weekly"
       day: "sunday"


### PR DESCRIPTION
I've just discovered the reusable composite actions were not actually taking into account with dependabot