### PR TITLE
Update publish URLS to sonatype central

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,7 +20,10 @@ subprojects {
 
 nexusPublishing {
   repositories {
-    sonatype()
+    sonatype {
+      nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+      snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
+    }
   }
 }
 


### PR DESCRIPTION
Should hopefully be good enough:
https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/#getting-started-for-maven-api-like-plugins


### Test

I ran this [Buildkite build](https://buildkite.com/elastic/elastic-otel-java-snapshot/builds/563) [Only Elastic employees can access]