### PR TITLE
decl. config: delta metrics temporality

### DIFF
--- a/custom/src/main/java/co/elastic/otel/declarativeconfig/ElasticDeclarativeConfigurationCustomizer.java
+++ b/custom/src/main/java/co/elastic/otel/declarativeconfig/ElasticDeclarativeConfigurationCustomizer.java
@@ -64,6 +64,7 @@ public class ElasticDeclarativeConfigurationCustomizer
         model -> {
           customizeResources(model);
           customizeUserAgent(model);
+          customizeMetricsTemporality(model);
           return model;
         });
   }
@@ -256,5 +257,41 @@ public class ElasticDeclarativeConfigurationCustomizer
     }
     result.add(new NameStringValuePairModel().withName(HEADER_NAME).withValue(value));
     return result;
+  }
+
+  private void customizeMetricsTemporality(OpenTelemetryConfigurationModel model) {
+    // configure otlp metric exporters temporality preference if not explicitly set.
+    // for users, setting it explicitly to 'cumulative' restores default SDK behavior.
+    //
+    // meter_provider:
+    //   readers:
+    //     - periodic:
+    //         exporter:
+    //           # or 'otlp_grpc' for grpc
+    //           otlp_http:
+    //             endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT:-http://localhost:4318}/v1/metrics
+    //             temporality_preference: delta
+
+    Optional.ofNullable(model.getMeterProvider())
+        .map(MeterProviderModel::getReaders)
+        .orElse(Collections.emptyList())
+        .forEach(
+            reader -> {
+              Optional.ofNullable(reader.getPeriodic())
+                  .map(PeriodicMetricReaderModel::getExporter)
+                  .ifPresent(
+                      metricExporterModel -> {
+                        OtlpGrpcMetricExporterModel otlpGrpc = metricExporterModel.getOtlpGrpc();
+                        if (otlpGrpc != null && otlpGrpc.getTemporalityPreference() == null) {
+                          otlpGrpc.withTemporalityPreference(
+                              OtlpHttpMetricExporterModel.ExporterTemporalityPreference.DELTA);
+                        }
+                        OtlpHttpMetricExporterModel otlpHttp = metricExporterModel.getOtlpHttp();
+                        if (otlpHttp != null && otlpHttp.getTemporalityPreference() == null) {
+                          otlpHttp.withTemporalityPreference(
+                              OtlpHttpMetricExporterModel.ExporterTemporalityPreference.DELTA);
+                        }
+                      });
+            });
   }
 }

--- a/custom/src/test/java/co/elastic/otel/declarativeconfig/ElasticDeclarativeConfigurationCustomizerTest.java
+++ b/custom/src/test/java/co/elastic/otel/declarativeconfig/ElasticDeclarativeConfigurationCustomizerTest.java
@@ -50,6 +50,7 @@ import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.Tracer
 import io.opentelemetry.sdk.logs.export.LogRecordExporter;
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -57,9 +58,13 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
 import java.util.function.Function;
+import java.util.stream.Stream;
+import javax.annotation.Nullable;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 class ElasticDeclarativeConfigurationCustomizerTest {
@@ -242,6 +247,69 @@ class ElasticDeclarativeConfigurationCustomizerTest {
     header.put("name", "User-Agent");
     header.put("value", value);
     return header;
+  }
+
+  @ParameterizedTest
+  @MethodSource("metricExporterTemporalityValues")
+  void metricExporterTemporality(String protocol, @Nullable String userSetTemporality) {
+
+    OpenTelemetryConfigurationModel model = new OpenTelemetryConfigurationModel();
+    PushMetricExporterModel metricExporterModel = new PushMetricExporterModel();
+
+    switch (protocol) {
+      case "grpc":
+        OtlpHttpMetricExporterModel.ExporterTemporalityPreference grpcUserPreference = null;
+        if (userSetTemporality != null) {
+          grpcUserPreference =
+              OtlpHttpMetricExporterModel.ExporterTemporalityPreference.fromValue(
+                  userSetTemporality);
+        }
+        metricExporterModel.withOtlpGrpc(
+            new OtlpGrpcMetricExporterModel().withTemporalityPreference(grpcUserPreference));
+        break;
+      case "http":
+        OtlpHttpMetricExporterModel.ExporterTemporalityPreference httpUserPreference = null;
+        if (userSetTemporality != null) {
+          httpUserPreference =
+              OtlpHttpMetricExporterModel.ExporterTemporalityPreference.fromValue(
+                  userSetTemporality);
+        }
+        metricExporterModel.withOtlpHttp(
+            new OtlpHttpMetricExporterModel().withTemporalityPreference(httpUserPreference));
+        break;
+      default:
+        throw new IllegalArgumentException("Unsupported protocol: " + protocol);
+    }
+
+    model.withMeterProvider(
+        new MeterProviderModel()
+            .withReaders(
+                Collections.singletonList(
+                    new MetricReaderModel()
+                        .withPeriodic(
+                            new PeriodicMetricReaderModel().withExporter(metricExporterModel)))));
+
+    applyConfigCustomize(model, new ElasticDeclarativeConfigurationCustomizer());
+
+    assertThat(model.getMeterProvider()).isNotNull();
+    assertThat(model.getMeterProvider().getReaders()).hasSize(1);
+    assertThatJson(json(model.getMeterProvider().getReaders().get(0)))
+        .inPath("periodic.exporter.otlp_" + protocol + ".temporality_preference")
+        .isEqualTo(userSetTemporality != null ? userSetTemporality : "delta");
+  }
+
+  public static Stream<Arguments> metricExporterTemporalityValues() {
+    ArrayList<Arguments> args = new ArrayList<>();
+    for (String protocol : Arrays.asList("grpc", "http")) {
+      for (OtlpHttpMetricExporterModel.ExporterTemporalityPreference temporality :
+          OtlpHttpMetricExporterModel.ExporterTemporalityPreference.values()) {
+        String userValue = temporality.name().toLowerCase();
+        args.add(Arguments.of(protocol, userValue));
+      }
+      // test for default value when user does not set any value
+      args.add(Arguments.of(protocol, null));
+    }
+    return args.stream();
   }
 
   private OpenTelemetryConfigurationModel applyConfigCustomize(


### PR DESCRIPTION
part of #1054 

This makes EDOT java set `temporality_preference` to `delta` when not explicitly set by user
```yaml
meter_provider:
  readers:
    - periodic:
        exporter:
          # or 'otlp_grpc' for grpc
          otlp_http:
            endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT:-http://localhost:4318}/v1/metrics
            temporality_preference: delta
```

users can opt-out by setting `temporality_preference` explicitly:
```yaml
meter_provider:
  readers:
    - periodic:
        exporter:
          # or 'otlp_grpc' for grpc
          otlp_http:
            endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT:-http://localhost:4318}/v1/metrics
            # or 'low_memory'
            temporality_preference: cumulative
```