### PR TITLE
Change the opamp document key used to 'elastic'

### DIFF
--- a/opamp/src/main/java/co/elastic/opamp/client/CentralConfigurationManagerImpl.java
+++ b/opamp/src/main/java/co/elastic/opamp/client/CentralConfigurationManagerImpl.java
@@ -67,8 +67,7 @@ public final class CentralConfigurationManagerImpl
 
   private void processRemoteConfig(OpampClient client, Opamp.AgentRemoteConfig remoteConfig) {
     Map<String, Opamp.AgentConfigFile> configMapMap = remoteConfig.getConfig().getConfigMapMap();
-    // TODO change the key to "elastic" when the collector has that
-    Opamp.AgentConfigFile centralConfig = configMapMap.get("");
+    Opamp.AgentConfigFile centralConfig = configMapMap.get("elastic");
     if (centralConfig != null) {
       Map<String, String> configuration = parseCentralConfiguration(centralConfig.getBody());
       Opamp.RemoteConfigStatuses status;

--- a/opamp/src/test/java/co/elastic/opamp/client/CentralConfigurationManagerTest.java
+++ b/opamp/src/test/java/co/elastic/opamp/client/CentralConfigurationManagerTest.java
@@ -144,7 +144,7 @@ class CentralConfigurationManagerTest {
             .build();
 
     Opamp.AgentConfigMap configMap =
-        Opamp.AgentConfigMap.newBuilder().putConfigMap("", agentConfigFile).build();
+        Opamp.AgentConfigMap.newBuilder().putConfigMap("elastic", agentConfigFile).build();
 
     return MessageData.builder()
         .setRemoteConfig(Opamp.AgentRemoteConfig.newBuilder().setConfig(configMap).build())


### PR DESCRIPTION
Already present in collector main, and tested using 9.1 snapshots of agent, collector and cloud