### PR TITLE
[changelog] add release dates + descriptions to existing releases bundles

### DIFF
--- a/docs/changelog.yml
+++ b/docs/changelog.yml
@@ -38,6 +38,7 @@ bundle:
   resolve: true
   repo: elastic-otel-java
   owner: elastic
+  release_dates: true
 
   profiles:
     edot-java-release:

--- a/docs/releases/1.0.0.yaml
+++ b/docs/releases/1.0.0.yaml
@@ -4,6 +4,7 @@ products:
   lifecycle: ga
   repo: elastic-otel-java
   owner: elastic
+release-date: '2024-09-02'
 entries:
 - file:
     name: 1774534599-first-ga-release.yaml

--- a/docs/releases/1.1.0.yaml
+++ b/docs/releases/1.1.0.yaml
@@ -4,6 +4,7 @@ products:
   lifecycle: ga
   repo: elastic-otel-java
   owner: elastic
+release-date: '2024-11-21'
 entries:
 - file:
     name: 455.yaml

--- a/docs/releases/1.1.0.yaml
+++ b/docs/releases/1.1.0.yaml
@@ -5,6 +5,13 @@ products:
   repo: elastic-otel-java
   owner: elastic
 release-date: '2024-11-21'
+description: |-
+  This release is based on the following upstream versions:
+
+  * opentelemetry-javaagent: [2.10.0](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v2.10.0).
+  * opentelemetry-sdk: [1.44.1](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.44.1).
+  * opentelemetry-semconv: [1.28.0](https://github.com/open-telemetry/semantic-conventions-java/releases/tag/v1.28.0).
+  * opentelemetry-java-contrib: [1.40.0](https://github.com/open-telemetry/opentelemetry-java-contrib/releases/tag/v1.40.0).
 entries:
 - file:
     name: 455.yaml

--- a/docs/releases/1.10.0.yaml
+++ b/docs/releases/1.10.0.yaml
@@ -5,6 +5,13 @@ products:
   repo: elastic-otel-java
   owner: elastic
 release-date: '2026-03-24'
+description: |-
+  This release is based on the following upstream versions:
+
+  * opentelemetry-javaagent: [2.26.1](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v2.26.1)
+  * opentelemetry-sdk: [1.60.1](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.60.1)
+  * opentelemetry-semconv: [1.40.0](https://github.com/open-telemetry/semantic-conventions-java/releases/tag/v1.40.0)
+  * opentelemetry-java-contrib: [1.54.0](https://github.com/open-telemetry/opentelemetry-java-contrib/releases/tag/v1.54.0)
 entries:
 - file:
     name: upstream-update.yaml

--- a/docs/releases/1.10.0.yaml
+++ b/docs/releases/1.10.0.yaml
@@ -4,6 +4,7 @@ products:
   lifecycle: ga
   repo: elastic-otel-java
   owner: elastic
+release-date: '2026-03-24'
 entries:
 - file:
     name: upstream-update.yaml

--- a/docs/releases/1.2.0.yaml
+++ b/docs/releases/1.2.0.yaml
@@ -5,6 +5,13 @@ products:
   repo: elastic-otel-java
   owner: elastic
 release-date: '2025-01-20'
+description: |-
+  This release is based on the following upstream versions:
+
+  * opentelemetry-javaagent: [2.12.0](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v2.12.0).
+  * opentelemetry-sdk: [1.46.0](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.46.0)
+  * opentelemetry-semconv: [1.29.0](https://github.com/open-telemetry/semantic-conventions-java/releases/tag/v1.29.0).
+  * opentelemetry-java-contrib: [1.42.0](https://github.com/open-telemetry/opentelemetry-java-contrib/releases/tag/v1.42.0).
 entries:
 - file:
     name: 497.yaml

--- a/docs/releases/1.2.0.yaml
+++ b/docs/releases/1.2.0.yaml
@@ -4,6 +4,7 @@ products:
   lifecycle: ga
   repo: elastic-otel-java
   owner: elastic
+release-date: '2025-01-20'
 entries:
 - file:
     name: 497.yaml

--- a/docs/releases/1.2.1.yaml
+++ b/docs/releases/1.2.1.yaml
@@ -5,6 +5,13 @@ products:
   repo: elastic-otel-java
   owner: elastic
 release-date: '2025-01-23'
+description: |-
+  This release is based on the following upstream versions:
+
+  * opentelemetry-javaagent: [2.12.0](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v2.12.0).
+  * opentelemetry-sdk: [1.46.0](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.46.0).
+  * opentelemetry-semconv: [1.29.0](https://github.com/open-telemetry/semantic-conventions-java/releases/tag/v1.29.0).
+  * opentelemetry-java-contrib: [1.42.0](https://github.com/open-telemetry/opentelemetry-java-contrib/releases/tag/v1.42.0).
 entries:
 - file:
     name: 514.yaml

--- a/docs/releases/1.2.1.yaml
+++ b/docs/releases/1.2.1.yaml
@@ -4,6 +4,7 @@ products:
   lifecycle: ga
   repo: elastic-otel-java
   owner: elastic
+release-date: '2025-01-23'
 entries:
 - file:
     name: 514.yaml

--- a/docs/releases/1.3.0.yaml
+++ b/docs/releases/1.3.0.yaml
@@ -4,6 +4,7 @@ products:
   lifecycle: ga
   repo: elastic-otel-java
   owner: elastic
+release-date: '2025-03-10'
 entries:
 - file:
     name: 564.yaml

--- a/docs/releases/1.3.0.yaml
+++ b/docs/releases/1.3.0.yaml
@@ -5,6 +5,13 @@ products:
   repo: elastic-otel-java
   owner: elastic
 release-date: '2025-03-10'
+description: |-
+  This release is based on the following upstream versions:
+
+  * opentelemetry-javaagent: [2.13.3](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v2.13.3).
+  * opentelemetry-sdk: [1.47.0](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.47.0).
+  * opentelemetry-semconv: [1.30.0-rc.1](https://github.com/open-telemetry/semantic-conventions-java/releases/tag/v1.30.0-rc.1).
+  * opentelemetry-java-contrib: [1.44.0](https://github.com/open-telemetry/opentelemetry-java-contrib/releases/tag/v1.44.0).
 entries:
 - file:
     name: 564.yaml

--- a/docs/releases/1.4.0.yaml
+++ b/docs/releases/1.4.0.yaml
@@ -5,6 +5,13 @@ products:
   repo: elastic-otel-java
   owner: elastic
 release-date: '2025-04-15'
+description: |-
+  This release is based on the following upstream versions:
+
+  * opentelemetry-javaagent: [2.15.0](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v2.15.0).
+  * opentelemetry-sdk: [1.49.0](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.49.0).
+  * opentelemetry-semconv: [1.32.0](https://github.com/open-telemetry/semantic-conventions-java/releases/tag/v1.32.0).
+  * opentelemetry-java-contrib: [1.45.0](https://github.com/open-telemetry/opentelemetry-java-contrib/releases/tag/v1.45.0).
 entries:
 - file:
     name: 583.yaml

--- a/docs/releases/1.4.0.yaml
+++ b/docs/releases/1.4.0.yaml
@@ -4,6 +4,7 @@ products:
   lifecycle: ga
   repo: elastic-otel-java
   owner: elastic
+release-date: '2025-04-15'
 entries:
 - file:
     name: 583.yaml

--- a/docs/releases/1.4.1.yaml
+++ b/docs/releases/1.4.1.yaml
@@ -5,6 +5,13 @@ products:
   repo: elastic-otel-java
   owner: elastic
 release-date: '2025-04-16'
+description: |-
+  This release is based on the following upstream versions:
+
+  * opentelemetry-javaagent: [2.15.0](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v2.15.0).
+  * opentelemetry-sdk: [1.49.0](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.49.0).
+  * opentelemetry-semconv: [1.32.0](https://github.com/open-telemetry/semantic-conventions-java/releases/tag/v1.32.0).
+  * opentelemetry-java-contrib: [1.45.0](https://github.com/open-telemetry/opentelemetry-java-contrib/releases/tag/v1.45.0).
 entries:
 - file:
     name: 610.yaml

--- a/docs/releases/1.4.1.yaml
+++ b/docs/releases/1.4.1.yaml
@@ -4,6 +4,7 @@ products:
   lifecycle: ga
   repo: elastic-otel-java
   owner: elastic
+release-date: '2025-04-16'
 entries:
 - file:
     name: 610.yaml

--- a/docs/releases/1.5.0.yaml
+++ b/docs/releases/1.5.0.yaml
@@ -5,6 +5,13 @@ products:
   repo: elastic-otel-java
   owner: elastic
 release-date: '2025-07-28'
+description: |-
+  This release is based on the following upstream versions:
+
+  * opentelemetry-javaagent: [2.17.1](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v2.17.1)
+  * opentelemetry-sdk: [1.51.0](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.51.0)
+  * opentelemetry-semconv: [1.34.0](https://github.com/open-telemetry/semantic-conventions-java/releases/tag/v1.34.0)
+  * opentelemetry-java-contrib: [1.46.0](https://github.com/open-telemetry/opentelemetry-java-contrib/releases/tag/v1.46.0)
 entries:
 - file:
     name: 1774965825-tech-preview-release-of-central-configuration-supp.yaml

--- a/docs/releases/1.5.0.yaml
+++ b/docs/releases/1.5.0.yaml
@@ -4,6 +4,7 @@ products:
   lifecycle: ga
   repo: elastic-otel-java
   owner: elastic
+release-date: '2025-07-28'
 entries:
 - file:
     name: 1774965825-tech-preview-release-of-central-configuration-supp.yaml

--- a/docs/releases/1.6.0.yaml
+++ b/docs/releases/1.6.0.yaml
@@ -4,6 +4,7 @@ products:
   lifecycle: ga
   repo: elastic-otel-java
   owner: elastic
+release-date: '2025-10-06'
 entries:
 - file:
     name: 818.yaml

--- a/docs/releases/1.6.0.yaml
+++ b/docs/releases/1.6.0.yaml
@@ -5,6 +5,13 @@ products:
   repo: elastic-otel-java
   owner: elastic
 release-date: '2025-10-06'
+description: |-
+  This release is based on the following upstream versions:
+
+  * opentelemetry-javaagent: [2.20.1](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v2.20.1)
+  * opentelemetry-sdk: [1.54.1](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.54.1)
+  * opentelemetry-semconv: [1.37.0](https://github.com/open-telemetry/semantic-conventions-java/releases/tag/v1.37.0)
+  * opentelemetry-java-contrib: [1.49.0](https://github.com/open-telemetry/opentelemetry-java-contrib/releases/tag/v1.49.0)
 entries:
 - file:
     name: 818.yaml

--- a/docs/releases/1.7.0.yaml
+++ b/docs/releases/1.7.0.yaml
@@ -5,6 +5,13 @@ products:
   repo: elastic-otel-java
   owner: elastic
 release-date: '2025-11-05'
+description: |-
+  This release is based on the following upstream versions:
+
+  * opentelemetry-javaagent: [2.21.0](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v2.21.0)
+  * opentelemetry-sdk: [1.55.0](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.55.0)
+  * opentelemetry-semconv: [1.37.0](https://github.com/open-telemetry/semantic-conventions-java/releases/tag/v1.37.0)
+  * opentelemetry-java-contrib: [1.50.0](https://github.com/open-telemetry/opentelemetry-java-contrib/releases/tag/v1.50.0)
 entries:
 - file:
     name: 835.yaml

--- a/docs/releases/1.7.0.yaml
+++ b/docs/releases/1.7.0.yaml
@@ -4,6 +4,7 @@ products:
   lifecycle: ga
   repo: elastic-otel-java
   owner: elastic
+release-date: '2025-11-05'
 entries:
 - file:
     name: 835.yaml

--- a/docs/releases/1.8.0.yaml
+++ b/docs/releases/1.8.0.yaml
@@ -4,6 +4,7 @@ products:
   lifecycle: ga
   repo: elastic-otel-java
   owner: elastic
+release-date: '2025-12-09'
 entries:
 - file:
     name: 899.yaml

--- a/docs/releases/1.9.0.yaml
+++ b/docs/releases/1.9.0.yaml
@@ -4,6 +4,7 @@ products:
   lifecycle: ga
   repo: elastic-otel-java
   owner: elastic
+release-date: '2026-02-09'
 entries:
 - file:
     name: 958.yaml


### PR DESCRIPTION
the release date is getting added to docs-builder in https://github.com/elastic/docs-builder/pull/3066

This PR just adds existing releases dates to the yaml so release dates can be rendered when the feature is available and deployed.

EDIT: thanks to @lcawl this PR now also enables generating release dates at release time.

EDIT: currently blocked on waiting for the 1.6.0 release of docs-builder as the `release_dates` option is not supported until then in changelog config https://github.com/elastic/elastic-otel-java/pull/1048#discussion_r3100782782.