### PR TITLE
Align dynamic config API to kibana send* config options

### DIFF
--- a/custom/src/main/java/co/elastic/otel/dynamicconfig/DynamicConfiguration.java
+++ b/custom/src/main/java/co/elastic/otel/dynamicconfig/DynamicConfiguration.java
@@ -84,51 +84,27 @@ public class DynamicConfiguration {
     }
   }
 
-  /** Can be executed repeatedly even if sending is currently stopped */
-  public void stopSendingSpans() {
+  /** Can be executed repeatedly regardless of the current state */
+  public void setSendingSpans(boolean send) {
     initSendingStates();
     if (recoverySendSpansState != null) {
-      BlockableSpanExporter.getInstance().setSendingSpans(false);
+      BlockableSpanExporter.getInstance().setSendingSpans(send);
     }
   }
 
-  /** Can be executed repeatedly even if sending is currently stopped */
-  public void startSendingSpans() {
-    initSendingStates();
-    if (recoverySendSpansState != null) {
-      BlockableSpanExporter.getInstance().setSendingSpans(true);
-    }
-  }
-
-  /** Can be executed repeatedly even if sending is currently stopped */
-  public void stopSendingMetrics() {
+  /** Can be executed repeatedly regardless of the current state */
+  public void setSendingMetrics(boolean send) {
     initSendingStates();
     if (recoverySendMetricsState != null) {
-      BlockableMetricExporter.getInstance().setSendingMetrics(false);
+      BlockableMetricExporter.getInstance().setSendingMetrics(send);
     }
   }
 
-  /** Can be executed repeatedly even if sending is currently stopped */
-  public void startSendingMetrics() {
-    initSendingStates();
-    if (recoverySendMetricsState != null) {
-      BlockableMetricExporter.getInstance().setSendingMetrics(true);
-    }
-  }
-
-  /** Can be executed repeatedly even if sending is currently stopped */
-  public void stopSendingLogs() {
+  /** Can be executed repeatedly regardless of the current state */
+  public void setSendingLogs(boolean send) {
     initSendingStates();
     if (recoverySendLogsState != null) {
-      BlockableLogRecordExporter.getInstance().setSendingLogs(false);
-    }
-  }
-
-  /** Can be executed repeatedly even if sending is currently stopped */
-  public void startSendingLogs() {
-    initSendingStates();
-    if (recoverySendLogsState != null) {
-      BlockableLogRecordExporter.getInstance().setSendingLogs(true);
+      BlockableLogRecordExporter.getInstance().setSendingLogs(send);
     }
   }
 

--- a/custom/src/main/java/co/elastic/otel/dynamicconfig/DynamicConfiguration.java
+++ b/custom/src/main/java/co/elastic/otel/dynamicconfig/DynamicConfiguration.java
@@ -85,6 +85,54 @@ public class DynamicConfiguration {
   }
 
   /** Can be executed repeatedly even if sending is currently stopped */
+  public void stopSendingSpans() {
+    initSendingStates();
+    if (recoverySendSpansState != null) {
+      BlockableSpanExporter.getInstance().setSendingSpans(false);
+    }
+  }
+
+  /** Can be executed repeatedly even if sending is currently stopped */
+  public void startSendingSpans() {
+    initSendingStates();
+    if (recoverySendSpansState != null) {
+      BlockableSpanExporter.getInstance().setSendingSpans(true);
+    }
+  }
+
+  /** Can be executed repeatedly even if sending is currently stopped */
+  public void stopSendingMetrics() {
+    initSendingStates();
+    if (recoverySendMetricsState != null) {
+      BlockableMetricExporter.getInstance().setSendingMetrics(false);
+    }
+  }
+
+  /** Can be executed repeatedly even if sending is currently stopped */
+  public void startSendingMetrics() {
+    initSendingStates();
+    if (recoverySendMetricsState != null) {
+      BlockableMetricExporter.getInstance().setSendingMetrics(true);
+    }
+  }
+
+  /** Can be executed repeatedly even if sending is currently stopped */
+  public void stopSendingLogs() {
+    initSendingStates();
+    if (recoverySendLogsState != null) {
+      BlockableLogRecordExporter.getInstance().setSendingLogs(false);
+    }
+  }
+
+  /** Can be executed repeatedly even if sending is currently stopped */
+  public void startSendingLogs() {
+    initSendingStates();
+    if (recoverySendLogsState != null) {
+      BlockableLogRecordExporter.getInstance().setSendingLogs(true);
+    }
+  }
+
+  /** Can be executed repeatedly even if sending is currently stopped */
   public void stopAllSending() {
     initSendingStates();
     if (recoverySendSpansState != null) {


### PR DESCRIPTION
We decided to provide per signal send_* config options in central config instead of just one global send, so we need those in teh dynamic config API