### PR TITLE
only elastic.otel.opamp.endpoint or env var are required

### DIFF
--- a/custom/src/main/java/co/elastic/otel/dynamicconfig/CentralConfig.java
+++ b/custom/src/main/java/co/elastic/otel/dynamicconfig/CentralConfig.java
@@ -42,6 +42,7 @@ public class CentralConfig {
   public static void init(SdkTracerProviderBuilder providerBuilder, ConfigProperties properties) {
     String endpoint = properties.getString("elastic.otel.opamp.endpoint");
     if (endpoint == null || endpoint.isEmpty()) {
+      logger.fine("OpAMP is not enabled");
       return;
     }
     logger.info("Enabling OpAMP as endpoint is defined: " + endpoint);

--- a/custom/src/main/java/co/elastic/otel/dynamicconfig/CentralConfig.java
+++ b/custom/src/main/java/co/elastic/otel/dynamicconfig/CentralConfig.java
@@ -41,10 +41,10 @@ public class CentralConfig {
 
   public static void init(SdkTracerProviderBuilder providerBuilder, ConfigProperties properties) {
     String endpoint = properties.getString("elastic.otel.opamp.endpoint");
-    logger.info("Enabling OpAMP as endpoint is defined: " + endpoint);
     if (endpoint == null || endpoint.isEmpty()) {
       return;
     }
+    logger.info("Enabling OpAMP as endpoint is defined: " + endpoint);
     if (!endpoint.endsWith("v1/opamp")) {
       if (endpoint.endsWith("/")) {
         endpoint += "v1/opamp";

--- a/custom/src/main/java/co/elastic/otel/dynamicconfig/CentralConfig.java
+++ b/custom/src/main/java/co/elastic/otel/dynamicconfig/CentralConfig.java
@@ -42,7 +42,7 @@ public class CentralConfig {
   public static void init(SdkTracerProviderBuilder providerBuilder, ConfigProperties properties) {
     String endpoint = properties.getString("elastic.otel.opamp.endpoint");
     if (endpoint == null || endpoint.isEmpty()) {
-      logger.fine("OpAMP is not enabled");
+      logger.fine("OpAMP is disabled");
       return;
     }
     logger.info("Enabling OpAMP as endpoint is defined: " + endpoint);


### PR DESCRIPTION
Aligning to decision that OpAMP is off by default but is enabled if elastic.otel.opamp.endpoint(or the equivalent env var) is defined, and that the "/v1/opamp" path is optional, so will be auto-added if not there