### PR TITLE
Add environment to OpAMP details

### DIFF
--- a/custom/src/main/java/co/elastic/otel/dynamicconfig/CentralConfig.java
+++ b/custom/src/main/java/co/elastic/otel/dynamicconfig/CentralConfig.java
@@ -54,6 +54,7 @@ public class CentralConfig {
       }
     }
     String serviceName = getServiceName(properties);
+    String environment = getServiceEnvironment(properties);
     logger.info("Starting OpAmp client for: " + serviceName + " on endpoint " + endpoint);
     DynamicInstrumentation.setTracerConfigurator(
         providerBuilder, DynamicConfiguration.UpdatableConfigurator.INSTANCE);
@@ -62,6 +63,7 @@ public class CentralConfig {
             .setServiceName(serviceName)
             .setPollingInterval(Duration.ofSeconds(30))
             .setConfigurationEndpoint(endpoint)
+            .setServiceEnvironment(environment)
             .build();
 
     centralConfigurationManager.start(
@@ -93,6 +95,18 @@ public class CentralConfig {
       }
     }
     return "unknown_service:java"; // Specified default
+  }
+
+  private static String getServiceEnvironment(ConfigProperties properties) {
+    Map<String, String> resourceMap = properties.getMap("otel.resource.attributes");
+    if (resourceMap != null) {
+      String environment = resourceMap.get("deployment.environment.name"); // semconv
+      if (environment != null) {
+        return environment;
+      }
+      return resourceMap.get("deployment.environment"); // backward compatible, can be null
+    }
+    return null;
   }
 
   public static class Configs {

--- a/opamp/src/main/java/co/elastic/opamp/client/CentralConfigurationManagerImpl.java
+++ b/opamp/src/main/java/co/elastic/opamp/client/CentralConfigurationManagerImpl.java
@@ -67,6 +67,7 @@ public final class CentralConfigurationManagerImpl
 
   private void processRemoteConfig(OpampClient client, Opamp.AgentRemoteConfig remoteConfig) {
     Map<String, Opamp.AgentConfigFile> configMapMap = remoteConfig.getConfig().getConfigMapMap();
+    // TODO change the key to "elastic" when the collector has that
     Opamp.AgentConfigFile centralConfig = configMapMap.get("");
     if (centralConfig != null) {
       Map<String, String> configuration = parseCentralConfiguration(centralConfig.getBody());
@@ -135,6 +136,7 @@ public final class CentralConfigurationManagerImpl
     private String serviceName;
     private String serviceNamespace;
     private String serviceVersion;
+    private String environment;
     private String configurationEndpoint;
     private Duration pollingInterval;
 
@@ -165,6 +167,11 @@ public final class CentralConfigurationManagerImpl
       return this;
     }
 
+    public Builder setServiceEnvironment(String environment) {
+      this.environment = environment;
+      return this;
+    }
+
     public CentralConfigurationManagerImpl build() {
       OpampClientBuilder builder = OpampClient.builder();
       OkHttpSender httpSender = OkHttpSender.create("http://localhost:4320/v1/opamp");
@@ -177,6 +184,9 @@ public final class CentralConfigurationManagerImpl
       }
       if (serviceVersion != null) {
         builder.setServiceVersion(serviceVersion);
+      }
+      if (environment != null) {
+        builder.setServiceEnvironment(environment);
       }
       if (configurationEndpoint != null) {
         httpSender = OkHttpSender.create(configurationEndpoint);

--- a/opamp/src/main/java/co/elastic/opamp/client/OpampClientBuilder.java
+++ b/opamp/src/main/java/co/elastic/opamp/client/OpampClientBuilder.java
@@ -110,6 +110,11 @@ public final class OpampClientBuilder {
     return this;
   }
 
+  public OpampClientBuilder setServiceEnvironment(String environment) {
+    addIdentifyingAttribute("deployment.environment.name", environment);
+    return this;
+  }
+
   /**
    * Adds the AcceptsRemoteConfig and ReportsRemoteConfig capabilities to the Client so that the
    * Server can offer remote config values as explained <a


### PR DESCRIPTION
The APM UI has central config defined by service name and environment, no environment is equivalent to "All" environments (which is an option for defining the central config). The collector OpAMP extension uses the semconv standard `deployment.environment.name` to determine the environment. 

The value for environments before semconv stabilized was `deployment.environment` and this is still widely used.

The `deployment.environment.name` (or the old key) is a resource attribute.

The PR handles this combo of things