### PR TITLE
remove classic agent options check

### DIFF
--- a/custom/src/test/java/co/elastic/otel/config/ReconcileOptionsTest.java
+++ b/custom/src/test/java/co/elastic/otel/config/ReconcileOptionsTest.java
@@ -51,8 +51,10 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
+@Disabled
 public class ReconcileOptionsTest {
   private static final Pattern VERSION_EXTRACTION_REGEX =
       Pattern.compile("^\\s*<[aA]\\s+[hH][rR][eE][fF]=\"(\\d+\\.\\d+\\.\\d+)/\"");


### PR DESCRIPTION
This will start to fail after 1.53.0 release as a new option has been added.
Also, it's not relevant anymore since the documentation is now in a separate repository.