### PR TITLE
pin artemis JMS server to preserve java8 compatibility

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -22,6 +22,13 @@
         "major"
       ],
       "enabled": false
+    },
+    {
+      "description": "keep old artemis version to preserve java8 compatibility in tests",
+      "matchPackageNames": [
+        "org.apache.activemq:artemis-jms-server"
+      ],
+      "enabled": false
     }
   ],
   "ignorePaths": [


### PR DESCRIPTION
Should avoid PRs like #970 (which should auto-close when this gets merged).