### PR TITLE
add indy by default in changelog

### DIFF
--- a/CHANGELOG.next-release.md
+++ b/CHANGELOG.next-release.md
@@ -13,7 +13,7 @@ This file contains all changes which are not released yet.
 <!--FIXES-END-->
 # Features and enhancements
 <!--ENHANCEMENTS-START-->
-
+* Enable indy delegation by default - [#899](https://github.com/elastic/apm-agent-java/pull/899)
 <!--ENHANCEMENTS-END-->
 # Deprecations
 <!--DEPRECATIONS-START-->


### PR DESCRIPTION
I forgot to update changelog in #899 , this is necessary before 1.8.0 release.