### PR TITLE
implement spans debug logging

### DIFF
--- a/custom/src/main/java/co/elastic/otel/ElasticAutoConfigurationCustomizerProvider.java
+++ b/custom/src/main/java/co/elastic/otel/ElasticAutoConfigurationCustomizerProvider.java
@@ -22,6 +22,7 @@ import co.elastic.otel.dynamicconfig.BlockableLogRecordExporter;
 import co.elastic.otel.dynamicconfig.BlockableMetricExporter;
 import co.elastic.otel.dynamicconfig.BlockableSpanExporter;
 import co.elastic.otel.dynamicconfig.CentralConfig;
+import co.elastic.otel.logging.AgentLog;
 import com.google.auto.service.AutoService;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizer;
@@ -72,6 +73,7 @@ public class ElasticAutoConfigurationCustomizerProvider
     autoConfiguration.addTracerProviderCustomizer(
         (providerBuilder, properties) -> {
           CentralConfig.init(providerBuilder, properties);
+          AgentLog.addSpanLoggingIfRequired(providerBuilder, properties);
           return providerBuilder;
         });
   }

--- a/internal-logging/build.gradle.kts
+++ b/internal-logging/build.gradle.kts
@@ -11,7 +11,7 @@ dependencies {
   compileOnly("io.opentelemetry.javaagent:opentelemetry-javaagent-tooling")
   compileOnly("io.opentelemetry.javaagent:opentelemetry-javaagent-bootstrap")
   compileOnly("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi")
-  implementation("io.opentelemetry:opentelemetry-exporter-logging")
+  compileOnly("io.opentelemetry:opentelemetry-exporter-logging")
   compileOnly(libs.slf4j.api)
   implementation(libs.bundles.log4j2) {
     // Workaround for https://github.com/apache/logging-log4j2/issues/3754

--- a/internal-logging/build.gradle.kts
+++ b/internal-logging/build.gradle.kts
@@ -12,6 +12,7 @@ dependencies {
   compileOnly("io.opentelemetry.javaagent:opentelemetry-javaagent-bootstrap")
   compileOnly("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi")
   compileOnly("io.opentelemetry:opentelemetry-exporter-logging")
+  compileOnly("io.opentelemetry:opentelemetry-exporter-logging-otlp")
   compileOnly(libs.slf4j.api)
   implementation(libs.bundles.log4j2) {
     // Workaround for https://github.com/apache/logging-log4j2/issues/3754

--- a/internal-logging/build.gradle.kts
+++ b/internal-logging/build.gradle.kts
@@ -10,6 +10,8 @@ dependencies {
 
   compileOnly("io.opentelemetry.javaagent:opentelemetry-javaagent-tooling")
   compileOnly("io.opentelemetry.javaagent:opentelemetry-javaagent-bootstrap")
+  compileOnly("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi")
+  implementation("io.opentelemetry:opentelemetry-exporter-logging")
   compileOnly(libs.slf4j.api)
   implementation(libs.bundles.log4j2) {
     // Workaround for https://github.com/apache/logging-log4j2/issues/3754

--- a/internal-logging/src/main/java/co/elastic/otel/logging/AgentLog.java
+++ b/internal-logging/src/main/java/co/elastic/otel/logging/AgentLog.java
@@ -153,7 +153,7 @@ public class AgentLog {
     }
 
     // when debugging the upstream otel agent configures an extra debug exporter
-    if(debugLogSpanExporter != null) {
+    if (debugLogSpanExporter != null) {
       debugLogSpanExporter.setEnabled(isDebug);
     }
   }

--- a/internal-logging/src/main/java/co/elastic/otel/logging/AgentLog.java
+++ b/internal-logging/src/main/java/co/elastic/otel/logging/AgentLog.java
@@ -71,15 +71,12 @@ public class AgentLog {
   public static void addSpanLoggingIfRequired(
       SdkTracerProviderBuilder providerBuilder, ConfigProperties config) {
 
-    boolean otelDebug = config.getBoolean(OTEL_JAVAAGENT_DEBUG, false);
-
-    // Replicate behavior of upstream agent: span logging exporter is automatically added
-    // when not already present when debugging.
-    // When logging exporter has been explicitly configured, spans logging will be done by the
-    // explicitly configured logging exporter instance
+    // Replicate behavior of the upstream agent: span logging exporter is automatically added when
+    // not already present when debugging. When logging exporter has been explicitly configured,
+    // spans logging will be done by the explicitly configured logging exporter instance.
     boolean loggingExporterNotAlreadyConfigured =
         !config.getList("otel.traces.exporter", emptyList()).contains("logging");
-    if (otelDebug && loggingExporterNotAlreadyConfigured) {
+    if (loggingExporterNotAlreadyConfigured) {
       providerBuilder.addSpanProcessor(SimpleSpanProcessor.create(debugLogSpanExporter));
     }
   }

--- a/internal-logging/src/main/java/co/elastic/otel/logging/AgentLog.java
+++ b/internal-logging/src/main/java/co/elastic/otel/logging/AgentLog.java
@@ -29,6 +29,7 @@ import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 import java.util.Collection;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.config.Configurator;
@@ -90,11 +91,11 @@ public class AgentLog {
     // spans logging will be done by the explicitly configured logging exporter instance.
 
     logPlainText = config.getBoolean(OTEL_JAVAAGENT_DEBUG, false);
-    String exporterName = logPlainText ? "logging" : "otlp-logging";
 
-    boolean loggingExporterNotAlreadyConfigured =
-        !config.getList("otel.traces.exporter", emptyList()).contains(exporterName);
-    if (loggingExporterNotAlreadyConfigured) {
+    List<String> configuredExporters = config.getList("otel.traces.exporter", emptyList());
+    boolean loggingConfigured =
+        configuredExporters.stream().anyMatch(e -> e.equals("logging") || e.equals("otlp-logging"));
+    if (!loggingConfigured) {
       debugLogSpanExporter =
           new DebugLogSpanExporter(
               logPlainText ? LoggingSpanExporter.create() : OtlpJsonLoggingSpanExporter.create());

--- a/internal-logging/src/main/java/co/elastic/otel/logging/AgentLog.java
+++ b/internal-logging/src/main/java/co/elastic/otel/logging/AgentLog.java
@@ -92,10 +92,8 @@ public class AgentLog {
 
     logPlainText = config.getBoolean(OTEL_JAVAAGENT_DEBUG, false);
 
-    List<String> configuredExporters = config.getList("otel.traces.exporter", emptyList());
-    boolean loggingConfigured =
-        configuredExporters.stream().anyMatch(e -> e.equals("logging") || e.equals("otlp-logging"));
-    if (!loggingConfigured) {
+    List<String> exporters = config.getList("otel.traces.exporter", emptyList());
+    if (!exporters.contains("logging") && !exporters.contains("otlp-logging")) {
       debugLogSpanExporter =
           new DebugLogSpanExporter(
               logPlainText ? LoggingSpanExporter.create() : OtlpJsonLoggingSpanExporter.create());

--- a/internal-logging/src/main/java/co/elastic/otel/logging/ElasticLoggingCustomizer.java
+++ b/internal-logging/src/main/java/co/elastic/otel/logging/ElasticLoggingCustomizer.java
@@ -22,6 +22,7 @@ import com.google.auto.service.AutoService;
 import io.opentelemetry.javaagent.bootstrap.InternalLogger;
 import io.opentelemetry.javaagent.tooling.LoggingCustomizer;
 import io.opentelemetry.javaagent.tooling.config.EarlyInitAgentConfig;
+import java.util.Optional;
 import org.apache.logging.log4j.Level;
 import org.slf4j.LoggerFactory;
 
@@ -43,20 +44,19 @@ public class ElasticLoggingCustomizer implements LoggingCustomizer {
     // make the agent internal logger delegate to slf4j, which will delegate to log4j
     InternalLogger.initialize(Slf4jInternalLogger::create);
 
-    AgentLog.init();
-
-    Level level = null;
-    if (earlyConfig.getBoolean(AgentLog.OTEL_JAVAAGENT_DEBUG, false)) {
+    boolean upstreamDebugEnabled = earlyConfig.getBoolean(AgentLog.OTEL_JAVAAGENT_DEBUG, false);
+    Level level;
+    if (upstreamDebugEnabled) {
       // set debug logging when enabled through configuration to behave like the upstream
       // distribution
       level = Level.DEBUG;
     } else {
-      String levelConfig = earlyConfig.getString("elastic.otel.javaagent.log.level");
-      if (levelConfig != null) {
-        level = Level.getLevel(levelConfig);
-      }
+      level =
+          Optional.ofNullable(earlyConfig.getString("elastic.otel.javaagent.log.level"))
+              .map(Level::getLevel)
+              .orElse(Level.INFO);
     }
-    AgentLog.setLevel(level != null ? level : Level.INFO);
+    AgentLog.init(upstreamDebugEnabled, level);
   }
 
   @Override

--- a/internal-logging/src/main/java/co/elastic/otel/logging/ElasticLoggingCustomizer.java
+++ b/internal-logging/src/main/java/co/elastic/otel/logging/ElasticLoggingCustomizer.java
@@ -46,7 +46,7 @@ public class ElasticLoggingCustomizer implements LoggingCustomizer {
     AgentLog.init();
 
     Level level = null;
-    if (earlyConfig.getBoolean("otel.javaagent.debug", false)) {
+    if (earlyConfig.getBoolean(AgentLog.OTEL_JAVAAGENT_DEBUG, false)) {
       // set debug logging when enabled through configuration to behave like the upstream
       // distribution
       level = Level.DEBUG;


### PR DESCRIPTION
With the upstream otel agent, when the `otel.javaagent.debug` option is set to `true`, an additional span logging exporter is added when there is none, that means spans start/and are logged at `INFO` level when `otel.javaagent.debug` is set to `true`.

Our current implementation of dynamic log level does currently replicates this behavior, which means that when the dynamic log level is set to `DEBUG` the resulting behavior is not exactly equivalent to setting `otel.javaagent.debug=true` with the upstream agent.

This PR replicates this behavior by doing the following:
- when an logging exporter is already configured, we let the configured one log the spans, which means span logging will happen whenever log level is `INFO` or above.
- when no logging exporter is configured, we add a dedicated `SpanExporter` that can be controlled at runtime, then when the log level is set to `DEBUG` or above we can then control this extra span exporter at runtime when needed.
- when the upstream debug config option is used, use the same plain text output as the upstream agent
- when setting our own logger level to `debug`, use the json output for easier log parsing.

Feature documentation is covered in https://github.com/elastic/opentelemetry/pull/315
