### PR TITLE
enable indy by default

### DIFF
--- a/custom/src/main/java/co/elastic/otel/ElasticAutoConfigurationCustomizerProvider.java
+++ b/custom/src/main/java/co/elastic/otel/ElasticAutoConfigurationCustomizerProvider.java
@@ -61,6 +61,7 @@ public class ElasticAutoConfigurationCustomizerProvider
       AttributeKey.stringKey("deployment.environment");
   private static final AttributeKey<String> DEPLOYMENT =
       AttributeKey.stringKey("deployment.environment.name");
+  private static final String OTEL_JAVAAGENT_EXPERIMENTAL_INDY = "otel.javaagent.experimental.indy";
 
   @Override
   public void customize(AutoConfigurationCustomizer autoConfiguration) {
@@ -107,6 +108,7 @@ public class ElasticAutoConfigurationCustomizerProvider
     defaultSampler(config, configProperties);
     ConfigLoggingAgentListener.logTheConfig(
         configProperties.getBoolean(ConfigLoggingAgentListener.LOG_THE_CONFIG, true));
+    indyInstrumentation(config, configProperties);
 
     return config;
   }
@@ -173,5 +175,11 @@ public class ElasticAutoConfigurationCustomizerProvider
     }
 
     config.put(STACKTRACE_OTEL_FILTER, SpanStackTraceFilter.class.getName());
+  }
+
+  private static void indyInstrumentation(
+      Map<String, String> config, ConfigProperties configProperties) {
+    boolean enabled = configProperties.getBoolean(OTEL_JAVAAGENT_EXPERIMENTAL_INDY, true);
+    config.put(OTEL_JAVAAGENT_EXPERIMENTAL_INDY, Boolean.toString(enabled));
   }
 }


### PR DESCRIPTION
This is part of the next steps to enable indy by default in upstream as suggested here: https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/13031#issuecomment-3496353158

We are enabling this by default in EDOT, in case of an unexpected behavior it is still possible to revert to the previous behavior by setting `otel.javaagent.experimental.indy=false` (or using `OTEL_JAVAAGENT_EXPERIMENTAL_INDY` environment variable).