### PR TITLE
fix(ci): add --retry-all-errors to musl toolchain download

### DIFF
--- a/jvmti-access/jni-build/jni_linux_musl_x64.Dockerfile
+++ b/jvmti-access/jni-build/jni_linux_musl_x64.Dockerfile
@@ -9,7 +9,7 @@ ENV CROSS_TRIPLE x86_64-linux-musl
 ENV CROSS_ROOT ${XCC_PREFIX}/${CROSS_TRIPLE}-cross
 
 RUN mkdir -p ${XCC_PREFIX}
-RUN curl --max-time 180 --retry 5 -LO https://github.com/JonasKunz/musl-x86_64-cross/raw/3aeb31dcddb450822e02b7d432c567873dc8c26b/x86_64-linux-musl-cross.tgz
+RUN curl --max-time 180 --retry 5 --retry-all-errors --retry-delay 10 -LO https://github.com/JonasKunz/musl-x86_64-cross/raw/3aeb31dcddb450822e02b7d432c567873dc8c26b/x86_64-linux-musl-cross.tgz
 # Verify that the downloaded file has not been altered via sha256 checksum
 RUN test "$(sha256sum -b ${CROSS_TRIPLE}-cross.tgz)" = "c5d410d9f82a4f24c549fe5d24f988f85b2679b452413a9f7e5f7b956f2fe7ea *${CROSS_TRIPLE}-cross.tgz"
 


### PR DESCRIPTION
## Summary
- The `build` job has been failing intermittently on `:jvmti-access:buildCompilerImageLinuxMuslX64` because the `curl` download of the ~109MB musl cross-compilation toolchain from GitHub LFS gets cut off near completion with `curl: (18) transfer closed with N bytes remaining to read`.
- The existing `--retry 5` flag was **not retrying** because curl only considers timeouts and HTTP 408/429/5xx as "transient errors" — exit code 18 (`CURLE_PARTIAL_FILE`) is not in that list.
- This adds `--retry-all-errors` so curl retries on **any** error (including partial transfers), and `--retry-delay 10` to space out retries and give the server time to recover.

This was observed on both PR #976 and on `main` (run [22630375120](https://github.com/elastic/elastic-otel-java/actions/runs/22630375120)).

## Test plan
- [x] Verify the Dockerfile change is syntactically correct
- [ ] Confirm the next CI build of this PR passes the `buildCompilerImageLinuxMuslX64` task

Made with [Cursor](https://cursor.com)