### PR TITLE
github-actions(labeller): add required permissions

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -25,7 +25,8 @@ jobs:
           {
             "members": "read",
             "organization_projects": "write",
-            "issues": "read"
+            "issues": "read",
+            "pull_requests": "write"
           }
 
     - name: Add agent-java label


### PR DESCRIPTION
See https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#get-a-pull-request

Otherwise, https://github.com/elastic/elastic-otel-java/pull/633/checks#step:8:21

```
Run project_id=$(gh api graphql -f query='query($org:String!,$project_number:Int!){ organization(login:$org){ projectV2(number:$project_number) { id } } }' -F project_number="${PROJECT_NUMBER_ID}" -F org="${ORG}" --jq '.data.organization.projectV2.id' )
  project_id=$(gh api graphql -f query='query($org:String!,$project_number:Int!){ organization(login:$org){ projectV2(number:$project_number) { id } } }' -F project_number="${PROJECT_NUMBER_ID}" -F org="${ORG}" --jq '.data.organization.projectV2.id' )
  item_id=$(gh project item-add "${PROJECT_NUMBER_ID}" --url "${ITEM_URL}" --owner "${ORG}" --format json --jq .id)
  echo "item-id=${item_id}" >> "${GITHUB_OUTPUT}"
  
  echo "::notice::Item added to project https://github.com/orgs/${ORG}/projects/${PROJECT_NUMBER_ID}"
  shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
  env:
    GH_TOKEN: ***
    ORG: elastic
    ITEM_URL: https://api.github.com/repos/elastic/elastic-otel-java/pulls/633
    PROJECT_NUMBER_ID: 1[8](https://github.com/elastic/elastic-otel-java/pull/633/checks#step:8:9)29
resource not found, please check the URL
Error: Process completed with exit code 1.
```