### PR TITLE
[ci] move upstream update script to .ci

### DIFF
--- a/.ci/update-upstream.sh
+++ b/.ci/update-upstream.sh
@@ -5,7 +5,8 @@ set -euo pipefail
 upstreamRef="${1:-main}"
 
 upstream_base_url="https://raw.githubusercontent.com/open-telemetry/opentelemetry-java-instrumentation/${upstreamRef}"
-folder="$(dirname "${0}")"
+# libs.versions.toml lives in gradle/; this script is under .ci/
+folder="$(dirname "${0}")/../gradle"
 
 upstream_version() {
     set +e

--- a/.ci/updatecli.d/bump-upstream-agent-version.yml
+++ b/.ci/updatecli.d/bump-upstream-agent-version.yml
@@ -55,7 +55,7 @@ targets:
     scmid: githubConfig
     spec:
       # We do the echo add the end to let updatecli know that there have been changes
-      command: gradle/update-upstream.sh v{{ source "upstream-agent-version" }} && echo "Update successful"
+      command: .ci/update-upstream.sh v{{ source "upstream-agent-version" }} && echo "Update successful"
 
 actions:
   open-pr:

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,15 +10,15 @@ log4j2 = "2.25.4"
 opentelemetryProto = "1.3.2-alpha"
 
 # otel agent, we rely on the '*-alpha' and get the non-alpha dependencies transitively
-# updated from upstream agent with gradle/update-upstream.sh
+# updated from upstream agent with .ci/update-upstream.sh
 opentelemetryJavaagentAlpha = "2.26.1-alpha"
 
 # otel contrib
-# updated from upstream agent with gradle/update-upstream.sh
+# updated from upstream agent with .ci/update-upstream.sh
 opentelemetryContribAlpha = "1.54.0-alpha"
 
 # otel semconv
-# updated from upstream agent with gradle/update-upstream.sh
+# updated from upstream agent with .ci/update-upstream.sh
 # While the semconv stable/incubating artifacts are provided as transitive dependencies, keeping
 # an explicit version here allows to easily override to a not-yet-released version.
 opentelemetrySemconv = "1.40.0"

--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,7 @@
   ],
   "packageRules": [
     {
-      "description": "Upstream agent dependencies are kept in sync via the gradle/update-upstream.sh script",
+      "description": "Upstream agent dependencies are kept in sync via the .ci/update-upstream.sh script",
       "matchPackageNames": [
         "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha",
         "io.opentelemetry.semconv:**",


### PR DESCRIPTION
this moves the script to update upstream dependencies next to other CI related scripts for consistency.

currently opened as draft as I'm using to test automatic changelog yaml addition (which currently fails as time of writing).