### PR TITLE
github-actions: artifact-metadata=write

### DIFF
--- a/.github/workflows/release-step-3.yml
+++ b/.github/workflows/release-step-3.yml
@@ -72,6 +72,7 @@ jobs:
     needs:
       - validate-tag
     permissions:
+      artifact-metadata: write
       attestations: write
       contents: write
       id-token: write
@@ -131,6 +132,7 @@ jobs:
     env:
       DOCKER_IMAGE_NAME: docker.elastic.co/observability/elastic-otel-javaagent
     permissions:
+      artifact-metadata: write
       attestations: write
       contents: read
       id-token: write

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -43,6 +43,7 @@ jobs:
     needs: 
       - validate
     permissions:
+      artifact-metadata: write
       attestations: write
       contents: write
       id-token: write


### PR DESCRIPTION
> The attestations permission is necessary to persist the attestation. The artifact-metadata permission is required to generate artifact metadata storage records

https://github.com/marketplace/actions/attest-build-provenance#usage


Let's take advantage of the new feature:
- https://github.blog/changelog/2026-01-20-strengthen-your-supply-chain-with-code-to-cloud-traceability-and-slsa-build-level-3-security/