### PR TITLE
docs: improve EDOT Java migration guide for accuracy & structure

### DIFF
--- a/docs/reference/edot-java/migration.md
+++ b/docs/reference/edot-java/migration.md
@@ -58,7 +58,7 @@ The following describes how Elastic {{product.apm}} Java agent configuration map
 
 ### Resource attributes when using the EDOT Collector
 
-Ingesting OpenTelemetry data directly through {{product.apm-server}} is [no longer supported](opentelemetry://reference/architecture.md#limitations). Historically, when ingesting OpenTelemetry data through the Elastic {{product.apm-server}}, unmapped resource attributes were added under `labels.*`. This behavior does not apply when using the EDOT Collector and is not recommended for new deployments. Use the EDOT Collector or Managed OTLP for supported ingestion.
+Ingesting OpenTelemetry data directly through {{product.apm-server}} is [no longer supported](opentelemetry://reference/architecture/index.md#limitations). Historically, when ingesting OpenTelemetry data through the Elastic {{product.apm-server}}, unmapped resource attributes were added under `labels.*`. This behavior does not apply when using the EDOT Collector and is not recommended for new deployments. Use the EDOT Collector or Managed OTLP for supported ingestion.
 
 If you rely on specific attribute mappings for querying or filtering in {{product.observability}}, configure explicit attribute processors in the EDOT Collector pipeline.
 


### PR DESCRIPTION
## Summary

Updates the EDOT Java migration guide for clearer structure and more accurate placement of configuration content.

## Changes

- Adds a dedicated subsection "Resource attributes when using the EDOT Collector" at the start of Configuration mapping 
- Adds a "No equivalent for `application_packages`" section

Relates to [5001](https://github.com/elastic/docs-content/issues/5001)