### PR TITLE
decl. config. enable experimental runtime metrics

### DIFF
--- a/custom/src/main/java/co/elastic/otel/declarativeconfig/ElasticDeclarativeConfigurationCustomizer.java
+++ b/custom/src/main/java/co/elastic/otel/declarativeconfig/ElasticDeclarativeConfigurationCustomizer.java
@@ -29,6 +29,9 @@ import io.opentelemetry.sdk.extension.incubator.fileconfig.DeclarativeConfigurat
 import io.opentelemetry.sdk.extension.incubator.fileconfig.DeclarativeConfigurationCustomizerProvider;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.BatchLogRecordProcessorModel;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.BatchSpanProcessorModel;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.ExperimentalInstrumentationModel;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.ExperimentalLanguageSpecificInstrumentationModel;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.ExperimentalLanguageSpecificInstrumentationPropertyModel;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.ExperimentalResourceDetectionModel;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.ExperimentalResourceDetectorModel;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.LogRecordExporterModel;
@@ -58,14 +61,47 @@ import javax.annotation.Nullable;
 public class ElasticDeclarativeConfigurationCustomizer
     implements DeclarativeConfigurationCustomizerProvider {
 
+  private static final String RUNTIME_TELEMETRY = "runtime_telemetry";
+  private static final String EMIT_EXPERIMENTAL_METRICS_DEVELOPMENT =
+      "emit_experimental_metrics/development";
+
   @Override
   public void customize(DeclarativeConfigurationCustomizer customizer) {
     customizer.addModelCustomizer(
         model -> {
           customizeResources(model);
           customizeUserAgent(model);
+          customizeExperimentalRuntimeTelemetryMetrics(model);
           return model;
         });
+  }
+
+  private static void customizeExperimentalRuntimeTelemetryMetrics(
+      OpenTelemetryConfigurationModel model) {
+
+    ExperimentalInstrumentationModel instrumentationDevelopment =
+        model.getInstrumentationDevelopment();
+    if (instrumentationDevelopment == null) {
+      instrumentationDevelopment = new ExperimentalInstrumentationModel();
+      model.withInstrumentationDevelopment(instrumentationDevelopment);
+    }
+
+    ExperimentalLanguageSpecificInstrumentationModel java = instrumentationDevelopment.getJava();
+    if (java == null) {
+      java = new ExperimentalLanguageSpecificInstrumentationModel();
+      instrumentationDevelopment.withJava(java);
+    }
+
+    ExperimentalLanguageSpecificInstrumentationPropertyModel runtimeTelemetry =
+        java.getAdditionalProperties().get(RUNTIME_TELEMETRY);
+    if (runtimeTelemetry == null) {
+      runtimeTelemetry = new ExperimentalLanguageSpecificInstrumentationPropertyModel();
+      java.withAdditionalProperty(RUNTIME_TELEMETRY, runtimeTelemetry);
+    }
+    if (runtimeTelemetry.getAdditionalProperties().get(EMIT_EXPERIMENTAL_METRICS_DEVELOPMENT)
+        == null) {
+      runtimeTelemetry.withAdditionalProperty(EMIT_EXPERIMENTAL_METRICS_DEVELOPMENT, true);
+    }
   }
 
   private static void customizeResources(OpenTelemetryConfigurationModel model) {

--- a/custom/src/test/java/co/elastic/otel/declarativeconfig/ElasticDeclarativeConfigurationCustomizerTest.java
+++ b/custom/src/test/java/co/elastic/otel/declarativeconfig/ElasticDeclarativeConfigurationCustomizerTest.java
@@ -29,6 +29,9 @@ import io.opentelemetry.sdk.extension.incubator.fileconfig.DeclarativeConfigurat
 import io.opentelemetry.sdk.extension.incubator.fileconfig.DeclarativeConfigurationCustomizerProvider;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.BatchLogRecordProcessorModel;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.BatchSpanProcessorModel;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.ExperimentalInstrumentationModel;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.ExperimentalLanguageSpecificInstrumentationModel;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.ExperimentalLanguageSpecificInstrumentationPropertyModel;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.LogRecordExporterModel;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.LogRecordProcessorModel;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.LoggerProviderModel;
@@ -80,6 +83,12 @@ class ElasticDeclarativeConfigurationCustomizerTest {
     assertThat(model.getTracerProvider()).isNull();
     assertThat(model.getMeterProvider()).isNull();
     assertThat(model.getLoggerProvider()).isNull();
+
+    // java experimental runtime metrics enabled by default
+    assertThatJson(json(model.getInstrumentationDevelopment()))
+        .inPath("java.runtime_telemetry.emit_experimental_metrics/development")
+        .isBoolean()
+        .isTrue();
   }
 
   @ParameterizedTest
@@ -234,6 +243,28 @@ class ElasticDeclarativeConfigurationCustomizerTest {
         .hasSize(1)
         .flatExtracting("name", "value")
         .contains("user-agent", "custom-user-Agent");
+  }
+
+  @Test
+  void optOutExperimentalRuntimeMetrics() {
+    OpenTelemetryConfigurationModel model =
+        new OpenTelemetryConfigurationModel()
+            .withInstrumentationDevelopment(
+                new ExperimentalInstrumentationModel()
+                    .withJava(
+                        new ExperimentalLanguageSpecificInstrumentationModel()
+                            .withAdditionalProperty(
+                                "runtime_telemetry",
+                                new ExperimentalLanguageSpecificInstrumentationPropertyModel()
+                                    .withAdditionalProperty(
+                                        "emit_experimental_metrics/development", false))));
+
+    model = applyConfigCustomize(model, new ElasticDeclarativeConfigurationCustomizer());
+
+    assertThatJson(json(model.getInstrumentationDevelopment()))
+        .inPath("java.runtime_telemetry.emit_experimental_metrics/development")
+        .isBoolean()
+        .isFalse();
   }
 
   @NotNull


### PR DESCRIPTION
Part of #1054 

Equivalent to add the following to declarative configuration
```yaml
instrumentation/development:
  java:
    runtime_telemetry:
      emit_experimental_metrics/development: true
```

Users can opt-out by setting it to `false` which will revert to the upstream default behavior with:
```yaml
instrumentation/development:
  java:
    runtime_telemetry:
      emit_experimental_metrics/development: false
```