### PR TITLE
Docs: Update applies_to syntax

### DIFF
--- a/docs/reference/edot-java/configuration.md
+++ b/docs/reference/edot-java/configuration.md
@@ -78,8 +78,9 @@ This table only contains minimal configuration, see each respective feature for 
 
 
 ## Elasticsearch Java client: Capturing search request bodies
+
 ```{applies_to}
-stack: ga 9.0, ga 8.0
+stack: ga 9.0+
 ```
 
 When using the {{es}} Java API client, spans for {{es}} operations are generated directly by the client’s built-in OpenTelemetry instrumentation.

--- a/docs/reference/edot-java/setup/runtime-attach.md
+++ b/docs/reference/edot-java/setup/runtime-attach.md
@@ -6,7 +6,7 @@ applies_to:
   serverless:
     observability:
   product:
-    edot_java: ga
+    edot_java: preview 1.0+
 products:
   - id: cloud-serverless
   - id: observability
@@ -14,10 +14,6 @@ products:
 ---
 
 # Instrumenting Java applications using the EDOT Java runtime attach
-
-```{applies_to}
-product: preview
-```
 
 Runtime attach includes the EDOT instrumentation agent in the application binary. This allows deploying the agent when access to JVM arguments or configuration is not possible, for example, with some managed services. The application development team can control the agent deployment and update cycle without having to modify the execution environment. Runtime attach only requires a minor modification of the application main entry point and one additional dependency.
 


### PR DESCRIPTION
Clean up `applies_to` in preparation for https://github.com/elastic/docs-builder/pull/2322.

This PR should only be merged after https://github.com/elastic/docs-builder/pull/2322 is merged.

Contributes to https://github.com/elastic/docs-content/issues/4361