### PR TITLE
remove community PR comment

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -62,18 +62,6 @@ jobs:
         NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Add comment for community PR
-      if: steps.is_elastic_member.outputs.result == 'false' && steps.user_type.outputs.result == 'user'
-      uses: wow-actions/auto-comment@v1
-      with:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        pullRequestOpened: |
-          👋 @{{ author }} Thanks a lot for your contribution! 
-          
-          It may take some time before we review a PR, so even if you don’t see activity for some time, it **does not** mean that we have forgotten about it. 
-          
-          Every once in a while we go through a process of prioritization, after which we are focussing on the tasks that were planned for the upcoming [milestone](https://github.com/elastic/apm-agent-java/milestones). The prioritization status is typically reflected through the PR labels. It could be pending triage, a candidate for a future milestone, or have a target milestone set to it.
-
     - name: Assign new internal pull requests to project
       id: add-to-project
       if: steps.is_elastic_member.outputs.result == 'true' && github.event_name == 'pull_request_target'


### PR DESCRIPTION
Remove stale automatic comment for community PRs as it's not relevant anymore and the priority is not reflected anymore in the labels.

Also, we currently receive less community PRs than we used to, hence making it less useful.

With this change, the `.github/workflows/labeler.yml` file becomes identical to the one in this PR:
- https://github.com/elastic/apm-agent-java/pull/4114