### PR TITLE
renovate ignore junit6 updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,6 +12,16 @@
         "io.opentelemetry.contrib:**"
       ],
       "enabled": false
+    },
+    {
+      "description": "junit 6+ requires Java 17+",
+      "matchPackageNames": [
+        "org.junit:**"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "enabled": false
     }
   ],
   "ignorePaths": [


### PR DESCRIPTION
ignore junit6 for now, back-ported from upstream:
- https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/14848