### PR TITLE
refactor deactivated instrumentations to be remembered (not just in test)

### DIFF
--- a/custom/src/main/java/co/elastic/otel/dynamicconfig/DynamicConfiguration.java
+++ b/custom/src/main/java/co/elastic/otel/dynamicconfig/DynamicConfiguration.java
@@ -182,7 +182,7 @@ public class DynamicConfiguration {
     final Set<String> instrumentationsToReactivate;
     final Set<String> instrumentationsToDeactivate;
 
-    public <E> Deactivations(Set<String> deactivateList, Set<String> alreadyDeactivated) {
+    public Deactivations(Set<String> deactivateList, Set<String> alreadyDeactivated) {
       instrumentationsToReactivate = new HashSet<>();
       instrumentationsToDeactivate = new HashSet<>();
       for (String instrumentation : deactivateList) {

--- a/custom/src/main/java/co/elastic/otel/dynamicconfig/DynamicConfiguration.java
+++ b/custom/src/main/java/co/elastic/otel/dynamicconfig/DynamicConfiguration.java
@@ -134,8 +134,8 @@ public class DynamicConfiguration {
     reenableTracesFor(ALL_INSTRUMENTATION);
   }
 
-  //okay to synchronize as this should only be called after multi-second intervals and
-  //additionally only called from threads which are not doing anything application blocking
+  // okay to synchronize as this should only be called after multi-second intervals and
+  // additionally only called from threads which are not doing anything application blocking
   public synchronized void deactivateInstrumentations(String deactivateList) {
     if (deactivateList != null && !deactivateList.trim().isEmpty()) {
       // some values in the disable_instrumentations list

--- a/custom/src/main/java/co/elastic/otel/dynamicconfig/DynamicConfiguration.java
+++ b/custom/src/main/java/co/elastic/otel/dynamicconfig/DynamicConfiguration.java
@@ -157,7 +157,7 @@ public class DynamicConfiguration {
       Set<String> keySet = alreadyDeactivated.keySet();
       for (String instrumentation : keySet) {
         DynamicConfiguration.getInstance().reenableTracesFor(instrumentation);
-        alreadyDeactivated.remove(instrumentation);
+        keySet.remove(instrumentation);
       }
     } else {
       // Applying (2)

--- a/custom/src/main/java/co/elastic/otel/dynamicconfig/DynamicConfiguration.java
+++ b/custom/src/main/java/co/elastic/otel/dynamicconfig/DynamicConfiguration.java
@@ -151,7 +151,7 @@ public class DynamicConfiguration {
     // 2. Otherwise
     // 2a. everything in both deactivateList and alreadyDeactivated is ignored (already deactivated)
     // 2b. everything in deactivateList not in alreadyDeactivated is deactivated
-    // 2c. everything in alreadyDeactivated not in deactivateList is re-eactivated
+    // 2c. everything in alreadyDeactivated not in deactivateList is re-activated
     if (deactivateList == null || deactivateList.trim().isEmpty()) {
       // Applying (1) - keySet.remove() is a valid concurrent mutation here within the loop
       Set<String> keySet = alreadyDeactivated.keySet();

--- a/custom/src/main/java/co/elastic/otel/dynamicconfig/DynamicConfigurationPropertyChecker.java
+++ b/custom/src/main/java/co/elastic/otel/dynamicconfig/DynamicConfigurationPropertyChecker.java
@@ -58,8 +58,6 @@ public class DynamicConfigurationPropertyChecker implements Runnable {
     }
   }
 
-  private final Map<String, Boolean> alreadyDisabled = new HashMap<>();
-
   private void checkSending() {
     boolean stopSending;
     synchronized (this) {
@@ -83,39 +81,7 @@ public class DynamicConfigurationPropertyChecker implements Runnable {
     synchronized (this) {
       disableList = System.getProperty(DynamicConfiguration.INSTRUMENTATION_DISABLE_OPTION);
     }
-    if (disableList != null && !disableList.trim().isEmpty()) {
-      // some values in the disable_instrumentations list
-      Set<String> toBeEnabled = null;
-      if (!alreadyDisabled.isEmpty()) {
-        toBeEnabled = new HashSet<>(alreadyDisabled.keySet());
-      }
-      for (String toBeDisabled : disableList.split(",")) {
-        toBeDisabled = toBeDisabled.trim();
-        if (alreadyDisabled.containsKey(toBeDisabled)) {
-          // already disabled and keep it that way
-          if (toBeEnabled != null) {
-            toBeEnabled.remove(toBeDisabled);
-          }
-        } else {
-          DynamicConfiguration.getInstance().disableTracesFor(toBeDisabled);
-          alreadyDisabled.put(toBeDisabled, Boolean.TRUE);
-        }
-      }
-      if (toBeEnabled != null) {
-        for (String instrumentation : toBeEnabled) {
-          DynamicConfiguration.getInstance().reenableTracesFor(instrumentation);
-          alreadyDisabled.remove(instrumentation);
-        }
-      }
-    } else {
-      // empty list so anything currently disabled should be re-enabled
-      if (!alreadyDisabled.isEmpty()) {
-        for (String instrumentation : new HashSet<>(alreadyDisabled.keySet())) {
-          DynamicConfiguration.getInstance().reenableTracesFor(instrumentation);
-          alreadyDisabled.remove(instrumentation);
-        }
-      }
-    }
+    DynamicConfiguration.getInstance().deactivateInstrumentations(disableList);
   }
 
   @Override

--- a/custom/src/main/java/co/elastic/otel/dynamicconfig/DynamicConfigurationPropertyChecker.java
+++ b/custom/src/main/java/co/elastic/otel/dynamicconfig/DynamicConfigurationPropertyChecker.java
@@ -18,10 +18,6 @@
  */
 package co.elastic.otel.dynamicconfig;
 
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 


### PR DESCRIPTION
This was previously only needed in the test loop, but the central config will send a list of instrumentations and this needs to be handled in the dynamic config class the same way, so I'm just moving it across

This is the second PR in a series to get to the agent handling central config, I've broken the full implementation into sections to make it more manageable