### PR TITLE
declarative config: set distro + user-agent

### DIFF
--- a/custom/build.gradle.kts
+++ b/custom/build.gradle.kts
@@ -71,6 +71,7 @@ dependencies {
   testImplementation("io.opentelemetry:opentelemetry-sdk-testing")
   testImplementation(libs.freemarker)
   testImplementation(libs.wiremockjre8)
+  testImplementation(libs.jsonunitassertj)
 }
 
 tasks {

--- a/custom/build.gradle.kts
+++ b/custom/build.gradle.kts
@@ -23,6 +23,7 @@ dependencies {
   }
 
   compileOnly("io.opentelemetry:opentelemetry-sdk")
+  compileOnly("io.opentelemetry:opentelemetry-api-incubator")
   compileOnly("io.opentelemetry:opentelemetry-exporter-otlp")
   compileOnly("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi")
   compileOnly("io.opentelemetry.javaagent:opentelemetry-javaagent-extension-api")

--- a/custom/build.gradle.kts
+++ b/custom/build.gradle.kts
@@ -26,6 +26,7 @@ dependencies {
   compileOnly("io.opentelemetry:opentelemetry-api-incubator")
   compileOnly("io.opentelemetry:opentelemetry-exporter-otlp")
   compileOnly("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi")
+  compileOnly("io.opentelemetry:opentelemetry-sdk-extension-incubator")
   compileOnly("io.opentelemetry.javaagent:opentelemetry-javaagent-extension-api")
   compileOnly("io.opentelemetry.javaagent:opentelemetry-javaagent-tooling")
   compileOnly(libs.bundles.semconv)
@@ -55,8 +56,10 @@ dependencies {
   // test dependencies
   testImplementation(project(":testing-common"))
   testImplementation("io.opentelemetry:opentelemetry-sdk")
+  testImplementation("io.opentelemetry:opentelemetry-api-incubator")
   testImplementation("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure")
   testImplementation("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi")
+  testImplementation("io.opentelemetry:opentelemetry-sdk-extension-incubator")
   testImplementation("io.opentelemetry:opentelemetry-exporter-otlp")
   testImplementation("io.opentelemetry.javaagent:opentelemetry-javaagent-tooling") {
     //The following dependency isn't actually needed, but breaks the classpath when testing with Java 8

--- a/custom/src/main/java/co/elastic/otel/ElasticDistroResource.java
+++ b/custom/src/main/java/co/elastic/otel/ElasticDistroResource.java
@@ -18,20 +18,31 @@
  */
 package co.elastic.otel;
 
-import com.google.auto.service.AutoService;
-import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
-import io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.javaagent.tooling.AgentVersion;
 import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.semconv.incubating.TelemetryIncubatingAttributes;
 
-/**
- * Provides {@code telemetry.distro.name} and {@code telemetry.distro.version} resource attributes
- * for automatic configuration
- */
-@AutoService(ResourceProvider.class)
-public class ElasticDistroResourceProvider implements ResourceProvider {
+public class ElasticDistroResource {
 
-  @Override
-  public Resource createResource(ConfigProperties configProperties) {
-    return ElasticDistroResource.get();
+  private ElasticDistroResource() {}
+
+  public static Resource get() {
+    if (AgentVersion.VERSION == null) {
+      return Resource.empty();
+    }
+    try {
+      Class.forName("co.elastic.otel.agent.ElasticAgent");
+    } catch (ClassNotFoundException e) {
+      // this means that we are running as an extension of the vanilla agent
+      // and not as distro.
+      return Resource.empty();
+    }
+    return Resource.create(
+        Attributes.of(
+            TelemetryIncubatingAttributes.TELEMETRY_DISTRO_NAME,
+            "elastic",
+            TelemetryIncubatingAttributes.TELEMETRY_DISTRO_VERSION,
+            AgentVersion.VERSION));
   }
 }

--- a/custom/src/main/java/co/elastic/otel/ElasticUserAgentHeader.java
+++ b/custom/src/main/java/co/elastic/otel/ElasticUserAgentHeader.java
@@ -32,17 +32,17 @@ import io.opentelemetry.sdk.trace.export.SpanExporter;
 /** set User-Agent for automatic configuration */
 public class ElasticUserAgentHeader {
 
-  private static final String HEADER_NAME = "User-Agent";
-  private static final String GRPC_VALUE = "elastic-otlp-grpc-java/" + AgentVersion.VERSION;
-  private static final String HTTP_VALUE = "elastic-otlp-http-java/" + AgentVersion.VERSION;
+  public static final String HEADER_NAME = "User-Agent";
+  public static final String OTLP_GRPC = "elastic-otlp-grpc-java/" + AgentVersion.VERSION;
+  public static final String OTLP_HTTP = "elastic-otlp-http-java/" + AgentVersion.VERSION;
 
   public static SpanExporter configureIfPossible(SpanExporter spanExporter) {
     if (spanExporter instanceof OtlpGrpcSpanExporter) {
       return ((OtlpGrpcSpanExporter) spanExporter)
-          .toBuilder().addHeader(HEADER_NAME, GRPC_VALUE).build();
+          .toBuilder().addHeader(HEADER_NAME, OTLP_GRPC).build();
     } else if (spanExporter instanceof OtlpHttpSpanExporter) {
       return ((OtlpHttpSpanExporter) spanExporter)
-          .toBuilder().addHeader(HEADER_NAME, HTTP_VALUE).build();
+          .toBuilder().addHeader(HEADER_NAME, OTLP_HTTP).build();
     }
     return spanExporter;
   }
@@ -50,10 +50,10 @@ public class ElasticUserAgentHeader {
   public static MetricExporter configureIfPossible(MetricExporter metricExporter) {
     if (metricExporter instanceof OtlpGrpcMetricExporter) {
       return ((OtlpGrpcMetricExporter) metricExporter)
-          .toBuilder().addHeader(HEADER_NAME, GRPC_VALUE).build();
+          .toBuilder().addHeader(HEADER_NAME, OTLP_GRPC).build();
     } else if (metricExporter instanceof OtlpHttpMetricExporter) {
       return ((OtlpHttpMetricExporter) metricExporter)
-          .toBuilder().addHeader(HEADER_NAME, HTTP_VALUE).build();
+          .toBuilder().addHeader(HEADER_NAME, OTLP_HTTP).build();
     }
     return metricExporter;
   }
@@ -61,10 +61,10 @@ public class ElasticUserAgentHeader {
   public static LogRecordExporter configureIfPossible(LogRecordExporter logExporter) {
     if (logExporter instanceof OtlpGrpcLogRecordExporter) {
       return ((OtlpGrpcLogRecordExporter) logExporter)
-          .toBuilder().addHeader(HEADER_NAME, GRPC_VALUE).build();
+          .toBuilder().addHeader(HEADER_NAME, OTLP_GRPC).build();
     } else if (logExporter instanceof OtlpHttpLogRecordExporter) {
       return ((OtlpHttpLogRecordExporter) logExporter)
-          .toBuilder().addHeader(HEADER_NAME, HTTP_VALUE).build();
+          .toBuilder().addHeader(HEADER_NAME, OTLP_HTTP).build();
     }
     return logExporter;
   }

--- a/custom/src/main/java/co/elastic/otel/ElasticUserAgentHeader.java
+++ b/custom/src/main/java/co/elastic/otel/ElasticUserAgentHeader.java
@@ -29,6 +29,7 @@ import io.opentelemetry.sdk.logs.export.LogRecordExporter;
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 
+/** set User-Agent for automatic configuration */
 public class ElasticUserAgentHeader {
 
   private static final String HEADER_NAME = "User-Agent";

--- a/custom/src/main/java/co/elastic/otel/declarativeconfig/ElasticDeclarativeConfigurationCustomizer.java
+++ b/custom/src/main/java/co/elastic/otel/declarativeconfig/ElasticDeclarativeConfigurationCustomizer.java
@@ -18,11 +18,13 @@
  */
 package co.elastic.otel.declarativeconfig;
 
+import static co.elastic.otel.ElasticUserAgentHeader.OTLP_GRPC;
+import static co.elastic.otel.ElasticUserAgentHeader.OTLP_HTTP;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toSet;
+import static jdk.internal.net.http.HttpRequestImpl.USER_AGENT;
 
 import com.google.auto.service.AutoService;
-import io.opentelemetry.javaagent.tooling.AgentVersion;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.DeclarativeConfigurationCustomizer;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.DeclarativeConfigurationCustomizerProvider;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.BatchLogRecordProcessorModel;
@@ -55,10 +57,6 @@ import javax.annotation.Nullable;
 @AutoService(DeclarativeConfigurationCustomizerProvider.class)
 public class ElasticDeclarativeConfigurationCustomizer
     implements DeclarativeConfigurationCustomizerProvider {
-
-  private static final String USER_AGENT = "User-Agent";
-  private static final String OTLP_GRPC = "elastic-otlp-grpc-java/" + AgentVersion.VERSION;
-  private static final String OTLP_HTTP = "elastic-otlp-http-java/" + AgentVersion.VERSION;
 
   @Override
   public void customize(DeclarativeConfigurationCustomizer customizer) {

--- a/custom/src/main/java/co/elastic/otel/declarativeconfig/ElasticDeclarativeConfigurationCustomizer.java
+++ b/custom/src/main/java/co/elastic/otel/declarativeconfig/ElasticDeclarativeConfigurationCustomizer.java
@@ -22,24 +22,50 @@ import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toSet;
 
 import com.google.auto.service.AutoService;
+import io.opentelemetry.javaagent.tooling.AgentVersion;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.DeclarativeConfigurationCustomizer;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.DeclarativeConfigurationCustomizerProvider;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.BatchLogRecordProcessorModel;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.BatchSpanProcessorModel;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.ExperimentalResourceDetectionModel;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.ExperimentalResourceDetectorModel;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.LogRecordExporterModel;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.LoggerProviderModel;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.MeterProviderModel;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.NameStringValuePairModel;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.OpenTelemetryConfigurationModel;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.OtlpGrpcExporterModel;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.OtlpGrpcMetricExporterModel;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.OtlpHttpExporterModel;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.OtlpHttpMetricExporterModel;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.PeriodicMetricReaderModel;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.PushMetricExporterModel;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.ResourceModel;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.SimpleLogRecordProcessorModel;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.SimpleSpanProcessorModel;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.SpanExporterModel;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.TracerProviderModel;
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 @AutoService(DeclarativeConfigurationCustomizerProvider.class)
 public class ElasticDeclarativeConfigurationCustomizer
     implements DeclarativeConfigurationCustomizerProvider {
 
+  public static final String USER_AGENT = "user-agent";
+  public static final String OTLP_GRPC = "elastic-otlp-grpc-java/" + AgentVersion.VERSION;
+  public static final String OTLP_HTTP = "elastic-otlp-http-java/" + AgentVersion.VERSION;
+
   @Override
   public void customize(DeclarativeConfigurationCustomizer customizer) {
     customizer.addModelCustomizer(
         model -> {
           customizeResources(model);
+          customizeUserAgent(model);
           return model;
         });
   }
@@ -59,7 +85,7 @@ public class ElasticDeclarativeConfigurationCustomizer
     }
 
     ExperimentalResourceDetectionModel detectionDevelopment = resource.getDetectionDevelopment();
-    if (null == detectionDevelopment) {
+    if (detectionDevelopment == null) {
       detectionDevelopment = new ExperimentalResourceDetectionModel();
       resource.withDetectionDevelopment(detectionDevelopment);
     }
@@ -78,4 +104,164 @@ public class ElasticDeclarativeConfigurationCustomizer
       detectors.add(detector);
     }
   }
+
+  private void customizeUserAgent(OpenTelemetryConfigurationModel model) {
+    // configure otlp exporters (grpc or http) to set the user-agent if not explicitly set
+    //
+    // This is equivalent to explicitly add 'user-agent' header in exporter configuration
+    // for 'tracer_provider', 'meter_provider' and 'logger_provider'.
+    //
+    // tracer_provider:
+    //  processors:
+    //    # or 'simple' for simple span processor
+    //    - batch:
+    //        exporter:
+    //          # or 'otlp_grpc' for grpc
+    //          otlp_http:
+    //            endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT:-http://localhost:4318}/v1/traces
+    //            headers:
+    //              # with 'elastic-otlp-grpc-java' prefix for grpc
+    //              user-agent: "elastic-otlp-http-java/<edot-version>"
+    //
+    //meter_provider:
+    //  readers:
+    //    - periodic:
+    //        exporter:
+    //          # or 'otlp_grpc' for grpc
+    //          otlp_http:
+    //            endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT:-http://localhost:4318}/v1/metrics
+    //            headers:
+    //              # with 'elastic-otlp-grpc-java' prefix for grpc
+    //              user-agent: "elastic-otlp-http-java/<edot-version>"
+    //
+    //logger_provider:
+    //  processors:
+    //    # or 'simple' for simple log processor
+    //    - batch:
+    //        exporter:
+    //          otlp_http:
+    //            endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT:-http://localhost:4318}/v1/logs
+    //            headers:
+    //              # with 'elastic-otlp-grpc-java' prefix for grpc
+    //              user-agent: "elastic-otlp-http-java/<edot-version>"
+
+    // traces
+    Optional.ofNullable(model.getTracerProvider())
+        .map(TracerProviderModel::getProcessors)
+        .orElse(Collections.emptyList())
+        .forEach(processor -> {
+          Optional.ofNullable(processor.getBatch())
+              .map(BatchSpanProcessorModel::getExporter)
+              .ifPresent(this::addUserAgent);
+          Optional.ofNullable(processor.getSimple())
+              .map(SimpleSpanProcessorModel::getExporter)
+              .ifPresent(this::addUserAgent);
+        });
+
+    // metrics
+    Optional.ofNullable(model.getMeterProvider())
+        .map(MeterProviderModel::getReaders)
+        .orElse(Collections.emptyList())
+        .forEach(
+            reader -> {
+              Optional.ofNullable(reader.getPeriodic())
+                  .map(PeriodicMetricReaderModel::getExporter)
+                  .ifPresent(this::addUserAgent);
+            });
+
+    // logs
+    Optional.ofNullable(model.getLoggerProvider())
+        .map(LoggerProviderModel::getProcessors)
+        .orElse(Collections.emptyList())
+        .forEach( processor ->{
+          Optional.ofNullable(processor.getBatch())
+              .map(BatchLogRecordProcessorModel::getExporter)
+              .ifPresent(this::addUserAgent);
+          Optional.ofNullable(processor.getSimple())
+              .map(SimpleLogRecordProcessorModel::getExporter)
+              .ifPresent(this::addUserAgent);
+        });
+
+
+  }
+
+  private void addUserAgent(@Nullable LogRecordExporterModel logExporterModel) {
+    if(logExporterModel == null) {
+      return;
+    }
+    addUserAgent(logExporterModel.getOtlpGrpc(), logExporterModel.getOtlpHttp());
+  }
+
+  private void addUserAgent(@Nullable PushMetricExporterModel metricExporterModel) {
+    if (metricExporterModel == null) {
+      return;
+    }
+
+    OtlpGrpcMetricExporterModel otlpGrpc = metricExporterModel.getOtlpGrpc();
+    if (otlpGrpc != null) {
+      String headersList = otlpGrpc.getHeadersList();
+      List<NameStringValuePairModel> headers = otlpGrpc.getHeaders();
+      otlpGrpc.withHeaders(addUserAgent(headersList, headers, OTLP_GRPC));
+    }
+    OtlpHttpMetricExporterModel otlpHttp = metricExporterModel.getOtlpHttp();
+    if (otlpHttp != null) {
+      String headersList = otlpHttp.getHeadersList();
+      List<NameStringValuePairModel> headers = otlpHttp.getHeaders();
+      otlpHttp.withHeaders(addUserAgent(headersList, headers, OTLP_HTTP));
+    }
+
+  }
+
+  private void addUserAgent(@Nullable SpanExporterModel spanExporterModel) {
+    if (spanExporterModel == null) {
+      return;
+    }
+    addUserAgent(spanExporterModel.getOtlpGrpc(), spanExporterModel.getOtlpHttp());
+  }
+
+  private static void addUserAgent(OtlpGrpcExporterModel otlpGrpc, OtlpHttpExporterModel otlpHttp) {
+    if (otlpGrpc != null) {
+      String headersList = otlpGrpc.getHeadersList();
+      List<NameStringValuePairModel> headers = otlpGrpc.getHeaders();
+      otlpGrpc.withHeaders(
+          addUserAgent(headersList, headers, OTLP_GRPC));
+    }
+    if (otlpHttp != null) {
+      String headersList = otlpHttp.getHeadersList();
+      List<NameStringValuePairModel> headers = otlpHttp.getHeaders();
+      otlpHttp.withHeaders(
+          addUserAgent(headersList, headers, OTLP_HTTP));
+    }
+  }
+
+  private static List<NameStringValuePairModel> addUserAgent(@Nullable String headersList, List<NameStringValuePairModel> headers,
+      String value) {
+    // skip if user-agent is already present in headers list (string)
+    if (headersList != null) {
+      for (String part : headersList.split(",")) {
+        String[] keyValue = part.split("=", 2);
+        if (keyValue.length == 2 && USER_AGENT.equalsIgnoreCase(keyValue[0].trim())) {
+          return headers;
+        }
+      }
+    }
+    // skip if user-agent is already present in headers (list)
+    if (headers != null && !headers.isEmpty()) {
+      for (NameStringValuePairModel header : headers) {
+        if (USER_AGENT.equalsIgnoreCase(header.getName())) {
+          return headers;
+        }
+      }
+    }
+
+    List<NameStringValuePairModel> result = new ArrayList<>();
+    if (headers != null) {
+      result.addAll(headers);
+    }
+    result.add(new NameStringValuePairModel()
+        .withName(USER_AGENT)
+        .withValue(value));
+    return result;
+  }
+
 }

--- a/custom/src/main/java/co/elastic/otel/declarativeconfig/ElasticDeclarativeConfigurationCustomizer.java
+++ b/custom/src/main/java/co/elastic/otel/declarativeconfig/ElasticDeclarativeConfigurationCustomizer.java
@@ -18,11 +18,11 @@
  */
 package co.elastic.otel.declarativeconfig;
 
+import static co.elastic.otel.ElasticUserAgentHeader.HEADER_NAME;
 import static co.elastic.otel.ElasticUserAgentHeader.OTLP_GRPC;
 import static co.elastic.otel.ElasticUserAgentHeader.OTLP_HTTP;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toSet;
-import static jdk.internal.net.http.HttpRequestImpl.USER_AGENT;
 
 import com.google.auto.service.AutoService;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.DeclarativeConfigurationCustomizer;
@@ -236,7 +236,7 @@ public class ElasticDeclarativeConfigurationCustomizer
     if (headersList != null) {
       for (String part : headersList.split(",")) {
         String[] keyValue = part.split("=", 2);
-        if (keyValue.length == 2 && USER_AGENT.equalsIgnoreCase(keyValue[0].trim())) {
+        if (keyValue.length == 2 && HEADER_NAME.equalsIgnoreCase(keyValue[0].trim())) {
           return headers;
         }
       }
@@ -244,7 +244,7 @@ public class ElasticDeclarativeConfigurationCustomizer
     // skip if user-agent is already present in headers (list)
     if (headers != null && !headers.isEmpty()) {
       for (NameStringValuePairModel header : headers) {
-        if (USER_AGENT.equalsIgnoreCase(header.getName())) {
+        if (HEADER_NAME.equalsIgnoreCase(header.getName())) {
           return headers;
         }
       }
@@ -254,7 +254,7 @@ public class ElasticDeclarativeConfigurationCustomizer
     if (headers != null) {
       result.addAll(headers);
     }
-    result.add(new NameStringValuePairModel().withName(USER_AGENT).withValue(value));
+    result.add(new NameStringValuePairModel().withName(HEADER_NAME).withValue(value));
     return result;
   }
 }

--- a/custom/src/main/java/co/elastic/otel/declarativeconfig/ElasticDeclarativeConfigurationCustomizer.java
+++ b/custom/src/main/java/co/elastic/otel/declarativeconfig/ElasticDeclarativeConfigurationCustomizer.java
@@ -45,12 +45,12 @@ import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.Simple
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.SimpleSpanProcessorModel;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.SpanExporterModel;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.TracerProviderModel;
-import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import javax.annotation.Nullable;
 
 @AutoService(DeclarativeConfigurationCustomizerProvider.class)
 public class ElasticDeclarativeConfigurationCustomizer
@@ -112,51 +112,52 @@ public class ElasticDeclarativeConfigurationCustomizer
     // for 'tracer_provider', 'meter_provider' and 'logger_provider'.
     //
     // tracer_provider:
-    //  processors:
-    //    # or 'simple' for simple span processor
-    //    - batch:
-    //        exporter:
-    //          # or 'otlp_grpc' for grpc
-    //          otlp_http:
-    //            endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT:-http://localhost:4318}/v1/traces
-    //            headers:
-    //              # with 'elastic-otlp-grpc-java' prefix for grpc
-    //              user-agent: "elastic-otlp-http-java/<edot-version>"
+    //   processors:
+    //     # or 'simple' for simple span processor
+    //     - batch:
+    //         exporter:
+    //           # or 'otlp_grpc' for grpc
+    //           otlp_http:
+    //             endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT:-http://localhost:4318}/v1/traces
+    //             headers:
+    //               # with 'elastic-otlp-grpc-java' prefix for grpc
+    //               user-agent: "elastic-otlp-http-java/<edot-version>"
     //
-    //meter_provider:
-    //  readers:
-    //    - periodic:
-    //        exporter:
-    //          # or 'otlp_grpc' for grpc
-    //          otlp_http:
-    //            endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT:-http://localhost:4318}/v1/metrics
-    //            headers:
-    //              # with 'elastic-otlp-grpc-java' prefix for grpc
-    //              user-agent: "elastic-otlp-http-java/<edot-version>"
+    // meter_provider:
+    //   readers:
+    //     - periodic:
+    //         exporter:
+    //           # or 'otlp_grpc' for grpc
+    //           otlp_http:
+    //             endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT:-http://localhost:4318}/v1/metrics
+    //             headers:
+    //               # with 'elastic-otlp-grpc-java' prefix for grpc
+    //               user-agent: "elastic-otlp-http-java/<edot-version>"
     //
-    //logger_provider:
-    //  processors:
-    //    # or 'simple' for simple log processor
-    //    - batch:
-    //        exporter:
-    //          otlp_http:
-    //            endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT:-http://localhost:4318}/v1/logs
-    //            headers:
-    //              # with 'elastic-otlp-grpc-java' prefix for grpc
-    //              user-agent: "elastic-otlp-http-java/<edot-version>"
+    // logger_provider:
+    //   processors:
+    //     # or 'simple' for simple log processor
+    //     - batch:
+    //         exporter:
+    //           otlp_http:
+    //             endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT:-http://localhost:4318}/v1/logs
+    //             headers:
+    //               # with 'elastic-otlp-grpc-java' prefix for grpc
+    //               user-agent: "elastic-otlp-http-java/<edot-version>"
 
     // traces
     Optional.ofNullable(model.getTracerProvider())
         .map(TracerProviderModel::getProcessors)
         .orElse(Collections.emptyList())
-        .forEach(processor -> {
-          Optional.ofNullable(processor.getBatch())
-              .map(BatchSpanProcessorModel::getExporter)
-              .ifPresent(this::addUserAgent);
-          Optional.ofNullable(processor.getSimple())
-              .map(SimpleSpanProcessorModel::getExporter)
-              .ifPresent(this::addUserAgent);
-        });
+        .forEach(
+            processor -> {
+              Optional.ofNullable(processor.getBatch())
+                  .map(BatchSpanProcessorModel::getExporter)
+                  .ifPresent(this::addUserAgent);
+              Optional.ofNullable(processor.getSimple())
+                  .map(SimpleSpanProcessorModel::getExporter)
+                  .ifPresent(this::addUserAgent);
+            });
 
     // metrics
     Optional.ofNullable(model.getMeterProvider())
@@ -173,20 +174,19 @@ public class ElasticDeclarativeConfigurationCustomizer
     Optional.ofNullable(model.getLoggerProvider())
         .map(LoggerProviderModel::getProcessors)
         .orElse(Collections.emptyList())
-        .forEach( processor ->{
-          Optional.ofNullable(processor.getBatch())
-              .map(BatchLogRecordProcessorModel::getExporter)
-              .ifPresent(this::addUserAgent);
-          Optional.ofNullable(processor.getSimple())
-              .map(SimpleLogRecordProcessorModel::getExporter)
-              .ifPresent(this::addUserAgent);
-        });
-
-
+        .forEach(
+            processor -> {
+              Optional.ofNullable(processor.getBatch())
+                  .map(BatchLogRecordProcessorModel::getExporter)
+                  .ifPresent(this::addUserAgent);
+              Optional.ofNullable(processor.getSimple())
+                  .map(SimpleLogRecordProcessorModel::getExporter)
+                  .ifPresent(this::addUserAgent);
+            });
   }
 
   private void addUserAgent(@Nullable LogRecordExporterModel logExporterModel) {
-    if(logExporterModel == null) {
+    if (logExporterModel == null) {
       return;
     }
     addUserAgent(logExporterModel.getOtlpGrpc(), logExporterModel.getOtlpHttp());
@@ -209,7 +209,6 @@ public class ElasticDeclarativeConfigurationCustomizer
       List<NameStringValuePairModel> headers = otlpHttp.getHeaders();
       otlpHttp.withHeaders(addUserAgent(headersList, headers, OTLP_HTTP));
     }
-
   }
 
   private void addUserAgent(@Nullable SpanExporterModel spanExporterModel) {
@@ -223,19 +222,18 @@ public class ElasticDeclarativeConfigurationCustomizer
     if (otlpGrpc != null) {
       String headersList = otlpGrpc.getHeadersList();
       List<NameStringValuePairModel> headers = otlpGrpc.getHeaders();
-      otlpGrpc.withHeaders(
-          addUserAgent(headersList, headers, OTLP_GRPC));
+      otlpGrpc.withHeaders(addUserAgent(headersList, headers, OTLP_GRPC));
     }
     if (otlpHttp != null) {
       String headersList = otlpHttp.getHeadersList();
       List<NameStringValuePairModel> headers = otlpHttp.getHeaders();
-      otlpHttp.withHeaders(
-          addUserAgent(headersList, headers, OTLP_HTTP));
+      otlpHttp.withHeaders(addUserAgent(headersList, headers, OTLP_HTTP));
     }
   }
 
-  private static List<NameStringValuePairModel> addUserAgent(@Nullable String headersList, List<NameStringValuePairModel> headers,
-      String value) {
+  // package protected for testing
+  static List<NameStringValuePairModel> addUserAgent(
+      @Nullable String headersList, List<NameStringValuePairModel> headers, String value) {
     // skip if user-agent is already present in headers list (string)
     if (headersList != null) {
       for (String part : headersList.split(",")) {
@@ -258,10 +256,7 @@ public class ElasticDeclarativeConfigurationCustomizer
     if (headers != null) {
       result.addAll(headers);
     }
-    result.add(new NameStringValuePairModel()
-        .withName(USER_AGENT)
-        .withValue(value));
+    result.add(new NameStringValuePairModel().withName(USER_AGENT).withValue(value));
     return result;
   }
-
 }

--- a/custom/src/main/java/co/elastic/otel/declarativeconfig/ElasticDeclarativeConfigurationCustomizer.java
+++ b/custom/src/main/java/co/elastic/otel/declarativeconfig/ElasticDeclarativeConfigurationCustomizer.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.otel.declarativeconfig;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toSet;
+
+import com.google.auto.service.AutoService;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.DeclarativeConfigurationCustomizer;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.DeclarativeConfigurationCustomizerProvider;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.ExperimentalResourceDetectionModel;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.ExperimentalResourceDetectorModel;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.OpenTelemetryConfigurationModel;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.ResourceModel;
+import java.util.List;
+import java.util.Set;
+
+@AutoService(DeclarativeConfigurationCustomizerProvider.class)
+public class ElasticDeclarativeConfigurationCustomizer
+    implements DeclarativeConfigurationCustomizerProvider {
+
+  @Override
+  public void customize(DeclarativeConfigurationCustomizer customizer) {
+    customizer.addModelCustomizer(
+        model -> {
+          customizeResources(model);
+          return model;
+        });
+  }
+
+  private static void customizeResources(OpenTelemetryConfigurationModel model) {
+    // this is equivalent to adding the following explicitly in declarative configuration
+    //
+    //  detection/development:
+    //    detectors:
+    //      - <... other detectors ...>
+    //      - elastic_distribution:
+
+    ResourceModel resource = model.getResource();
+    if (resource == null) {
+      resource = new ResourceModel();
+      model.withResource(resource);
+    }
+
+    ExperimentalResourceDetectionModel detectionDevelopment = resource.getDetectionDevelopment();
+    if (null == detectionDevelopment) {
+      detectionDevelopment = new ExperimentalResourceDetectionModel();
+      resource.withDetectionDevelopment(detectionDevelopment);
+    }
+    List<ExperimentalResourceDetectorModel> detectors =
+        requireNonNull(detectionDevelopment.getDetectors());
+
+    Set<String> names =
+        detectors.stream()
+            .flatMap(detector -> detector.getAdditionalProperties().keySet().stream())
+            .collect(toSet());
+
+    // add at the end to make it have priority over upstream distro provider (which is added 1st)
+    if (!names.contains(ElasticDistroComponentProvider.NAME)) {
+      ExperimentalResourceDetectorModel detector = new ExperimentalResourceDetectorModel();
+      detector.getAdditionalProperties().put(ElasticDistroComponentProvider.NAME, null);
+      detectors.add(detector);
+    }
+  }
+}

--- a/custom/src/main/java/co/elastic/otel/declarativeconfig/ElasticDeclarativeConfigurationCustomizer.java
+++ b/custom/src/main/java/co/elastic/otel/declarativeconfig/ElasticDeclarativeConfigurationCustomizer.java
@@ -56,9 +56,9 @@ import javax.annotation.Nullable;
 public class ElasticDeclarativeConfigurationCustomizer
     implements DeclarativeConfigurationCustomizerProvider {
 
-  public static final String USER_AGENT = "user-agent";
-  public static final String OTLP_GRPC = "elastic-otlp-grpc-java/" + AgentVersion.VERSION;
-  public static final String OTLP_HTTP = "elastic-otlp-http-java/" + AgentVersion.VERSION;
+  private static final String USER_AGENT = "User-Agent";
+  private static final String OTLP_GRPC = "elastic-otlp-grpc-java/" + AgentVersion.VERSION;
+  private static final String OTLP_HTTP = "elastic-otlp-http-java/" + AgentVersion.VERSION;
 
   @Override
   public void customize(DeclarativeConfigurationCustomizer customizer) {

--- a/custom/src/main/java/co/elastic/otel/declarativeconfig/ElasticDistroComponentProvider.java
+++ b/custom/src/main/java/co/elastic/otel/declarativeconfig/ElasticDistroComponentProvider.java
@@ -16,22 +16,33 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package co.elastic.otel;
+package co.elastic.otel.declarativeconfig;
 
+import co.elastic.otel.ElasticDistroResource;
 import com.google.auto.service.AutoService;
-import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
-import io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider;
+import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
+import io.opentelemetry.sdk.autoconfigure.spi.internal.ComponentProvider;
 import io.opentelemetry.sdk.resources.Resource;
 
 /**
  * Provides {@code telemetry.distro.name} and {@code telemetry.distro.version} resource attributes
- * for automatic configuration
+ * for declarative configuration
  */
-@AutoService(ResourceProvider.class)
-public class ElasticDistroResourceProvider implements ResourceProvider {
+@AutoService(ComponentProvider.class)
+public class ElasticDistroComponentProvider implements ComponentProvider {
 
   @Override
-  public Resource createResource(ConfigProperties configProperties) {
+  public Class<?> getType() {
+    return Resource.class;
+  }
+
+  @Override
+  public String getName() {
+    return "elastic_opentelemetry_javaagent_distribution";
+  }
+
+  @Override
+  public Object create(DeclarativeConfigProperties config) {
     return ElasticDistroResource.get();
   }
 }

--- a/custom/src/main/java/co/elastic/otel/declarativeconfig/ElasticDistroComponentProvider.java
+++ b/custom/src/main/java/co/elastic/otel/declarativeconfig/ElasticDistroComponentProvider.java
@@ -31,6 +31,8 @@ import io.opentelemetry.sdk.resources.Resource;
 @AutoService(ComponentProvider.class)
 public class ElasticDistroComponentProvider implements ComponentProvider {
 
+  static final String NAME = "elastic_distribution";
+
   @Override
   public Class<?> getType() {
     return Resource.class;
@@ -38,7 +40,7 @@ public class ElasticDistroComponentProvider implements ComponentProvider {
 
   @Override
   public String getName() {
-    return "elastic_opentelemetry_javaagent_distribution";
+    return NAME;
   }
 
   @Override

--- a/custom/src/test/java/co/elastic/otel/declarativeconfig/ElasticDeclarativeConfigurationCustomizerTest.java
+++ b/custom/src/test/java/co/elastic/otel/declarativeconfig/ElasticDeclarativeConfigurationCustomizerTest.java
@@ -205,7 +205,7 @@ class ElasticDeclarativeConfigurationCustomizerTest {
         .describedAs("add user agent when none is present in headers list or headers")
         .hasSize(1)
         .flatExtracting("name", "value")
-        .contains("user-agent", "my-user-agent");
+        .contains("User-Agent", "my-user-agent");
 
     assertThat(
             ElasticDeclarativeConfigurationCustomizer.addUserAgent(
@@ -213,11 +213,12 @@ class ElasticDeclarativeConfigurationCustomizerTest {
         .describedAs("add user agent when none is present in headers list or headers")
         .hasSize(1)
         .flatExtracting("name", "value")
-        .contains("user-agent", "my-user-agent");
+        .contains("User-Agent", "my-user-agent");
 
     assertThat(
             ElasticDeclarativeConfigurationCustomizer.addUserAgent(
-                "User-Agent=custom-user-agent", null, "my-user-agent"))
+                // using non-standard case is intentional for testing
+                "User-agent=custom-user-agent", null, "my-user-agent"))
         .describedAs("configured user-agent is preserved")
         .isNull();
 
@@ -226,19 +227,19 @@ class ElasticDeclarativeConfigurationCustomizerTest {
                 null,
                 Collections.singletonList(
                     new NameStringValuePairModel()
-                        .withName("User-Agent")
+                        .withName("user-agent") // using lower-case is intentional for testing
                         .withValue("custom-user-Agent")),
                 "my-user-agent"))
         .describedAs("configured user-agent is preserved")
         .hasSize(1)
         .flatExtracting("name", "value")
-        .contains("User-Agent", "custom-user-Agent");
+        .contains("user-agent", "custom-user-Agent");
   }
 
   @NotNull
   private static Map<String, String> userAgentHeader(String value) {
     Map<String, String> header = new HashMap<>();
-    header.put("name", "user-agent");
+    header.put("name", "User-Agent");
     header.put("value", value);
     return header;
   }

--- a/custom/src/test/java/co/elastic/otel/declarativeconfig/ElasticDeclarativeConfigurationCustomizerTest.java
+++ b/custom/src/test/java/co/elastic/otel/declarativeconfig/ElasticDeclarativeConfigurationCustomizerTest.java
@@ -27,10 +27,22 @@ import io.opentelemetry.javaagent.tooling.AgentVersion;
 import io.opentelemetry.javaagent.tooling.resources.ResourceCustomizerProvider;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.DeclarativeConfigurationCustomizer;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.DeclarativeConfigurationCustomizerProvider;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.BatchLogRecordProcessorModel;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.BatchSpanProcessorModel;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.LogRecordExporterModel;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.LogRecordProcessorModel;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.LoggerProviderModel;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.MeterProviderModel;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.MetricReaderModel;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.NameStringValuePairModel;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.OpenTelemetryConfigurationModel;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.OtlpGrpcExporterModel;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.OtlpGrpcMetricExporterModel;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.OtlpHttpExporterModel;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.OtlpHttpMetricExporterModel;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.PeriodicMetricReaderModel;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.PushMetricExporterModel;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.SimpleLogRecordProcessorModel;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.SimpleSpanProcessorModel;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.SpanExporterModel;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.SpanProcessorModel;
@@ -39,6 +51,7 @@ import io.opentelemetry.sdk.logs.export.LogRecordExporter;
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
@@ -57,8 +70,7 @@ class ElasticDeclarativeConfigurationCustomizerTest {
     model = applyConfigCustomize(model, new ElasticDeclarativeConfigurationCustomizer());
 
     // ensures that we add our resource detector even if the model does not provide any
-    assertThatJson(json(model.getResource()))
-        .inPath("attributes").isArray().isEmpty();
+    assertThatJson(json(model.getResource())).inPath("attributes").isArray().isEmpty();
     assertThatJson(json(model.getResource()))
         .inPath("detection/development.detectors")
         .isArray()
@@ -105,46 +117,127 @@ class ElasticDeclarativeConfigurationCustomizerTest {
     OpenTelemetryConfigurationModel model = new OpenTelemetryConfigurationModel();
 
     SpanExporterModel spanExporter = new SpanExporterModel();
+    PushMetricExporterModel metricExporter = new PushMetricExporterModel();
+    LogRecordExporterModel logExporter = new LogRecordExporterModel();
+
     switch (protocol) {
       case "grpc":
         spanExporter.withOtlpGrpc(new OtlpGrpcExporterModel());
+        metricExporter.withOtlpGrpc(new OtlpGrpcMetricExporterModel());
+        logExporter.withOtlpGrpc(new OtlpGrpcExporterModel());
         break;
       case "http":
         spanExporter.withOtlpHttp(new OtlpHttpExporterModel());
+        metricExporter.withOtlpHttp(new OtlpHttpMetricExporterModel());
+        logExporter.withOtlpHttp(new OtlpHttpExporterModel());
         break;
       default:
         throw new IllegalArgumentException("Unsupported protocol: " + protocol);
     }
 
-    SpanProcessorModel simpleProcessor = new SpanProcessorModel()
-        .withSimple(new SimpleSpanProcessorModel()
-            .withExporter(spanExporter));
-    SpanProcessorModel batchProcessor = new SpanProcessorModel()
-        .withBatch(new BatchSpanProcessorModel()
-            .withExporter(spanExporter));
+    // tracer provider
+    SpanProcessorModel spanSimpleProcessor =
+        new SpanProcessorModel()
+            .withSimple(new SimpleSpanProcessorModel().withExporter(spanExporter));
+    SpanProcessorModel spanBatchProcessor =
+        new SpanProcessorModel()
+            .withBatch(new BatchSpanProcessorModel().withExporter(spanExporter));
+    model.withTracerProvider(
+        new TracerProviderModel()
+            .withProcessors(Arrays.asList(spanSimpleProcessor, spanBatchProcessor)));
 
-    model.withTracerProvider(new TracerProviderModel().withProcessors(Arrays.asList(
-        simpleProcessor, batchProcessor)));
+    // meter provider
+    model.withMeterProvider(
+        new MeterProviderModel()
+            .withReaders(
+                Collections.singletonList(
+                    new MetricReaderModel()
+                        .withPeriodic(
+                            new PeriodicMetricReaderModel().withExporter(metricExporter)))));
+
+    // logger provider
+    LogRecordProcessorModel logSimpleProcessor =
+        new LogRecordProcessorModel()
+            .withSimple(new SimpleLogRecordProcessorModel().withExporter(logExporter));
+    LogRecordProcessorModel logBatchProcessor =
+        new LogRecordProcessorModel()
+            .withBatch(new BatchLogRecordProcessorModel().withExporter(logExporter));
+    model.withLoggerProvider(
+        new LoggerProviderModel()
+            .withProcessors(Arrays.asList(logSimpleProcessor, logBatchProcessor)));
 
     model = applyConfigCustomize(model, new ElasticDeclarativeConfigurationCustomizer());
 
+    // tracer provider
     assertThat(model.getTracerProvider()).isNotNull();
-    assertThatJson(model.getTracerProvider()).inPath("processors")
-        .isArray().hasSize(2);
+    assertThatJson(model.getTracerProvider()).inPath("processors").isArray().hasSize(2);
     for (int i = 0; i < 2; i++) {
       String pathPrefix = i == 0 ? "simple" : "batch";
-      assertThatJson(json(model.getTracerProvider().getProcessors().get(i)))
+      assertThatJson(model.getTracerProvider().getProcessors().get(i))
           .inPath(pathPrefix + ".exporter.otlp_" + protocol + ".headers")
           .isArray()
-          .contains(
-              json(userAgentAsMap("elastic-otlp-" + protocol + "-java/" + AgentVersion.VERSION)));
+          .contains(userAgentHeader("elastic-otlp-" + protocol + "-java/" + AgentVersion.VERSION));
     }
 
+    // meter provider
+    assertThat(model.getMeterProvider()).isNotNull();
+    assertThatJson(model.getMeterProvider()).inPath("readers").isArray().hasSize(1);
+    assertThatJson(model.getMeterProvider().getReaders().get(0))
+        .inPath("periodic.exporter.otlp_" + protocol + ".headers")
+        .isArray()
+        .contains(userAgentHeader("elastic-otlp-" + protocol + "-java/" + AgentVersion.VERSION));
+
+    // logger provider
+    assertThat(model.getLoggerProvider()).isNotNull();
+    assertThatJson(model.getLoggerProvider()).inPath("processors").isArray().hasSize(2);
+    for (int i = 0; i < 2; i++) {
+      String pathPrefix = i == 0 ? "simple" : "batch";
+      assertThatJson(model.getLoggerProvider().getProcessors().get(i))
+          .inPath(pathPrefix + ".exporter.otlp_" + protocol + ".headers")
+          .isArray()
+          .contains(userAgentHeader("elastic-otlp-" + protocol + "-java/" + AgentVersion.VERSION));
+    }
+  }
+
+  @Test
+  void addUserAgentPriority() {
+    assertThat(ElasticDeclarativeConfigurationCustomizer.addUserAgent(null, null, "my-user-agent"))
+        .describedAs("add user agent when none is present in headers list or headers")
+        .hasSize(1)
+        .flatExtracting("name", "value")
+        .contains("user-agent", "my-user-agent");
+
+    assertThat(
+            ElasticDeclarativeConfigurationCustomizer.addUserAgent(
+                null, Collections.emptyList(), "my-user-agent"))
+        .describedAs("add user agent when none is present in headers list or headers")
+        .hasSize(1)
+        .flatExtracting("name", "value")
+        .contains("user-agent", "my-user-agent");
+
+    assertThat(
+            ElasticDeclarativeConfigurationCustomizer.addUserAgent(
+                "User-Agent=custom-user-agent", null, "my-user-agent"))
+        .describedAs("configured user-agent is preserved")
+        .isNull();
+
+    assertThat(
+            ElasticDeclarativeConfigurationCustomizer.addUserAgent(
+                null,
+                Collections.singletonList(
+                    new NameStringValuePairModel()
+                        .withName("User-Agent")
+                        .withValue("custom-user-Agent")),
+                "my-user-agent"))
+        .describedAs("configured user-agent is preserved")
+        .hasSize(1)
+        .flatExtracting("name", "value")
+        .contains("User-Agent", "custom-user-Agent");
   }
 
   @NotNull
-  private static Map<String, String> userAgentAsMap(String value) {
-    Map<String,String> header = new HashMap<>();
+  private static Map<String, String> userAgentHeader(String value) {
+    Map<String, String> header = new HashMap<>();
     header.put("name", "user-agent");
     header.put("value", value);
     return header;

--- a/custom/src/test/java/co/elastic/otel/declarativeconfig/ElasticDeclarativeConfigurationCustomizerTest.java
+++ b/custom/src/test/java/co/elastic/otel/declarativeconfig/ElasticDeclarativeConfigurationCustomizerTest.java
@@ -18,30 +18,38 @@
  */
 package co.elastic.otel.declarativeconfig;
 
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.json;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
+import io.opentelemetry.javaagent.tooling.AgentVersion;
 import io.opentelemetry.javaagent.tooling.resources.ResourceCustomizerProvider;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.DeclarativeConfigurationCustomizer;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.DeclarativeConfigurationCustomizerProvider;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.BatchSpanProcessorModel;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.OpenTelemetryConfigurationModel;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.OtlpGrpcExporterModel;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.OtlpHttpExporterModel;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.SimpleSpanProcessorModel;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.SpanExporterModel;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.SpanProcessorModel;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.TracerProviderModel;
 import io.opentelemetry.sdk.logs.export.LogRecordExporter;
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
 import java.util.function.Function;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 class ElasticDeclarativeConfigurationCustomizerTest {
-
-  // because declarative config relies on json mapping annotations, we can leverage this for testing
-  // the configuration customization.
-  private final ObjectMapper objectMapper = new ObjectMapper();
 
   @Test
   void defaultConfig() {
@@ -49,14 +57,22 @@ class ElasticDeclarativeConfigurationCustomizerTest {
     model = applyConfigCustomize(model, new ElasticDeclarativeConfigurationCustomizer());
 
     // ensures that we add our resource detector even if the model does not provide any
-    checkJson(
-        model.getResource(),
-        "{\"attributes\":[],\"detection/development\":{\"detectors\":[{\"elastic_distribution\":null}]}}");
+    assertThatJson(json(model.getResource()))
+        .inPath("attributes").isArray().isEmpty();
+    assertThatJson(json(model.getResource()))
+        .inPath("detection/development.detectors")
+        .isArray()
+        .containsExactly(json("{\"elastic_distribution\":null}]}"));
+
+    // no exporter is configured by default for any signal
+    assertThat(model.getTracerProvider()).isNull();
+    assertThat(model.getMeterProvider()).isNull();
+    assertThat(model.getLoggerProvider()).isNull();
   }
 
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
-  void upstreamProvider(boolean elasticFirst) {
+  void distributionResourceProvider(boolean elasticFirst) {
     // upstream provider is always added first in the list, even if we add ours first
     // this ordering behavior is implemented in upstream provider
     OpenTelemetryConfigurationModel model = new OpenTelemetryConfigurationModel();
@@ -72,17 +88,66 @@ class ElasticDeclarativeConfigurationCustomizerTest {
 
     model = applyConfigCustomize(model, first);
     model = applyConfigCustomize(model, second);
-    checkJson(
-        model.getResource(),
-        "{\"attributes\":[],\"detection/development\":{\"detectors\":[{\"opentelemetry_javaagent_distribution\":null},{\"elastic_distribution\":null}]}}");
+
+    assertThatJson(json(model.getResource()))
+        .inPath("detection/development.detectors")
+        .isArray()
+        .containsExactly(
+            json("{\"opentelemetry_javaagent_distribution\":null}]}"),
+            json("{\"elastic_distribution\":null}]}"));
   }
 
-  private void checkJson(Object o, String expected) {
-    try {
-      assertThat(objectMapper.writeValueAsString(o)).isEqualTo(expected);
-    } catch (JsonProcessingException e) {
-      throw new IllegalStateException(e);
+  @ParameterizedTest
+  @ValueSource(strings = {"grpc", "http"})
+  void userAgent(String protocol) {
+    // setup tracer provider with single + batch exporter
+    // check that the user-agent value is set as expected
+    OpenTelemetryConfigurationModel model = new OpenTelemetryConfigurationModel();
+
+    SpanExporterModel spanExporter = new SpanExporterModel();
+    switch (protocol) {
+      case "grpc":
+        spanExporter.withOtlpGrpc(new OtlpGrpcExporterModel());
+        break;
+      case "http":
+        spanExporter.withOtlpHttp(new OtlpHttpExporterModel());
+        break;
+      default:
+        throw new IllegalArgumentException("Unsupported protocol: " + protocol);
     }
+
+    SpanProcessorModel simpleProcessor = new SpanProcessorModel()
+        .withSimple(new SimpleSpanProcessorModel()
+            .withExporter(spanExporter));
+    SpanProcessorModel batchProcessor = new SpanProcessorModel()
+        .withBatch(new BatchSpanProcessorModel()
+            .withExporter(spanExporter));
+
+    model.withTracerProvider(new TracerProviderModel().withProcessors(Arrays.asList(
+        simpleProcessor, batchProcessor)));
+
+    model = applyConfigCustomize(model, new ElasticDeclarativeConfigurationCustomizer());
+
+    assertThat(model.getTracerProvider()).isNotNull();
+    assertThatJson(model.getTracerProvider()).inPath("processors")
+        .isArray().hasSize(2);
+    for (int i = 0; i < 2; i++) {
+      String pathPrefix = i == 0 ? "simple" : "batch";
+      assertThatJson(json(model.getTracerProvider().getProcessors().get(i)))
+          .inPath(pathPrefix + ".exporter.otlp_" + protocol + ".headers")
+          .isArray()
+          .contains(
+              json(userAgentAsMap("elastic-otlp-" + protocol + "-java/" + AgentVersion.VERSION)));
+    }
+
+  }
+
+  @NotNull
+  private static Map<String, String> userAgentAsMap(String value) {
+    Map<String,String> header = new HashMap<>();
+    header.put("name", "user-agent");
+    header.put("value", value);
+    return header;
   }
 
   private OpenTelemetryConfigurationModel applyConfigCustomize(

--- a/custom/src/test/java/co/elastic/otel/declarativeconfig/ElasticDeclarativeConfigurationCustomizerTest.java
+++ b/custom/src/test/java/co/elastic/otel/declarativeconfig/ElasticDeclarativeConfigurationCustomizerTest.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.otel.declarativeconfig;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
+import io.opentelemetry.javaagent.tooling.resources.ResourceCustomizerProvider;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.DeclarativeConfigurationCustomizer;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.DeclarativeConfigurationCustomizerProvider;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.OpenTelemetryConfigurationModel;
+import io.opentelemetry.sdk.logs.export.LogRecordExporter;
+import io.opentelemetry.sdk.metrics.export.MetricExporter;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class ElasticDeclarativeConfigurationCustomizerTest {
+
+  // because declarative config relies on json mapping annotations, we can leverage this for testing
+  // the configuration customization.
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  @Test
+  void defaultConfig() {
+    OpenTelemetryConfigurationModel model = new OpenTelemetryConfigurationModel();
+    model = applyConfigCustomize(model, new ElasticDeclarativeConfigurationCustomizer());
+
+    // ensures that we add our resource detector even if the model does not provide any
+    checkJson(
+        model.getResource(),
+        "{\"attributes\":[],\"detection/development\":{\"detectors\":[{\"elastic_distribution\":null}]}}");
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void upstreamProvider(boolean elasticFirst) {
+    // upstream provider is always added first in the list, even if we add ours first
+    // this ordering behavior is implemented in upstream provider
+    OpenTelemetryConfigurationModel model = new OpenTelemetryConfigurationModel();
+    DeclarativeConfigurationCustomizerProvider first;
+    DeclarativeConfigurationCustomizerProvider second;
+    if (elasticFirst) {
+      first = new ElasticDeclarativeConfigurationCustomizer();
+      second = new ResourceCustomizerProvider();
+    } else {
+      first = new ElasticDeclarativeConfigurationCustomizer();
+      second = new ResourceCustomizerProvider();
+    }
+
+    model = applyConfigCustomize(model, first);
+    model = applyConfigCustomize(model, second);
+    checkJson(
+        model.getResource(),
+        "{\"attributes\":[],\"detection/development\":{\"detectors\":[{\"opentelemetry_javaagent_distribution\":null},{\"elastic_distribution\":null}]}}");
+  }
+
+  private void checkJson(Object o, String expected) {
+    try {
+      assertThat(objectMapper.writeValueAsString(o)).isEqualTo(expected);
+    } catch (JsonProcessingException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  private OpenTelemetryConfigurationModel applyConfigCustomize(
+      OpenTelemetryConfigurationModel originalModel,
+      DeclarativeConfigurationCustomizerProvider customizerProvider) {
+    AtomicReference<OpenTelemetryConfigurationModel> resultModel = new AtomicReference<>();
+    customizerProvider.customize(
+        new TestCustomizer() {
+          @Override
+          public void addModelCustomizer(
+              Function<OpenTelemetryConfigurationModel, OpenTelemetryConfigurationModel>
+                  customizer) {
+            resultModel.set(customizer.apply(originalModel));
+          }
+        });
+    return resultModel.get();
+  }
+
+  private static class TestCustomizer implements DeclarativeConfigurationCustomizer {
+
+    @Override
+    public void addModelCustomizer(
+        Function<OpenTelemetryConfigurationModel, OpenTelemetryConfigurationModel> customizer) {}
+
+    @Override
+    public <T extends SpanExporter> void addSpanExporterCustomizer(
+        Class<T> exporterType, BiFunction<T, DeclarativeConfigProperties, T> customizer) {}
+
+    @Override
+    public <T extends MetricExporter> void addMetricExporterCustomizer(
+        Class<T> exporterType, BiFunction<T, DeclarativeConfigProperties, T> customizer) {}
+
+    @Override
+    public <T extends LogRecordExporter> void addLogRecordExporterCustomizer(
+        Class<T> exporterType, BiFunction<T, DeclarativeConfigProperties, T> customizer) {}
+  }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -45,6 +45,8 @@ autoservice-processor = { group = "com.google.auto.service", name = "auto-servic
 autoservice-annotations = { group = "com.google.auto.service", name = "auto-service-annotations", version.ref = "autoservice" }
 
 assertj-core = "org.assertj:assertj-core:3.27.7"
+# json unit assertj compatible with java 8
+jsonunitassertj = "net.javacrumbs.json-unit:json-unit-assertj:2.40.1"
 awaitility = "org.awaitility:awaitility:4.3.0"
 findbugs-jsr305 = "com.google.code.findbugs:jsr305:3.0.2"
 wiremockjre8 = "com.github.tomakehurst:wiremock-jre8:2.35.2"


### PR DESCRIPTION
Part of #1054 

Adding declarative configuration support will likely require many steps as it will require to replicate all the custom behavior implemented in `co.elastic.otel.ElasticAutoConfigurationCustomizerProvider`

This PR aims to start the process by providing the following:

- set `telemetry.distro.name` and `telemetry.distro.version` for EDOT.
- set custom `user-agent` for EDOT.