### PR TITLE
fix(ci): pre-install Semeru JDK for OpenJ9 test matrix entries

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,6 +95,15 @@ jobs:
           path: ./
       - name: Untar cached build working directory
         run: "tar -xvf working-dir-build-cache.tar.gz"
+      # Workaround for https://github.com/foojayio/discoapi/issues/143
+      # The foojay disco API has a broken redirect for Semeru JDK 25, so we pre-install it
+      # for Gradle's toolchain auto-detection to find locally.
+      - name: Pre-install Semeru JDK
+        if: matrix.vm == 'openj9'
+        uses: actions/setup-java@v4
+        with:
+          distribution: semeru
+          java-version: ${{ matrix.version }}
       - name: Run tests
         uses: ./.github/workflows/gradle-goal
         with:


### PR DESCRIPTION
## Summary

- Work around a broken redirect in the [foojay disco API](https://github.com/foojayio/discoapi/issues/143) that prevents Gradle from auto-provisioning IBM Semeru (OpenJ9) JDK 25.
- Pre-install the Semeru JDK via `actions/setup-java` for all OpenJ9 matrix entries so Gradle's toolchain auto-detection finds it locally, bypassing the broken foojay download.

## Context

The foojay API resolves `{languageVersion=25, implementation=J9}` to IBM Semeru JDK `25.0.2.1`, but the redirect URL points to the wrong GitHub release tag (`jdk-25.0.2+10_openj9-0.57.0` instead of `jdk-25.0.2+10.1_openj9-0.57.0`), resulting in a 404. This has been causing `test (25, openj9)` failures since Feb 26.

## Test plan

- [x] Verify `test (25, openj9)` passes in the CI run for this PR
- [x] Verify other OpenJ9 matrix entries (11, 21) are unaffected

Made with [Cursor](https://cursor.com)