### PR TITLE
Add experimental composite samplers

### DIFF
--- a/custom/build.gradle.kts
+++ b/custom/build.gradle.kts
@@ -24,6 +24,11 @@ dependencies {
   compileOnly("io.opentelemetry.javaagent:opentelemetry-javaagent-tooling")
   compileOnly(libs.bundles.semconv)
 
+  implementation(libs.contribConsistentSampling) {
+    // exclude transitive dependency as it's provided through agent packaging
+    exclude(group = "io.opentelemetry", module = "opentelemetry-sdk-trace")
+    exclude(group = "io.opentelemetry", module = "opentelemetry-sdk-extension-autoconfigure-spi")
+  }
   implementation(libs.contribSpanStacktrace) {
     // exclude transitive dependency as it's provided through agent packaging
     exclude(group = "io.opentelemetry", module = "opentelemetry-sdk")

--- a/custom/src/main/java/co/elastic/otel/compositesampling/CompositeAlwaysOffSamplerProvider.java
+++ b/custom/src/main/java/co/elastic/otel/compositesampling/CompositeAlwaysOffSamplerProvider.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.otel.compositesampling;
+
+import com.google.auto.service.AutoService;
+import io.opentelemetry.contrib.sampler.consistent56.ConsistentSampler;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSamplerProvider;
+import io.opentelemetry.sdk.trace.samplers.Sampler;
+
+@AutoService(ConfigurableSamplerProvider.class)
+public class CompositeAlwaysOffSamplerProvider implements ConfigurableSamplerProvider {
+  @Override
+  public Sampler createSampler(ConfigProperties config) {
+    return ConsistentSampler.alwaysOff();
+  }
+
+  @Override
+  public String getName() {
+    return "experimental_composite_always_off";
+  }
+}

--- a/custom/src/main/java/co/elastic/otel/compositesampling/CompositeAlwaysOnSamplerProvider.java
+++ b/custom/src/main/java/co/elastic/otel/compositesampling/CompositeAlwaysOnSamplerProvider.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.otel.compositesampling;
+
+import com.google.auto.service.AutoService;
+import io.opentelemetry.contrib.sampler.consistent56.ConsistentSampler;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSamplerProvider;
+import io.opentelemetry.sdk.trace.samplers.Sampler;
+
+@AutoService(ConfigurableSamplerProvider.class)
+public class CompositeAlwaysOnSamplerProvider implements ConfigurableSamplerProvider {
+  @Override
+  public Sampler createSampler(ConfigProperties config) {
+    return ConsistentSampler.alwaysOn();
+  }
+
+  @Override
+  public String getName() {
+    return "experimental_composite_always_on";
+  }
+}

--- a/custom/src/main/java/co/elastic/otel/compositesampling/CompositeParentBasedAlwaysOffSamplerProvider.java
+++ b/custom/src/main/java/co/elastic/otel/compositesampling/CompositeParentBasedAlwaysOffSamplerProvider.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.otel.compositesampling;
+
+import com.google.auto.service.AutoService;
+import io.opentelemetry.contrib.sampler.consistent56.ConsistentSampler;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSamplerProvider;
+import io.opentelemetry.sdk.trace.samplers.Sampler;
+
+@AutoService(ConfigurableSamplerProvider.class)
+public class CompositeParentBasedAlwaysOffSamplerProvider implements ConfigurableSamplerProvider {
+
+  @Override
+  public Sampler createSampler(ConfigProperties config) {
+    return ConsistentSampler.parentBased(ConsistentSampler.alwaysOff());
+  }
+
+  @Override
+  public String getName() {
+    return "experimental_composite_parentbased_always_off";
+  }
+}

--- a/custom/src/main/java/co/elastic/otel/compositesampling/CompositeParentBasedAlwaysOnSamplerProvider.java
+++ b/custom/src/main/java/co/elastic/otel/compositesampling/CompositeParentBasedAlwaysOnSamplerProvider.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.otel.compositesampling;
+
+import com.google.auto.service.AutoService;
+import io.opentelemetry.contrib.sampler.consistent56.ConsistentSampler;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSamplerProvider;
+import io.opentelemetry.sdk.trace.samplers.Sampler;
+
+@AutoService(ConfigurableSamplerProvider.class)
+public class CompositeParentBasedAlwaysOnSamplerProvider implements ConfigurableSamplerProvider {
+
+  @Override
+  public Sampler createSampler(ConfigProperties config) {
+    return ConsistentSampler.parentBased(ConsistentSampler.alwaysOn());
+  }
+
+  @Override
+  public String getName() {
+    return "experimental_composite_parentbased_always_on";
+  }
+}

--- a/custom/src/main/java/co/elastic/otel/compositesampling/CompositeParentBasedTraceIdRatioBasedSamplerProvider.java
+++ b/custom/src/main/java/co/elastic/otel/compositesampling/CompositeParentBasedTraceIdRatioBasedSamplerProvider.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.otel.compositesampling;
+
+import com.google.auto.service.AutoService;
+import io.opentelemetry.contrib.sampler.consistent56.ConsistentSampler;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSamplerProvider;
+import io.opentelemetry.sdk.trace.samplers.Sampler;
+
+@AutoService(ConfigurableSamplerProvider.class)
+public class CompositeParentBasedTraceIdRatioBasedSamplerProvider
+    implements ConfigurableSamplerProvider {
+  private static final double DEFAULT_TRACEIDRATIO_SAMPLE_RATIO = 1.0d;
+
+  @Override
+  public Sampler createSampler(ConfigProperties config) {
+    return ConsistentSampler.parentBased(
+        ConsistentSampler.probabilityBased(
+            config.getDouble("otel.traces.sampler.arg", DEFAULT_TRACEIDRATIO_SAMPLE_RATIO)));
+  }
+
+  @Override
+  public String getName() {
+    return "experimental_composite_parentbased_traceidratio";
+  }
+}

--- a/custom/src/main/java/co/elastic/otel/compositesampling/CompositeTraceIdRatioBasedSamplerProvider.java
+++ b/custom/src/main/java/co/elastic/otel/compositesampling/CompositeTraceIdRatioBasedSamplerProvider.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.otel.compositesampling;
+
+import com.google.auto.service.AutoService;
+import io.opentelemetry.contrib.sampler.consistent56.ConsistentSampler;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSamplerProvider;
+import io.opentelemetry.sdk.trace.samplers.Sampler;
+
+@AutoService(ConfigurableSamplerProvider.class)
+public class CompositeTraceIdRatioBasedSamplerProvider implements ConfigurableSamplerProvider {
+  private static final double DEFAULT_TRACEIDRATIO_SAMPLE_RATIO = 1.0d;
+
+  @Override
+  public Sampler createSampler(ConfigProperties config) {
+    return ConsistentSampler.probabilityBased(
+        config.getDouble("otel.traces.sampler.arg", DEFAULT_TRACEIDRATIO_SAMPLE_RATIO));
+  }
+
+  @Override
+  public String getName() {
+    return "experimental_composite_traceidratio";
+  }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,6 +31,7 @@ opentelemetryInstrumentationAlphaBom = { group = "io.opentelemetry.instrumentati
 
 opentelemetryProto = { group = "io.opentelemetry.proto", name = "opentelemetry-proto", version.ref = "opentelemetryProto" }
 
+contribConsistentSampling = { group = "io.opentelemetry.contrib", name = "opentelemetry-consistent-sampling", version.ref = "opentelemetryContribAlpha" }
 contribResources = { group = "io.opentelemetry.contrib", name = "opentelemetry-resource-providers", version.ref = "opentelemetryContribAlpha" }
 contribSpanStacktrace = { group = "io.opentelemetry.contrib", name = "opentelemetry-span-stacktrace", version.ref = "opentelemetryContribAlpha" }
 contribInferredSpans = { group = "io.opentelemetry.contrib", name = "opentelemetry-inferred-spans", version.ref = "opentelemetryContribAlpha" }


### PR DESCRIPTION
This adds the contrib composite samplers to EDOT. There is interest from @AlexanderWert and others in being able to check sampling + representative count behavior end-to-end with EDOT, so sending this PR. One issue is there aren't any official env vars for it yet, so I prefaced with `experimental_composite_` to be able to use them initially. In the long term, the SDK will probably switch the samplers transparently to the new ones at which point they can be deprecated / removed.

Let me know what you think of the approach - whatever we decide on we would want to apply to other languages in the same way as the sampler implementations become available.