### PR TITLE
switch to 2.18.1, and switch openai to upstream

### DIFF
--- a/custom/src/test/java/co/elastic/otel/ElasticAutoConfigurationCustomizerProviderTest.java
+++ b/custom/src/test/java/co/elastic/otel/ElasticAutoConfigurationCustomizerProviderTest.java
@@ -58,7 +58,8 @@ class ElasticAutoConfigurationCustomizerProviderTest {
   void disableCustomResourceProvider() {
     Map<String, String> userConfig = new HashMap<>();
     userConfig.put("otel.java.disabled.resource.providers", "my.disabled.provider.Provider");
-    Map<String, String> config = propertiesCustomizer(DefaultConfigProperties.create(userConfig));
+    Map<String, String> config =
+        propertiesCustomizer(DefaultConfigProperties.createFromMap(userConfig));
     String value = config.get("otel.java.disabled.resource.providers");
     assertThat(value)
         .satisfies(
@@ -73,7 +74,8 @@ class ElasticAutoConfigurationCustomizerProviderTest {
   void disableExperimentalRuntimeMetrics() {
     Map<String, String> userConfig = new HashMap<>();
     userConfig.put("otel.instrumentation.runtime-telemetry.emit-experimental-telemetry", "false");
-    Map<String, String> config = propertiesCustomizer(DefaultConfigProperties.create(userConfig));
+    Map<String, String> config =
+        propertiesCustomizer(DefaultConfigProperties.createFromMap(userConfig));
     String value = config.get("otel.instrumentation.runtime-telemetry.emit-experimental-telemetry");
     assertThat(value).isEqualTo("false");
   }
@@ -81,7 +83,7 @@ class ElasticAutoConfigurationCustomizerProviderTest {
   @Test
   void ensureDefaultMetricTemporalityIsDelta() {
     Map<String, String> config =
-        propertiesCustomizer(DefaultConfigProperties.create(new HashMap<>()));
+        propertiesCustomizer(DefaultConfigProperties.createFromMap(new HashMap<>()));
     String value = config.get("otel.exporter.otlp.metrics.temporality.preference");
     assertThat(value).isEqualTo("DELTA");
   }
@@ -90,7 +92,8 @@ class ElasticAutoConfigurationCustomizerProviderTest {
   void customizeMetricTemporalityPreference() {
     Map<String, String> userConfig = new HashMap<>();
     userConfig.put("otel.exporter.otlp.metrics.temporality.preference", "LOWMEMORY");
-    Map<String, String> config = propertiesCustomizer(DefaultConfigProperties.create(userConfig));
+    Map<String, String> config =
+        propertiesCustomizer(DefaultConfigProperties.createFromMap(userConfig));
     String value = config.get("otel.exporter.otlp.metrics.temporality.preference");
     assertThat(value).isEqualTo("LOWMEMORY");
   }

--- a/docs/release-notes/breaking-changes.md
+++ b/docs/release-notes/breaking-changes.md
@@ -29,7 +29,7 @@ Breaking changes can impact your applications, potentially disrupting normal ope
 % TEMPLATE END
 
 ::::{dropdown} OpenAI instrumentation switched from openai-client to openai
-In OpenTelemetry Java agent version 2.18.0, an `openai` instrumentation module was added. This conflicted with the `openai-client` instrumentation module that was implemented in the EDOT agent. Since the `openai` module is on by default, we switched off the `openai-client` instrumentation module (previously on by default). The functionality is broadly the same
+In OpenTelemetry Java agent version 2.18.0, an `openai` instrumentation module was added. This conflicted with the `openai-client` instrumentation module that was implemented in the EDOT agent. Since the `openai` module is on by default, we switched off the `openai-client` instrumentation module (previously on by default). The functionality is broadly the same.
 **Impact**<br> Small changes in span names and attributes expected. If the elastic specific `ELASTIC_OTEL_JAVA_INSTRUMENTATION_GENAI_EMIT_EVENTS` was previously set to true, this would no longer produce events
 **Action**<br> the equivalent of `ELASTIC_OTEL_JAVA_INSTRUMENTATION_GENAI_EMIT_EVENTS` is simply `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT`. If you want to revert entirely to the previous setup, you can disable the upstream implementation and enable the EDOT one, eg `OTEL_INSTRUMENTATION_OPENAI=false` and `OTEL_INSTRUMENTATION_OPENAI_CLIENT=true`
 View [PR #763](https://github.com/elastic/elastic-otel-java/pull/763).

--- a/docs/release-notes/breaking-changes.md
+++ b/docs/release-notes/breaking-changes.md
@@ -28,4 +28,9 @@ Breaking changes can impact your applications, potentially disrupting normal ope
 % ::::
 % TEMPLATE END
 
-No breaking changes.
+::::{dropdown} openai instrumentation switched from openai-client to openai
+In OpenTelemetry Java agent version 2.18.0, an `openai` instrumentation module was added. This conflicted with the `openai-client` instrumentation module that was implemented in the EDOT agent. Since the `openai` module is on by default, we switched off the `openai-client` instrumentation module (previously on by default). The functionality is broadly the same
+**Impact**<br> Small changes in span names and attributes expected. If the elastic specific `ELASTIC_OTEL_JAVA_INSTRUMENTATION_GENAI_EMIT_EVENTS` was previously set to true, this would no longer produce events
+**Action**<br> the equivalent of `ELASTIC_OTEL_JAVA_INSTRUMENTATION_GENAI_EMIT_EVENTS` is simply `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT`. If you want to revert entirely to the previous setup, you can disable the upstream implementation and enable the EDOT one, eg `OTEL_INSTRUMENTATION_OPENAI=false` and `OTEL_INSTRUMENTATION_OPENAI_CLIENT=true`
+View [PR #763](https://github.com/elastic/elastic-otel-java/pull/763).
+::::

--- a/docs/release-notes/breaking-changes.md
+++ b/docs/release-notes/breaking-changes.md
@@ -28,7 +28,7 @@ Breaking changes can impact your applications, potentially disrupting normal ope
 % ::::
 % TEMPLATE END
 
-::::{dropdown} openai instrumentation switched from openai-client to openai
+::::{dropdown} OpenAI instrumentation switched from openai-client to openai
 In OpenTelemetry Java agent version 2.18.0, an `openai` instrumentation module was added. This conflicted with the `openai-client` instrumentation module that was implemented in the EDOT agent. Since the `openai` module is on by default, we switched off the `openai-client` instrumentation module (previously on by default). The functionality is broadly the same
 **Impact**<br> Small changes in span names and attributes expected. If the elastic specific `ELASTIC_OTEL_JAVA_INSTRUMENTATION_GENAI_EMIT_EVENTS` was previously set to true, this would no longer produce events
 **Action**<br> the equivalent of `ELASTIC_OTEL_JAVA_INSTRUMENTATION_GENAI_EMIT_EVENTS` is simply `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT`. If you want to revert entirely to the previous setup, you can disable the upstream implementation and enable the EDOT one, eg `OTEL_INSTRUMENTATION_OPENAI=false` and `OTEL_INSTRUMENTATION_OPENAI_CLIENT=true`

--- a/docs/release-notes/breaking-changes.md
+++ b/docs/release-notes/breaking-changes.md
@@ -31,6 +31,6 @@ Breaking changes can impact your applications, potentially disrupting normal ope
 ::::{dropdown} OpenAI instrumentation switched from openai-client to openai
 In OpenTelemetry Java agent version 2.18.0, an `openai` instrumentation module was added. This conflicted with the `openai-client` instrumentation module that was implemented in the EDOT agent. Since the `openai` module is on by default, we switched off the `openai-client` instrumentation module (previously on by default). The functionality is broadly the same.
 **Impact**<br> Small changes in span names and attributes expected. If the elastic specific `ELASTIC_OTEL_JAVA_INSTRUMENTATION_GENAI_EMIT_EVENTS` was previously set to true, this would no longer produce events.
-**Action**<br> the equivalent of `ELASTIC_OTEL_JAVA_INSTRUMENTATION_GENAI_EMIT_EVENTS` is simply `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT`. If you want to revert entirely to the previous setup, you can disable the upstream implementation and enable the EDOT one, eg `OTEL_INSTRUMENTATION_OPENAI=false` and `OTEL_INSTRUMENTATION_OPENAI_CLIENT=true`
+**Action**<br> The equivalent of `ELASTIC_OTEL_JAVA_INSTRUMENTATION_GENAI_EMIT_EVENTS` is `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT`. If you want to revert entirely to the previous setup, turn off the upstream implementation and turn on the EDOT one. For example: `OTEL_INSTRUMENTATION_OPENAI=false` and `OTEL_INSTRUMENTATION_OPENAI_CLIENT=true`
 View [PR #763](https://github.com/elastic/elastic-otel-java/pull/763).
 ::::

--- a/docs/release-notes/breaking-changes.md
+++ b/docs/release-notes/breaking-changes.md
@@ -30,7 +30,7 @@ Breaking changes can impact your applications, potentially disrupting normal ope
 
 ::::{dropdown} OpenAI instrumentation switched from openai-client to openai
 In OpenTelemetry Java agent version 2.18.0, an `openai` instrumentation module was added. This conflicted with the `openai-client` instrumentation module that was implemented in the EDOT agent. Since the `openai` module is on by default, we switched off the `openai-client` instrumentation module (previously on by default). The functionality is broadly the same.
-**Impact**<br> Small changes in span names and attributes expected. If the elastic specific `ELASTIC_OTEL_JAVA_INSTRUMENTATION_GENAI_EMIT_EVENTS` was previously set to true, this would no longer produce events
+**Impact**<br> Small changes in span names and attributes expected. If the elastic specific `ELASTIC_OTEL_JAVA_INSTRUMENTATION_GENAI_EMIT_EVENTS` was previously set to true, this would no longer produce events.
 **Action**<br> the equivalent of `ELASTIC_OTEL_JAVA_INSTRUMENTATION_GENAI_EMIT_EVENTS` is simply `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT`. If you want to revert entirely to the previous setup, you can disable the upstream implementation and enable the EDOT one, eg `OTEL_INSTRUMENTATION_OPENAI=false` and `OTEL_INSTRUMENTATION_OPENAI_CLIENT=true`
 View [PR #763](https://github.com/elastic/elastic-otel-java/pull/763).
 ::::

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,11 +11,11 @@ opentelemetryProto = "1.3.2-alpha"
 
 # otel agent, we rely on the '*-alpha' and get the non-alpha dependencies transitively
 # updated from upstream agent with gradle/update-upstream.sh
-opentelemetryJavaagentAlpha = "2.17.1-alpha"
+opentelemetryJavaagentAlpha = "2.18.1-alpha"
 
 # otel contrib
 # updated from upstream agent with gradle/update-upstream.sh
-opentelemetryContribAlpha = "1.46.0-alpha"
+opentelemetryContribAlpha = "1.47.0-alpha"
 
 # otel semconv
 # updated from upstream agent with gradle/update-upstream.sh

--- a/instrumentation/openai-client-instrumentation/instrumentation-1.1/src/main/java/co/elastic/otel/openai/v1_1/OpenAiClientInstrumentationModule.java
+++ b/instrumentation/openai-client-instrumentation/instrumentation-1.1/src/main/java/co/elastic/otel/openai/v1_1/OpenAiClientInstrumentationModule.java
@@ -22,6 +22,7 @@ import co.elastic.otel.openai.v1_1.wrappers.Constants;
 import com.google.auto.service.AutoService;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import java.util.Collections;
 import java.util.List;
 
@@ -40,5 +41,14 @@ public class OpenAiClientInstrumentationModule extends InstrumentationModule {
   @Override
   public boolean isHelperClass(String className) {
     return className.startsWith("co.elastic.otel.openai");
+  }
+
+  @Override
+  public boolean defaultEnabled(ConfigProperties config) {
+    // the upstream implementation - openai or openai-java - is used in preference to this
+    // you could disable that and enable this with
+    // OTEL_INSTRUMENTATION_OPENAI=false
+    // OTEL_INSTRUMENTATION_OPENAI_CLIENT=true
+    return false;
   }
 }

--- a/instrumentation/openai-client-instrumentation/instrumentation-1.1/src/test/java/co/elastic/otel/openai/v1_1/ChatTest.java
+++ b/instrumentation/openai-client-instrumentation/instrumentation-1.1/src/test/java/co/elastic/otel/openai/v1_1/ChatTest.java
@@ -85,9 +85,11 @@ import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+@Disabled
 class ChatTest {
 
   @RegisterExtension

--- a/instrumentation/openai-client-instrumentation/instrumentation-1.1/src/test/java/co/elastic/otel/openai/v1_1/EmbeddingsTest.java
+++ b/instrumentation/openai-client-instrumentation/instrumentation-1.1/src/test/java/co/elastic/otel/openai/v1_1/EmbeddingsTest.java
@@ -37,9 +37,11 @@ import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import java.util.Collections;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+@Disabled
 class EmbeddingsTest {
   @RegisterExtension
   static final AgentInstrumentationExtension testing = AgentInstrumentationExtension.create();


### PR DESCRIPTION
upstream agent now 2.18.1 (needs some small internal test changes)
this distributions openai-client is turned off, leaving the upstream openai instrumentation to do the work (needed a couple of tests disabled)
