### PR TITLE
enable azure provider by default

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,8 +30,6 @@ opentelemetryInstrumentationAlphaBom = { group = "io.opentelemetry.instrumentati
 
 opentelemetryProto = { group = "io.opentelemetry.proto", name = "opentelemetry-proto", version.ref = "opentelemetryProto" }
 
-awsContribResources = { group = "io.opentelemetry.contrib", name = "opentelemetry-aws-resources", version.ref = "opentelemetryContribAlpha" }
-gcpContribResources = { group = "io.opentelemetry.contrib", name = "opentelemetry-gcp-resources", version.ref = "opentelemetryContribAlpha" }
 contribResources = { group = "io.opentelemetry.contrib", name = "opentelemetry-resource-providers", version.ref = "opentelemetryContribAlpha" }
 contribSpanStacktrace = { group = "io.opentelemetry.contrib", name = "opentelemetry-span-stacktrace", version.ref = "opentelemetryContribAlpha" }
 contribInferredSpans = { group = "io.opentelemetry.contrib", name = "opentelemetry-inferred-spans", version.ref = "opentelemetryContribAlpha" }

--- a/resources/src/main/java/co/elastic/otel/resources/ResourcesAutoConfiguration.java
+++ b/resources/src/main/java/co/elastic/otel/resources/ResourcesAutoConfiguration.java
@@ -28,7 +28,7 @@ import java.util.Map;
 @AutoService(AutoConfigurationCustomizerProvider.class)
 public class ResourcesAutoConfiguration implements AutoConfigurationCustomizerProvider {
 
-  private static final String[] PROVIDERS = {"aws", "gcp"};
+  private static final String[] PROVIDERS = {"aws", "gcp", "azure"};
 
   @Override
   public void customize(AutoConfigurationCustomizer autoConfiguration) {

--- a/resources/src/test/java/co/elastic/otel/resources/ResourcesAutoConfigurationTest.java
+++ b/resources/src/test/java/co/elastic/otel/resources/ResourcesAutoConfigurationTest.java
@@ -30,6 +30,7 @@ class ResourcesAutoConfigurationTest {
 
   public static final String GCP_ENABLED = "otel.resource.providers.gcp.enabled";
   public static final String AWS_ENABLED = "otel.resource.providers.aws.enabled";
+  public static final String AZURE_ENABLED = "otel.resource.providers.azure.enabled";
 
   @Test
   void elastic_defaults() {
@@ -39,6 +40,7 @@ class ResourcesAutoConfigurationTest {
     Map<String, String> expectedResult = new HashMap<>();
     expectedResult.put(GCP_ENABLED, "true");
     expectedResult.put(AWS_ENABLED, "true");
+    expectedResult.put(AZURE_ENABLED, "true");
 
     testConfig(explicitConfig, expectedResult);
   }
@@ -51,6 +53,7 @@ class ResourcesAutoConfigurationTest {
     Map<String, String> expectedResult = new HashMap<>();
     expectedResult.put(GCP_ENABLED, "true");
     expectedResult.put(AWS_ENABLED, "true");
+    expectedResult.put(AZURE_ENABLED, "true");
 
     testConfig(explicitConfig, expectedResult);
   }
@@ -63,6 +66,7 @@ class ResourcesAutoConfigurationTest {
     Map<String, String> expectedResult = new HashMap<>();
     expectedResult.put(GCP_ENABLED, "false");
     expectedResult.put(AWS_ENABLED, "true");
+    expectedResult.put(AZURE_ENABLED, "true");
 
     testConfig(explicitConfig, expectedResult);
   }


### PR DESCRIPTION
Azure resource provider has been added in upstream instrumentation with https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/13627

because we enable those providers by default, we can anticipate this addition even if it will only be included in the next upstream release.