### PR TITLE
release changelog automation

### DIFF
--- a/.ci/ReleaseChangelog.java
+++ b/.ci/ReleaseChangelog.java
@@ -35,216 +35,234 @@ import java.util.regex.Pattern;
 
 public class ReleaseChangelog {
 
-    public static void main(String[] args) throws IOException {
-        if (args.length != 3) {
-            System.out.println("Expected exactly three arguments: <ChangelogFile> <ReleaseNotesPath> <VersionToRelease>");
-            System.exit(-1);
+  public static void main(String[] args) throws IOException {
+    if (args.length != 3) {
+      System.out.println(
+          "Expected exactly three arguments: <ChangelogFile> <ReleaseNotesPath> <VersionToRelease>");
+      System.exit(-1);
+    }
+    Path nextChangelogFile = Paths.get(args[0]);
+    Path releaseNotesDir = Paths.get(args[1]);
+    Path releaseNotesFile = releaseNotesDir.resolve("index.md");
+    Path deprecationsFile = releaseNotesDir.resolve("deprecations.md");
+    Path breakingChangesFile = releaseNotesDir.resolve("breaking-changes.md");
+    VersionNumber version = VersionNumber.parse(args[2].trim());
+
+    Lines nextChangelogLines = new Lines(
+        Files.readAllLines(nextChangelogFile, StandardCharsets.UTF_8));
+    Lines fixes = nextChangelogLines.cutLinesBetween("<!--FIXES-START-->", "<!--FIXES-END-->");
+    Lines enhancements = nextChangelogLines.cutLinesBetween("<!--ENHANCEMENTS-START-->",
+        "<!--ENHANCEMENTS-END-->");
+    Lines deprecations = nextChangelogLines.cutLinesBetween("<!--DEPRECATIONS-START-->",
+        "<!--DEPRECATIONS-END-->");
+    Lines breakingChanges = nextChangelogLines.cutLinesBetween("<!--BREAKING-CHANGES-START-->",
+        "<!--BREAKING-CHANGES-END-->");
+
+    var formatter = DateTimeFormatter.ofPattern("LLLL d, yyyy", Locale.ENGLISH);
+    String releaseDateLine = "**Release date:** " + formatter.format(LocalDate.now());
+
+    Lines allReleaseNotes = new Lines(Files.readAllLines(releaseNotesFile, StandardCharsets.UTF_8));
+    int insertBeforeLine = findHeadingOfPreviousVersion(allReleaseNotes, version);
+    allReleaseNotes.insert(generateReleaseNotes(version, releaseDateLine, enhancements, fixes),
+        insertBeforeLine);
+
+    if (!deprecations.isEmpty()) {
+      Lines allDeprecations = new Lines(
+          Files.readAllLines(deprecationsFile, StandardCharsets.UTF_8));
+      int insertDepsBeforeLine = findHeadingOfPreviousVersion(allDeprecations, version);
+      allDeprecations.insert(generateDeprecations(version, releaseDateLine, deprecations),
+          insertDepsBeforeLine);
+      Files.writeString(deprecationsFile, allDeprecations + "\n", StandardCharsets.UTF_8);
+    }
+    if (!breakingChanges.isEmpty()) {
+      Lines allBreakingChanges = new Lines(
+          Files.readAllLines(breakingChangesFile, StandardCharsets.UTF_8));
+      int insertBcBeforeLine = findHeadingOfPreviousVersion(allBreakingChanges, version);
+      allBreakingChanges.insert(generateBreakingChanges(version, releaseDateLine, breakingChanges),
+          insertBcBeforeLine);
+      Files.writeString(breakingChangesFile, allBreakingChanges + "\n", StandardCharsets.UTF_8);
+    }
+    Files.writeString(releaseNotesFile, allReleaseNotes + "\n", StandardCharsets.UTF_8);
+    Files.writeString(nextChangelogFile, nextChangelogLines + "\n", StandardCharsets.UTF_8);
+  }
+
+  private static Lines generateReleaseNotes(VersionNumber version, String releaseDateLine,
+      Lines enhancements, Lines fixes) {
+    Lines result = new Lines()
+        .append("## " + version.dotStr() + " [edot-java-" + version.dashStr() + "-release-notes]")
+        .append(releaseDateLine);
+    if (!enhancements.isEmpty()) {
+      result
+          .append("")
+          .append("### Features and enhancements [edot-java-" + version.dashStr()
+              + "-features-enhancements]")
+          .append(enhancements);
+    }
+    if (!fixes.isEmpty()) {
+      result
+          .append("")
+          .append("### Fixes [edot-java-" + version.dashStr() + "-fixes]")
+          .append(fixes);
+    }
+    result.append("");
+    return result;
+  }
+
+  private static Lines generateDeprecations(VersionNumber version, String releaseDateLine,
+      Lines deprecations) {
+    return new Lines()
+        .append("## " + version.dotStr() + " [edot-java-" + version.dashStr() + "-deprecations]")
+        .append(releaseDateLine)
+        .append("")
+        .append(deprecations)
+        .append("");
+  }
+
+  private static Lines generateBreakingChanges(VersionNumber version, String releaseDateLine,
+      Lines breakingChanges) {
+    return new Lines()
+        .append("## " + version.dotStr() + " [" + version.dotStr() + "]")
+        .append("")
+        .append(releaseDateLine)
+        .append("")
+        .append(breakingChanges)
+        .append("");
+  }
+
+  static int findHeadingOfPreviousVersion(Lines lines, VersionNumber version) {
+    Pattern headingPattern = Pattern.compile("## (\\d+\\.\\d+\\.\\d+) .*");
+    Comparator<VersionNumber> comp = VersionNumber.comparator();
+    int currentBestLineNo = -1;
+    VersionNumber currentBestVersion = null;
+    for (int i = 0; i < lines.lineCount(); i++) {
+      Matcher matcher = headingPattern.matcher(lines.getLine(i));
+      if (matcher.matches()) {
+        VersionNumber headingForVersion = VersionNumber.parse(matcher.group(1));
+        if (comp.compare(headingForVersion, version) < 0
+            && (currentBestVersion == null
+            || comp.compare(headingForVersion, currentBestVersion) > 0)) {
+          currentBestLineNo = i;
+          currentBestVersion = headingForVersion;
         }
-        Path nextChangelogFile = Paths.get(args[0]);
-        Path releaseNotesDir = Paths.get(args[1]);
-        Path releaseNotesFile = releaseNotesDir.resolve("index.md");
-        Path deprecationsFile = releaseNotesDir.resolve("deprecations.md");
-        Path breakingChangesFile = releaseNotesDir.resolve("breaking-changes.md");
-        VersionNumber version = VersionNumber.parse(args[2].trim());
+      }
+    }
+    return currentBestLineNo;
+  }
 
-        Lines nextChangelogLines = new Lines(Files.readAllLines(nextChangelogFile, StandardCharsets.UTF_8));
-        Lines fixes = nextChangelogLines.cutLinesBetween("<!--FIXES-START-->", "<!--FIXES-END-->");
-        Lines enhancements = nextChangelogLines.cutLinesBetween("<!--ENHANCEMENTS-START-->", "<!--ENHANCEMENTS-END-->");
-        Lines deprecations = nextChangelogLines.cutLinesBetween("<!--DEPRECATIONS-START-->", "<!--DEPRECATIONS-END-->");
-        Lines breakingChanges = nextChangelogLines.cutLinesBetween("<!--BREAKING-CHANGES-START-->", "<!--BREAKING-CHANGES-END-->");
-
-
-        var formatter = DateTimeFormatter.ofPattern("LLLL d, yyyy", Locale.ENGLISH);
-        String releaseDateLine = "**Release date:** " + formatter.format(LocalDate.now());
-
-        Lines allReleaseNotes = new Lines(Files.readAllLines(releaseNotesFile, StandardCharsets.UTF_8));
-        int insertBeforeLine = findHeadingOfPreviousVersion(allReleaseNotes, version);
-        allReleaseNotes.insert(generateReleaseNotes(version, releaseDateLine, enhancements, fixes), insertBeforeLine);
-
-        if (!deprecations.isEmpty()) {
-            Lines allDeprecations = new Lines(Files.readAllLines(deprecationsFile, StandardCharsets.UTF_8));
-            int insertDepsBeforeLine = findHeadingOfPreviousVersion(allDeprecations, version);
-            allDeprecations.insert(generateDeprecations(version, releaseDateLine, deprecations), insertDepsBeforeLine);
-            Files.writeString(deprecationsFile, allDeprecations + "\n", StandardCharsets.UTF_8);
-        }
-        if (!breakingChanges.isEmpty()) {
-            Lines allBreakingChanges = new Lines(Files.readAllLines(breakingChangesFile, StandardCharsets.UTF_8));
-            int insertBcBeforeLine = findHeadingOfPreviousVersion(allBreakingChanges, version);
-            allBreakingChanges.insert(generateBreakingChanges(version, releaseDateLine, breakingChanges), insertBcBeforeLine);
-            Files.writeString(breakingChangesFile, allBreakingChanges + "\n", StandardCharsets.UTF_8);
-        }
-        Files.writeString(releaseNotesFile, allReleaseNotes + "\n", StandardCharsets.UTF_8);
-        Files.writeString(nextChangelogFile, nextChangelogLines + "\n", StandardCharsets.UTF_8);
+  record VersionNumber(int major, int minor, int patch) {
+    public static VersionNumber parse (String versionString){
+      if (!versionString.matches("\\d+\\.\\d+\\.\\d+")) {
+        throw new IllegalArgumentException(
+            "Version must be in the format x.x.x but was not: " + versionString);
+      }
+      String[] parts = versionString.split("\\.");
+      return new VersionNumber(Integer.parseInt(parts[0]), Integer.parseInt(parts[1]),
+          Integer.parseInt(parts[2]));
     }
 
-    private static Lines generateReleaseNotes(VersionNumber version, String releaseDateLine, Lines enhancements, Lines fixes) {
-        Lines result = new Lines()
-            .append("## " + version.dotStr() + " [edot-java-" + version.dashStr() + "-release-notes]")
-            .append(releaseDateLine);
-        if (!enhancements.isEmpty()) {
-            result
-                .append("")
-                .append("### Features and enhancements [edot-java-" + version.dashStr() + "-features-enhancements]")
-                .append(enhancements);
-        }
-        if (!fixes.isEmpty()) {
-            result
-                .append("")
-                .append("### Fixes [edot-java-" + version.dashStr() + "-fixes]")
-                .append(fixes);
-        }
-        result.append("");
-        return result;
+    static Comparator<VersionNumber> comparator () {
+      return Comparator
+          .comparing(VersionNumber::major)
+          .thenComparing(VersionNumber::minor)
+          .thenComparing(VersionNumber::patch);
     }
 
-    private static Lines generateDeprecations(VersionNumber version, String releaseDateLine, Lines deprecations) {
-        return new Lines()
-            .append("## " + version.dotStr() + " [edot-java-" + version.dashStr() + "-deprecations]")
-            .append(releaseDateLine)
-            .append("")
-            .append(deprecations)
-            .append("");
+    String dashStr () {
+      return major + "-" + minor + "-" + patch;
     }
 
-    private static Lines generateBreakingChanges(VersionNumber version, String releaseDateLine, Lines breakingChanges) {
-        return new Lines()
-            .append("## " + version.dotStr() + " [" + version.dotStr() + "]")
-            .append("")
-            .append(releaseDateLine)
-            .append("")
-            .append(breakingChanges)
-            .append("");
+    String dotStr () {
+      return major + "." + minor + "." + patch;
     }
 
-    static int findHeadingOfPreviousVersion(Lines lines, VersionNumber version) {
-        Pattern headingPattern = Pattern.compile("## (\\d+\\.\\d+\\.\\d+) .*");
-        Comparator<VersionNumber> comp = VersionNumber.comparator();
-        int currentBestLineNo = -1;
-        VersionNumber currentBestVersion = null;
-        for (int i = 0; i < lines.lineCount(); i++) {
-            Matcher matcher = headingPattern.matcher(lines.getLine(i));
-            if (matcher.matches()) {
-                VersionNumber headingForVersion = VersionNumber.parse(matcher.group(1));
-                if (comp.compare(headingForVersion, version) < 0
-                    && (currentBestVersion == null || comp.compare(headingForVersion, currentBestVersion) > 0)) {
-                    currentBestLineNo = i;
-                    currentBestVersion = headingForVersion;
-                }
-            }
-        }
-        return currentBestLineNo;
+  }
+
+  static class Lines {
+
+    private final List<String> lines;
+
+    public Lines() {
+      this.lines = new ArrayList<>();
     }
 
-    record VersionNumber(int major, int minor, int patch) {
-        public static VersionNumber parse(String versionString) {
-            if (!versionString.matches("\\d+\\.\\d+\\.\\d+")) {
-                throw new IllegalArgumentException("Version must be in the format x.x.x but was not: " + versionString);
-            }
-            String[] parts = versionString.split("\\.");
-            return new VersionNumber(Integer.parseInt(parts[0]), Integer.parseInt(parts[1]), Integer.parseInt(parts[2]));
-        }
-
-        static Comparator<VersionNumber> comparator() {
-            return Comparator
-                .comparing(VersionNumber::major)
-                .thenComparing(VersionNumber::minor)
-                .thenComparing(VersionNumber::patch);
-        }
-
-        String dashStr() {
-            return major + "-" + minor + "-" + patch;
-        }
-
-        String dotStr() {
-            return major + "." + minor + "." + patch;
-        }
-
+    public Lines(List<String> lines) {
+      this.lines = new ArrayList<>(lines);
     }
 
-    static class Lines {
-
-        private final List<String> lines;
-
-        public Lines() {
-            this.lines = new ArrayList<>();
-        }
-
-        public Lines(List<String> lines) {
-            this.lines = new ArrayList<>(lines);
-        }
-
-        int lineCount() {
-            return lines.size();
-        }
-
-        boolean isEmpty() {
-            return lines.isEmpty();
-        }
-
-        Lines cutLinesBetween(String startLine, String endLine) {
-            int start = findLine(l -> l.trim().equals(startLine), 0)
-                .orElseThrow(() -> new IllegalStateException("Expected line '" + startLine + "' to exist"));
-            int end = findLine(l -> l.trim().equals(endLine), start + 1)
-                .orElseThrow(() -> new IllegalStateException("Expected line '" + endLine + "' to exist after '" + startLine + "'"));
-            Lines result = cut(start + 1, end).trim();
-
-            lines.add(start + 1, "");
-
-            return result;
-        }
-
-        OptionalInt findLine(Predicate<String> condition, int startAt) {
-            for (int i = startAt; i < lines.size(); i++) {
-                if (condition.test(lines.get(i))) {
-                    return OptionalInt.of(i);
-                }
-            }
-            return OptionalInt.empty();
-        }
-
-        Lines cut(int startInclusive, int endExclusive) {
-            List<String> cutLines = new ArrayList<>();
-            for (int i = startInclusive; i < endExclusive; i++) {
-                cutLines.add(lines.remove(startInclusive));
-            }
-            return new Lines(cutLines);
-        }
-
-        void insert(Lines other, int insertAt) {
-            this.lines.addAll(insertAt, other.lines);
-        }
-
-        Lines append(String line) {
-            lines.add(line);
-            return this;
-        }
-
-        Lines append(Lines toAppend) {
-            lines.addAll(toAppend.lines);
-            return this;
-        }
-
-        /**
-         * Trims lines consisting of only blanks at the top and bottom
-         */
-        Lines trim() {
-            while (!lines.isEmpty() && lines.get(0).matches("\\s*")) {
-                lines.remove(0);
-            }
-            while (!lines.isEmpty() && lines.get(lines.size() - 1).matches("\\s*")) {
-                lines.remove(lines.size() - 1);
-            }
-            return this;
-        }
-
-        @Override
-        public String toString() {
-            return String.join("\n", lines);
-        }
-
-        public String getLine(int number) {
-            return lines.get(number);
-        }
+    int lineCount() {
+      return lines.size();
     }
+
+    boolean isEmpty() {
+      return lines.isEmpty();
+    }
+
+    Lines cutLinesBetween(String startLine, String endLine) {
+      int start = findLine(l -> l.trim().equals(startLine), 0)
+          .orElseThrow(
+              () -> new IllegalStateException("Expected line '" + startLine + "' to exist"));
+      int end = findLine(l -> l.trim().equals(endLine), start + 1)
+          .orElseThrow(() -> new IllegalStateException(
+              "Expected line '" + endLine + "' to exist after '" + startLine + "'"));
+      Lines result = cut(start + 1, end).trim();
+
+      lines.add(start + 1, "");
+
+      return result;
+    }
+
+    OptionalInt findLine(Predicate<String> condition, int startAt) {
+      for (int i = startAt; i < lines.size(); i++) {
+        if (condition.test(lines.get(i))) {
+          return OptionalInt.of(i);
+        }
+      }
+      return OptionalInt.empty();
+    }
+
+    Lines cut(int startInclusive, int endExclusive) {
+      List<String> cutLines = new ArrayList<>();
+      for (int i = startInclusive; i < endExclusive; i++) {
+        cutLines.add(lines.remove(startInclusive));
+      }
+      return new Lines(cutLines);
+    }
+
+    void insert(Lines other, int insertAt) {
+      this.lines.addAll(insertAt, other.lines);
+    }
+
+    Lines append(String line) {
+      lines.add(line);
+      return this;
+    }
+
+    Lines append(Lines toAppend) {
+      lines.addAll(toAppend.lines);
+      return this;
+    }
+
+    /**
+     * Trims lines consisting of only blanks at the top and bottom
+     */
+    Lines trim() {
+      while (!lines.isEmpty() && lines.get(0).matches("\\s*")) {
+        lines.remove(0);
+      }
+      while (!lines.isEmpty() && lines.get(lines.size() - 1).matches("\\s*")) {
+        lines.remove(lines.size() - 1);
+      }
+      return this;
+    }
+
+    @Override
+    public String toString() {
+      return String.join("\n", lines);
+    }
+
+    public String getLine(int number) {
+      return lines.get(number);
+    }
+  }
 
 }

--- a/.ci/ReleaseChangelog.java
+++ b/.ci/ReleaseChangelog.java
@@ -64,7 +64,7 @@ public class ReleaseChangelog {
     Lines allReleaseNotes = new Lines(Files.readAllLines(releaseNotesFile, StandardCharsets.UTF_8));
     int insertBeforeLine = findHeadingOfPreviousVersion(allReleaseNotes, version);
     if(insertBeforeLine < 0){
-      insertBeforeLine = allReleaseNotes.lineCount() + 1;
+      insertBeforeLine = allReleaseNotes.lineCount();
     }
     allReleaseNotes.insert(generateReleaseNotes(version, releaseDateLine, enhancements, fixes),
         insertBeforeLine);
@@ -75,7 +75,7 @@ public class ReleaseChangelog {
       int insertDepsBeforeLine = findHeadingOfPreviousVersion(allDeprecations, version);
       if(insertDepsBeforeLine < 0){
         // in case no previous version was listed
-        insertDepsBeforeLine = allDeprecations.lineCount() + 1;
+        insertDepsBeforeLine = allDeprecations.lineCount();
       }
       allDeprecations.insert(generateDeprecations(version, releaseDateLine, deprecations),
           insertDepsBeforeLine);
@@ -87,7 +87,7 @@ public class ReleaseChangelog {
       int insertBcBeforeLine = findHeadingOfPreviousVersion(allBreakingChanges, version);
       if (insertBcBeforeLine < 0) {
         // in case no previous version was listed
-        insertBcBeforeLine = allBreakingChanges.lineCount() - 1;
+        insertBcBeforeLine = allBreakingChanges.lineCount();
       }
       allBreakingChanges.insert(generateBreakingChanges(version, releaseDateLine, breakingChanges),
           insertBcBeforeLine);

--- a/.ci/ReleaseChangelog.java
+++ b/.ci/ReleaseChangelog.java
@@ -66,7 +66,7 @@ public class ReleaseChangelog {
     if(insertBeforeLine < 0){
       insertBeforeLine = allReleaseNotes.lineCount();
     }
-    allReleaseNotes.insert(generateReleaseNotes(version, releaseDateLine, enhancements, fixes),
+    allReleaseNotes.insert(generateReleaseNotes(version, releaseDateLine, enhancements, fixes, breakingChanges),
         insertBeforeLine);
 
     if (!deprecations.isEmpty()) {
@@ -98,7 +98,7 @@ public class ReleaseChangelog {
   }
 
   private static Lines generateReleaseNotes(VersionNumber version, String releaseDateLine,
-      Lines enhancements, Lines fixes) {
+      Lines enhancements, Lines fixes, Lines breaking) {
     Lines result = new Lines()
         .append("## " + version.dotStr() + " [edot-java-" + version.dashStr() + "-release-notes]")
         .append(releaseDateLine);
@@ -114,6 +114,12 @@ public class ReleaseChangelog {
           .append("")
           .append("### Fixes [edot-java-" + version.dashStr() + "-fixes]")
           .append(fixes);
+    }
+    if(!breaking.isEmpty()){
+      result
+          .append("")
+          .append("### Breaking changes [edot-java-" + version.dashStr() + "-fixes]")
+          .append(breaking);
     }
     result.append("");
     return result;

--- a/.ci/ReleaseChangelog.java
+++ b/.ci/ReleaseChangelog.java
@@ -1,0 +1,250 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.OptionalInt;
+import java.util.function.Predicate;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class ReleaseChangelog {
+
+    public static void main(String[] args) throws IOException {
+        if (args.length != 3) {
+            System.out.println("Expected exactly three arguments: <ChangelogFile> <ReleaseNotesPath> <VersionToRelease>");
+            System.exit(-1);
+        }
+        Path nextChangelogFile = Paths.get(args[0]);
+        Path releaseNotesDir = Paths.get(args[1]);
+        Path releaseNotesFile = releaseNotesDir.resolve("index.md");
+        Path deprecationsFile = releaseNotesDir.resolve("deprecations.md");
+        Path breakingChangesFile = releaseNotesDir.resolve("breaking-changes.md");
+        VersionNumber version = VersionNumber.parse(args[2].trim());
+
+        Lines nextChangelogLines = new Lines(Files.readAllLines(nextChangelogFile, StandardCharsets.UTF_8));
+        Lines fixes = nextChangelogLines.cutLinesBetween("<!--FIXES-START-->", "<!--FIXES-END-->");
+        Lines enhancements = nextChangelogLines.cutLinesBetween("<!--ENHANCEMENTS-START-->", "<!--ENHANCEMENTS-END-->");
+        Lines deprecations = nextChangelogLines.cutLinesBetween("<!--DEPRECATIONS-START-->", "<!--DEPRECATIONS-END-->");
+        Lines breakingChanges = nextChangelogLines.cutLinesBetween("<!--BREAKING-CHANGES-START-->", "<!--BREAKING-CHANGES-END-->");
+
+
+        var formatter = DateTimeFormatter.ofPattern("LLLL d, yyyy", Locale.ENGLISH);
+        String releaseDateLine = "**Release date:** " + formatter.format(LocalDate.now());
+
+        Lines allReleaseNotes = new Lines(Files.readAllLines(releaseNotesFile, StandardCharsets.UTF_8));
+        int insertBeforeLine = findHeadingOfPreviousVersion(allReleaseNotes, version);
+        allReleaseNotes.insert(generateReleaseNotes(version, releaseDateLine, enhancements, fixes), insertBeforeLine);
+
+        if (!deprecations.isEmpty()) {
+            Lines allDeprecations = new Lines(Files.readAllLines(deprecationsFile, StandardCharsets.UTF_8));
+            int insertDepsBeforeLine = findHeadingOfPreviousVersion(allDeprecations, version);
+            allDeprecations.insert(generateDeprecations(version, releaseDateLine, deprecations), insertDepsBeforeLine);
+            Files.writeString(deprecationsFile, allDeprecations + "\n", StandardCharsets.UTF_8);
+        }
+        if (!breakingChanges.isEmpty()) {
+            Lines allBreakingChanges = new Lines(Files.readAllLines(breakingChangesFile, StandardCharsets.UTF_8));
+            int insertBcBeforeLine = findHeadingOfPreviousVersion(allBreakingChanges, version);
+            allBreakingChanges.insert(generateBreakingChanges(version, releaseDateLine, breakingChanges), insertBcBeforeLine);
+            Files.writeString(breakingChangesFile, allBreakingChanges + "\n", StandardCharsets.UTF_8);
+        }
+        Files.writeString(releaseNotesFile, allReleaseNotes + "\n", StandardCharsets.UTF_8);
+        Files.writeString(nextChangelogFile, nextChangelogLines + "\n", StandardCharsets.UTF_8);
+    }
+
+    private static Lines generateReleaseNotes(VersionNumber version, String releaseDateLine, Lines enhancements, Lines fixes) {
+        Lines result = new Lines()
+            .append("## " + version.dotStr() + " [edot-java-" + version.dashStr() + "-release-notes]")
+            .append(releaseDateLine);
+        if (!enhancements.isEmpty()) {
+            result
+                .append("")
+                .append("### Features and enhancements [edot-java-" + version.dashStr() + "-features-enhancements]")
+                .append(enhancements);
+        }
+        if (!fixes.isEmpty()) {
+            result
+                .append("")
+                .append("### Fixes [edot-java-" + version.dashStr() + "-fixes]")
+                .append(fixes);
+        }
+        result.append("");
+        return result;
+    }
+
+    private static Lines generateDeprecations(VersionNumber version, String releaseDateLine, Lines deprecations) {
+        return new Lines()
+            .append("## " + version.dotStr() + " [edot-java-" + version.dashStr() + "-deprecations]")
+            .append(releaseDateLine)
+            .append("")
+            .append(deprecations)
+            .append("");
+    }
+
+    private static Lines generateBreakingChanges(VersionNumber version, String releaseDateLine, Lines breakingChanges) {
+        return new Lines()
+            .append("## " + version.dotStr() + " [" + version.dotStr() + "]")
+            .append("")
+            .append(releaseDateLine)
+            .append("")
+            .append(breakingChanges)
+            .append("");
+    }
+
+    static int findHeadingOfPreviousVersion(Lines lines, VersionNumber version) {
+        Pattern headingPattern = Pattern.compile("## (\\d+\\.\\d+\\.\\d+) .*");
+        Comparator<VersionNumber> comp = VersionNumber.comparator();
+        int currentBestLineNo = -1;
+        VersionNumber currentBestVersion = null;
+        for (int i = 0; i < lines.lineCount(); i++) {
+            Matcher matcher = headingPattern.matcher(lines.getLine(i));
+            if (matcher.matches()) {
+                VersionNumber headingForVersion = VersionNumber.parse(matcher.group(1));
+                if (comp.compare(headingForVersion, version) < 0
+                    && (currentBestVersion == null || comp.compare(headingForVersion, currentBestVersion) > 0)) {
+                    currentBestLineNo = i;
+                    currentBestVersion = headingForVersion;
+                }
+            }
+        }
+        return currentBestLineNo;
+    }
+
+    record VersionNumber(int major, int minor, int patch) {
+        public static VersionNumber parse(String versionString) {
+            if (!versionString.matches("\\d+\\.\\d+\\.\\d+")) {
+                throw new IllegalArgumentException("Version must be in the format x.x.x but was not: " + versionString);
+            }
+            String[] parts = versionString.split("\\.");
+            return new VersionNumber(Integer.parseInt(parts[0]), Integer.parseInt(parts[1]), Integer.parseInt(parts[2]));
+        }
+
+        static Comparator<VersionNumber> comparator() {
+            return Comparator
+                .comparing(VersionNumber::major)
+                .thenComparing(VersionNumber::minor)
+                .thenComparing(VersionNumber::patch);
+        }
+
+        String dashStr() {
+            return major + "-" + minor + "-" + patch;
+        }
+
+        String dotStr() {
+            return major + "." + minor + "." + patch;
+        }
+
+    }
+
+    static class Lines {
+
+        private final List<String> lines;
+
+        public Lines() {
+            this.lines = new ArrayList<>();
+        }
+
+        public Lines(List<String> lines) {
+            this.lines = new ArrayList<>(lines);
+        }
+
+        int lineCount() {
+            return lines.size();
+        }
+
+        boolean isEmpty() {
+            return lines.isEmpty();
+        }
+
+        Lines cutLinesBetween(String startLine, String endLine) {
+            int start = findLine(l -> l.trim().equals(startLine), 0)
+                .orElseThrow(() -> new IllegalStateException("Expected line '" + startLine + "' to exist"));
+            int end = findLine(l -> l.trim().equals(endLine), start + 1)
+                .orElseThrow(() -> new IllegalStateException("Expected line '" + endLine + "' to exist after '" + startLine + "'"));
+            Lines result = cut(start + 1, end).trim();
+
+            lines.add(start + 1, "");
+
+            return result;
+        }
+
+        OptionalInt findLine(Predicate<String> condition, int startAt) {
+            for (int i = startAt; i < lines.size(); i++) {
+                if (condition.test(lines.get(i))) {
+                    return OptionalInt.of(i);
+                }
+            }
+            return OptionalInt.empty();
+        }
+
+        Lines cut(int startInclusive, int endExclusive) {
+            List<String> cutLines = new ArrayList<>();
+            for (int i = startInclusive; i < endExclusive; i++) {
+                cutLines.add(lines.remove(startInclusive));
+            }
+            return new Lines(cutLines);
+        }
+
+        void insert(Lines other, int insertAt) {
+            this.lines.addAll(insertAt, other.lines);
+        }
+
+        Lines append(String line) {
+            lines.add(line);
+            return this;
+        }
+
+        Lines append(Lines toAppend) {
+            lines.addAll(toAppend.lines);
+            return this;
+        }
+
+        /**
+         * Trims lines consisting of only blanks at the top and bottom
+         */
+        Lines trim() {
+            while (!lines.isEmpty() && lines.get(0).matches("\\s*")) {
+                lines.remove(0);
+            }
+            while (!lines.isEmpty() && lines.get(lines.size() - 1).matches("\\s*")) {
+                lines.remove(lines.size() - 1);
+            }
+            return this;
+        }
+
+        @Override
+        public String toString() {
+            return String.join("\n", lines);
+        }
+
+        public String getLine(int number) {
+            return lines.get(number);
+        }
+    }
+
+}

--- a/.ci/ReleaseChangelog.java
+++ b/.ci/ReleaseChangelog.java
@@ -63,6 +63,9 @@ public class ReleaseChangelog {
 
     Lines allReleaseNotes = new Lines(Files.readAllLines(releaseNotesFile, StandardCharsets.UTF_8));
     int insertBeforeLine = findHeadingOfPreviousVersion(allReleaseNotes, version);
+    if(insertBeforeLine < 0){
+      insertBeforeLine = allReleaseNotes.lineCount() + 1;
+    }
     allReleaseNotes.insert(generateReleaseNotes(version, releaseDateLine, enhancements, fixes),
         insertBeforeLine);
 
@@ -70,6 +73,10 @@ public class ReleaseChangelog {
       Lines allDeprecations = new Lines(
           Files.readAllLines(deprecationsFile, StandardCharsets.UTF_8));
       int insertDepsBeforeLine = findHeadingOfPreviousVersion(allDeprecations, version);
+      if(insertDepsBeforeLine < 0){
+        // in case no previous version was listed
+        insertDepsBeforeLine = allDeprecations.lineCount() + 1;
+      }
       allDeprecations.insert(generateDeprecations(version, releaseDateLine, deprecations),
           insertDepsBeforeLine);
       Files.writeString(deprecationsFile, allDeprecations + "\n", StandardCharsets.UTF_8);
@@ -78,6 +85,10 @@ public class ReleaseChangelog {
       Lines allBreakingChanges = new Lines(
           Files.readAllLines(breakingChangesFile, StandardCharsets.UTF_8));
       int insertBcBeforeLine = findHeadingOfPreviousVersion(allBreakingChanges, version);
+      if (insertBcBeforeLine < 0) {
+        // in case no previous version was listed
+        insertBcBeforeLine = allBreakingChanges.lineCount() - 1;
+      }
       allBreakingChanges.insert(generateBreakingChanges(version, releaseDateLine, breakingChanges),
           insertBcBeforeLine);
       Files.writeString(breakingChangesFile, allBreakingChanges + "\n", StandardCharsets.UTF_8);

--- a/.ci/ReleaseChangelog.java
+++ b/.ci/ReleaseChangelog.java
@@ -58,6 +58,9 @@ public class ReleaseChangelog {
     Lines breakingChanges = nextChangelogLines.cutLinesBetween("<!--BREAKING-CHANGES-START-->",
         "<!--BREAKING-CHANGES-END-->");
 
+    Lines dependenciesNotes = nextChangelogLines.cutLinesBetween("<!--DEPENDENCIES-NOTES-START-->",
+        "<!--DEPENDENCIES-NOTES-END-->");
+
     var formatter = DateTimeFormatter.ofPattern("LLLL d, yyyy", Locale.ENGLISH);
     String releaseDateLine = "**Release date:** " + formatter.format(LocalDate.now());
 
@@ -66,7 +69,9 @@ public class ReleaseChangelog {
     if (insertBeforeLine < 0) {
       insertBeforeLine = allReleaseNotes.lineCount();
     }
-    allReleaseNotes.insert(generateReleaseNotes(version, releaseDateLine, enhancements, fixes, breakingChanges),
+    allReleaseNotes.insert(
+        generateReleaseNotes(version, releaseDateLine, enhancements, fixes, breakingChanges,
+            dependenciesNotes),
         insertBeforeLine);
 
     if (!deprecations.isEmpty()) {
@@ -98,7 +103,7 @@ public class ReleaseChangelog {
   }
 
   private static Lines generateReleaseNotes(VersionNumber version, String releaseDateLine,
-      Lines enhancements, Lines fixes, Lines breaking) {
+      Lines enhancements, Lines fixes, Lines breaking, Lines dependenciesNotes) {
     Lines result = new Lines()
         .append("## " + version.dotStr() + " [edot-java-" + version.dashStr() + "-release-notes]")
         .append(releaseDateLine);
@@ -120,6 +125,11 @@ public class ReleaseChangelog {
           .append("")
           .append("### Breaking changes [edot-java-" + version.dashStr() + "-fixes]")
           .append(breaking);
+    }
+    if (!dependenciesNotes.isEmpty()) {
+      result
+          .append("")
+          .append(dependenciesNotes);
     }
     result.append("");
     return result;

--- a/.ci/ReleaseChangelog.java
+++ b/.ci/ReleaseChangelog.java
@@ -63,7 +63,7 @@ public class ReleaseChangelog {
 
     Lines allReleaseNotes = new Lines(Files.readAllLines(releaseNotesFile, StandardCharsets.UTF_8));
     int insertBeforeLine = findHeadingOfPreviousVersion(allReleaseNotes, version);
-    if(insertBeforeLine < 0){
+    if (insertBeforeLine < 0) {
       insertBeforeLine = allReleaseNotes.lineCount();
     }
     allReleaseNotes.insert(generateReleaseNotes(version, releaseDateLine, enhancements, fixes, breakingChanges),
@@ -73,7 +73,7 @@ public class ReleaseChangelog {
       Lines allDeprecations = new Lines(
           Files.readAllLines(deprecationsFile, StandardCharsets.UTF_8));
       int insertDepsBeforeLine = findHeadingOfPreviousVersion(allDeprecations, version);
-      if(insertDepsBeforeLine < 0){
+      if (insertDepsBeforeLine < 0) {
         // in case no previous version was listed
         insertDepsBeforeLine = allDeprecations.lineCount();
       }
@@ -115,7 +115,7 @@ public class ReleaseChangelog {
           .append("### Fixes [edot-java-" + version.dashStr() + "-fixes]")
           .append(fixes);
     }
-    if(!breaking.isEmpty()){
+    if (!breaking.isEmpty()) {
       result
           .append("")
           .append("### Breaking changes [edot-java-" + version.dashStr() + "-fixes]")

--- a/.github/workflows/pre-post-release.yml
+++ b/.github/workflows/pre-post-release.yml
@@ -100,21 +100,10 @@ jobs:
         with:
           command: ./gradlew -q setNextVersion
 
-      - name: Insert notes into cumulative changelog (post release)
+      - name: Generate documentation changelog (post release)
         if: inputs.phase == 'post'
         run: |
-          echo "# ${VERSION} - $(date +'%d/%m/%Y')" > tmpchangelog
-          echo "${CHANGELOG}" >> tmpchangelog
-          cat CHANGELOG.md >> tmpchangelog
-          mv tmpchangelog CHANGELOG.md
-        env:
-          VERSION: ${{ inputs.version }}
-          CHANGELOG: ${{ inputs.changelog }}
-
-      - name: Clear next release changelog (post release)
-        if: inputs.phase == 'post'
-        run: |
-          echo '' > CHANGELOG.next-release.md
+          java .ci/ReleaseChangelog.java CHANGELOG.next-release.md docs/release-notes ${{ env.RELEASE_VERSION }}
   
       - name: Push the ${{ inputs.phase }} release branch
         run: |

--- a/.github/workflows/pre-post-release.yml
+++ b/.github/workflows/pre-post-release.yml
@@ -26,11 +26,6 @@ on:
         description: 'pull-request body'
         type: string
         required: true
-      changelog:
-        description: 'The changelog to prepend to CHANGELOG.md without heading'
-        type: string
-        required: false
-        default: ''
 
 env:
   RELEASE_VERSION: ${{ inputs.version }}

--- a/.github/workflows/pre-post-release.yml
+++ b/.github/workflows/pre-post-release.yml
@@ -98,8 +98,10 @@ jobs:
       - name: Generate documentation changelog (post release)
         if: inputs.phase == 'post'
         run: |
-          echo -e "\nThis release is based on the following upstream versions:\n\n" >> CHANGELOG.next-release.md
+          echo '<!--DEPENDENCIES-NOTES-START-->' >> CHANGELOG.next-release.md
+          echo -e "This release is based on the following upstream versions:\n\n" >> CHANGELOG.next-release.md
           ./gradlew -q printUpstreamDependenciesMarkdown >> CHANGELOG.next-release.md
+          echo '<!--DEPENDENCIES-NOTES-END-->' >> CHANGELOG.next-release.md
           java .ci/ReleaseChangelog.java CHANGELOG.next-release.md docs/release-notes ${{ env.RELEASE_VERSION }}
   
       - name: Push the ${{ inputs.phase }} release branch

--- a/.github/workflows/pre-post-release.yml
+++ b/.github/workflows/pre-post-release.yml
@@ -98,6 +98,8 @@ jobs:
       - name: Generate documentation changelog (post release)
         if: inputs.phase == 'post'
         run: |
+          echo -e "\nThis release is based on the following upstream versions:\n\n" >> CHANGELOG.next-release.md
+          ./gradlew -q printUpstreamDependenciesMarkdown >> CHANGELOG.next-release.md
           java .ci/ReleaseChangelog.java CHANGELOG.next-release.md docs/release-notes ${{ env.RELEASE_VERSION }}
   
       - name: Push the ${{ inputs.phase }} release branch

--- a/.github/workflows/release-step-3.yml
+++ b/.github/workflows/release-step-3.yml
@@ -218,6 +218,8 @@ jobs:
           command: ""
       - name: Print Release Notes
         id: print_release_notes
+        # note: release notes here will be copied as-is from 'CHANGELOG.next-release.md'
+        # the 'pre-post-release' workflow executed after this will reset contents of 'CHANGELOG.next-release.md'
         run: |
           echo 'notes<<RELNOTESEOF' >> $GITHUB_OUTPUT
           cat CHANGELOG.next-release.md >> $GITHUB_OUTPUT

--- a/CHANGELOG.next-release.md
+++ b/CHANGELOG.next-release.md
@@ -26,11 +26,4 @@ This file contains all changes which are not released yet.
 <!--BREAKING-CHANGES-START-->
 * Switch to upstream instrumentation of openai by default #763
 
-::::{dropdown} OpenAI instrumentation switched from openai-client to openai
-In OpenTelemetry Java agent version 2.18.0, an `openai` instrumentation module was added. This conflicted with the `openai-client` instrumentation module that was implemented in the EDOT agent. Since the `openai` module is on by default, we switched off the `openai-client` instrumentation module (previously on by default). The functionality is broadly the same.
-**Impact**<br> Small changes in span names and attributes expected. If the elastic specific `ELASTIC_OTEL_JAVA_INSTRUMENTATION_GENAI_EMIT_EVENTS` was previously set to true, this would no longer produce events.
-**Action**<br> The equivalent of `ELASTIC_OTEL_JAVA_INSTRUMENTATION_GENAI_EMIT_EVENTS` is `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT`. If you want to revert entirely to the previous setup, turn off the upstream implementation and turn on the EDOT one. For example: `OTEL_INSTRUMENTATION_OPENAI=false` and `OTEL_INSTRUMENTATION_OPENAI_CLIENT=true`
-View [PR #763](https://github.com/elastic/elastic-otel-java/pull/763).
-::::
-
 <!--BREAKING-CHANGES-END-->

--- a/CHANGELOG.next-release.md
+++ b/CHANGELOG.next-release.md
@@ -26,4 +26,11 @@ This file contains all changes which are not released yet.
 <!--BREAKING-CHANGES-START-->
 * Switch to upstream instrumentation of openai by default #763
 
+::::{dropdown} OpenAI instrumentation switched from openai-client to openai
+In OpenTelemetry Java agent version 2.18.0, an `openai` instrumentation module was added. This conflicted with the `openai-client` instrumentation module that was implemented in the EDOT agent. Since the `openai` module is on by default, we switched off the `openai-client` instrumentation module (previously on by default). The functionality is broadly the same.
+**Impact**<br> Small changes in span names and attributes expected. If the elastic specific `ELASTIC_OTEL_JAVA_INSTRUMENTATION_GENAI_EMIT_EVENTS` was previously set to true, this would no longer produce events.
+**Action**<br> The equivalent of `ELASTIC_OTEL_JAVA_INSTRUMENTATION_GENAI_EMIT_EVENTS` is `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT`. If you want to revert entirely to the previous setup, turn off the upstream implementation and turn on the EDOT one. For example: `OTEL_INSTRUMENTATION_OPENAI=false` and `OTEL_INSTRUMENTATION_OPENAI_CLIENT=true`
+View [PR #763](https://github.com/elastic/elastic-otel-java/pull/763).
+::::
+
 <!--BREAKING-CHANGES-END-->

--- a/CHANGELOG.next-release.md
+++ b/CHANGELOG.next-release.md
@@ -1,3 +1,29 @@
+This file contains all changes which are not released yet.
+<!--
+ Note that the content between the marker comment lines (e.g. FIXES-START/END) will be automatically
+ moved into the docs/release-notes markdown files on release (via the .ci/ReleaseChangelog.java script).
+ Simply add the changes as bullet points into those sections, empty lines will be ignored. Example:
+
+* Description of the change - [#1234](https://github.com/elastic/apm-agent-java/pull/1234)
+-->
+
+# Fixes
+<!--FIXES-START-->
+
+<!--FIXES-END-->
+# Features and enhancements
+<!--ENHANCEMENTS-START-->
 * Add support for dynamic configuration options for 9.2 #818
 * Switch upstream Opamp client #789
+
+<!--ENHANCEMENTS-END-->
+# Deprecations
+<!--DEPRECATIONS-START-->
+
+<!--DEPRECATIONS-END-->
+
+# Breaking Changes
+<!--BREAKING-CHANGES-START-->
 * Switch to upstream instrumentation of openai by default #763
+
+<!--BREAKING-CHANGES-END-->

--- a/docs/release-notes/breaking-changes.md
+++ b/docs/release-notes/breaking-changes.md
@@ -27,10 +27,3 @@ Breaking changes can impact your applications, potentially disrupting normal ope
 % View [PR #](PR link).
 % ::::
 % TEMPLATE END
-
-::::{dropdown} OpenAI instrumentation switched from openai-client to openai
-In OpenTelemetry Java agent version 2.18.0, an `openai` instrumentation module was added. This conflicted with the `openai-client` instrumentation module that was implemented in the EDOT agent. Since the `openai` module is on by default, we switched off the `openai-client` instrumentation module (previously on by default). The functionality is broadly the same.
-**Impact**<br> Small changes in span names and attributes expected. If the elastic specific `ELASTIC_OTEL_JAVA_INSTRUMENTATION_GENAI_EMIT_EVENTS` was previously set to true, this would no longer produce events.
-**Action**<br> The equivalent of `ELASTIC_OTEL_JAVA_INSTRUMENTATION_GENAI_EMIT_EVENTS` is `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT`. If you want to revert entirely to the previous setup, turn off the upstream implementation and turn on the EDOT one. For example: `OTEL_INSTRUMENTATION_OPENAI=false` and `OTEL_INSTRUMENTATION_OPENAI_CLIENT=true`
-View [PR #763](https://github.com/elastic/elastic-otel-java/pull/763).
-::::

--- a/docs/release-notes/breaking-changes.md
+++ b/docs/release-notes/breaking-changes.md
@@ -27,3 +27,10 @@ Breaking changes can impact your applications, potentially disrupting normal ope
 % View [PR #](PR link).
 % ::::
 % TEMPLATE END
+
+::::{dropdown} OpenAI instrumentation switched from openai-client to openai
+In OpenTelemetry Java agent version 2.18.0, an `openai` instrumentation module was added. This conflicted with the `openai-client` instrumentation module that was implemented in the EDOT agent. Since the `openai` module is on by default, we switched off the `openai-client` instrumentation module (previously on by default). The functionality is broadly the same.
+**Impact**<br> Small changes in span names and attributes expected. If the elastic specific `ELASTIC_OTEL_JAVA_INSTRUMENTATION_GENAI_EMIT_EVENTS` was previously set to true, this would no longer produce events.
+**Action**<br> The equivalent of `ELASTIC_OTEL_JAVA_INSTRUMENTATION_GENAI_EMIT_EVENTS` is `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT`. If you want to revert entirely to the previous setup, turn off the upstream implementation and turn on the EDOT one. For example: `OTEL_INSTRUMENTATION_OPENAI=false` and `OTEL_INSTRUMENTATION_OPENAI_CLIENT=true`
+View [PR #763](https://github.com/elastic/elastic-otel-java/pull/763).
+::::

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -27,7 +27,7 @@ To check for security updates, go to [Security announcements for the Elastic sta
 % ### Fixes [edot-java-X.X.X-fixes]
 % *
 
-# 1.5.0 [edot-java-1.5.0-release-notes]
+## 1.5.0 [edot-java-1.5.0-release-notes]
 
 ### Features and enhancements [edot-java-1.5.0-features-enhancements]
 


### PR DESCRIPTION
Fixes https://github.com/elastic/elastic-otel-java/issues/692

This is a first step to improve release automation, there are definitely rough edges and future improvements will be necessary. In particular, it adds an `DEPENDENCIES-NOTES` section at runtime to include the dependencies versions. In the future maybe managing everything within gradle would be cleaner and more reliable.

We can test it locally for the release 1.6.0 in the current state of main by running the following commands:

```bash
echo '<!--DEPENDENCIES-NOTES-START-->' >> CHANGELOG.next-release.md
echo -e "This release is based on the following upstream versions:\n\n" >> CHANGELOG.next-release.md
./gradlew -q printUpstreamDependenciesMarkdown >> CHANGELOG.next-release.md
echo '<!--DEPENDENCIES-NOTES-END-->' >> CHANGELOG.next-release.md

java \
.ci/ReleaseChangelog.java \
CHANGELOG.next-release.md \
docs/release-notes 1.6.0

```
