### PR TITLE
Workaround for temporality configuration not being possible

### DIFF
--- a/CHANGELOG.next-release.md
+++ b/CHANGELOG.next-release.md
@@ -1,1 +1,1 @@
-
+* Fix `otel.exporter.otlp.metrics.temporality.preference` config option having no effect. - #610

--- a/custom/build.gradle.kts
+++ b/custom/build.gradle.kts
@@ -35,7 +35,9 @@ dependencies {
   // test dependencies
   testImplementation(project(":testing-common"))
   testImplementation("io.opentelemetry:opentelemetry-sdk")
+  testImplementation("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure")
   testImplementation("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi")
+  testImplementation("io.opentelemetry:opentelemetry-exporter-otlp")
   testImplementation("io.opentelemetry.javaagent:opentelemetry-javaagent-tooling") {
     //The following dependency isn't actually needed, but breaks the classpath when testing with Java 8
     exclude(group = "io.opentelemetry.javaagent", module = "opentelemetry-javaagent-tooling-java9")

--- a/custom/src/main/java/co/elastic/otel/ElasticUserAgentHeader.java
+++ b/custom/src/main/java/co/elastic/otel/ElasticUserAgentHeader.java
@@ -47,12 +47,23 @@ public class ElasticUserAgentHeader {
   }
 
   public static MetricExporter configureIfPossible(MetricExporter metricExporter) {
+    // TODO remove workaround for https://github.com/open-telemetry/opentelemetry-java/issues/7276
+    // once fixed, setAggregationTemporalitySelector and setDefaultAggregationSelector can then be
+    // removed
     if (metricExporter instanceof OtlpGrpcMetricExporter) {
       return ((OtlpGrpcMetricExporter) metricExporter)
-          .toBuilder().addHeader(HEADER_NAME, GRPC_VALUE).build();
+          .toBuilder()
+              .setAggregationTemporalitySelector(metricExporter)
+              .setDefaultAggregationSelector(metricExporter)
+              .addHeader(HEADER_NAME, GRPC_VALUE)
+              .build();
     } else if (metricExporter instanceof OtlpHttpMetricExporter) {
       return ((OtlpHttpMetricExporter) metricExporter)
-          .toBuilder().addHeader(HEADER_NAME, HTTP_VALUE).build();
+          .toBuilder()
+              .setAggregationTemporalitySelector(metricExporter)
+              .setDefaultAggregationSelector(metricExporter)
+              .addHeader(HEADER_NAME, HTTP_VALUE)
+              .build();
     }
     return metricExporter;
   }

--- a/custom/src/test/java/co/elastic/otel/ElasticAutoConfigurationCustomizerProviderTest.java
+++ b/custom/src/test/java/co/elastic/otel/ElasticAutoConfigurationCustomizerProviderTest.java
@@ -96,7 +96,7 @@ class ElasticAutoConfigurationCustomizerProviderTest {
   }
 
   @Test
-  void verifyEffectiveDefaultTemporality() {
+  void verifyDefaultTemporalityOverriddenToDelta() {
     try (OpenTelemetrySdk sdk =
         AutoConfiguredOpenTelemetrySdk.builder().build().getOpenTelemetrySdk()) {
       List<MetricExporter> metricExporters =


### PR DESCRIPTION
Just after releasing, I discovered that the temporality setting `otel.exporter.otlp.metrics.temporality.preference` had no more effect. The temporality would always be cumulative, independent of what is configured. Even our changed default to delta did not take effect.

This was introduced in #593 due to a bug in the `toBuilder()` implementation in the exporters:
https://github.com/open-telemetry/opentelemetry-java/issues/7276

I've added more integrationish test reproducing the problem and added a workaround. I've also manually verified the fix.