### PR TITLE
switch alternative approach to declarative config

### DIFF
--- a/agent/entrypoint/src/main/java/co/elastic/otel/agent/ElasticAgent.java
+++ b/agent/entrypoint/src/main/java/co/elastic/otel/agent/ElasticAgent.java
@@ -19,7 +19,10 @@
 package co.elastic.otel.agent;
 
 import io.opentelemetry.javaagent.OpenTelemetryAgent;
+import java.io.IOException;
+import java.io.InputStream;
 import java.lang.instrument.Instrumentation;
+import java.util.Objects;
 
 /** Elastic agent entry point, delegates to OpenTelemetry agent */
 public class ElasticAgent {
@@ -56,7 +59,36 @@ public class ElasticAgent {
    * @param args arguments
    */
   public static void main(String[] args) {
-    OpenTelemetryAgent.main(args);
+    boolean upstreamDefault = true;
+    for (String arg : args) {
+      switch (arg) {
+        case "--default-config-yaml":
+          printDefaultConfigYaml();
+          upstreamDefault = false;
+          break;
+      }
+    }
+
+    if (upstreamDefault) {
+      OpenTelemetryAgent.main(args);
+    }
+  }
+
+  private static void printDefaultConfigYaml() {
+    try (InputStream input =
+        ElasticAgent.class
+            .getClassLoader()
+            .getResourceAsStream("inst/co/elastic/otel/config.yaml")) {
+      Objects.requireNonNull(input, "Default config yaml resource is missing");
+
+      byte[] buffer = new byte[8192];
+      int read;
+      while ((read = input.read(buffer)) != -1) {
+        System.out.write(buffer, 0, read);
+      }
+    } catch (IOException e) {
+      throw new IllegalStateException("Failed to print default config yaml", e);
+    }
   }
 
   private static void initLogging() {

--- a/custom/src/main/java/co/elastic/otel/declarativeconfig/ElasticDeclarativeConfigurationCustomizer.java
+++ b/custom/src/main/java/co/elastic/otel/declarativeconfig/ElasticDeclarativeConfigurationCustomizer.java
@@ -29,9 +29,6 @@ import io.opentelemetry.sdk.extension.incubator.fileconfig.DeclarativeConfigurat
 import io.opentelemetry.sdk.extension.incubator.fileconfig.DeclarativeConfigurationCustomizerProvider;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.BatchLogRecordProcessorModel;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.BatchSpanProcessorModel;
-import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.ExperimentalInstrumentationModel;
-import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.ExperimentalLanguageSpecificInstrumentationModel;
-import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.ExperimentalLanguageSpecificInstrumentationPropertyModel;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.ExperimentalResourceDetectionModel;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.ExperimentalResourceDetectorModel;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.LogRecordExporterModel;
@@ -61,47 +58,14 @@ import javax.annotation.Nullable;
 public class ElasticDeclarativeConfigurationCustomizer
     implements DeclarativeConfigurationCustomizerProvider {
 
-  private static final String RUNTIME_TELEMETRY = "runtime_telemetry";
-  private static final String EMIT_EXPERIMENTAL_METRICS_DEVELOPMENT =
-      "emit_experimental_metrics/development";
-
   @Override
   public void customize(DeclarativeConfigurationCustomizer customizer) {
     customizer.addModelCustomizer(
         model -> {
           customizeResources(model);
           customizeUserAgent(model);
-          customizeExperimentalRuntimeTelemetryMetrics(model);
           return model;
         });
-  }
-
-  private static void customizeExperimentalRuntimeTelemetryMetrics(
-      OpenTelemetryConfigurationModel model) {
-
-    ExperimentalInstrumentationModel instrumentationDevelopment =
-        model.getInstrumentationDevelopment();
-    if (instrumentationDevelopment == null) {
-      instrumentationDevelopment = new ExperimentalInstrumentationModel();
-      model.withInstrumentationDevelopment(instrumentationDevelopment);
-    }
-
-    ExperimentalLanguageSpecificInstrumentationModel java = instrumentationDevelopment.getJava();
-    if (java == null) {
-      java = new ExperimentalLanguageSpecificInstrumentationModel();
-      instrumentationDevelopment.withJava(java);
-    }
-
-    ExperimentalLanguageSpecificInstrumentationPropertyModel runtimeTelemetry =
-        java.getAdditionalProperties().get(RUNTIME_TELEMETRY);
-    if (runtimeTelemetry == null) {
-      runtimeTelemetry = new ExperimentalLanguageSpecificInstrumentationPropertyModel();
-      java.withAdditionalProperty(RUNTIME_TELEMETRY, runtimeTelemetry);
-    }
-    if (runtimeTelemetry.getAdditionalProperties().get(EMIT_EXPERIMENTAL_METRICS_DEVELOPMENT)
-        == null) {
-      runtimeTelemetry.withAdditionalProperty(EMIT_EXPERIMENTAL_METRICS_DEVELOPMENT, true);
-    }
   }
 
   private static void customizeResources(OpenTelemetryConfigurationModel model) {

--- a/custom/src/main/java/co/elastic/otel/declarativeconfig/ElasticDeclarativeConfigurationCustomizer.java
+++ b/custom/src/main/java/co/elastic/otel/declarativeconfig/ElasticDeclarativeConfigurationCustomizer.java
@@ -62,6 +62,10 @@ public class ElasticDeclarativeConfigurationCustomizer
   public void customize(DeclarativeConfigurationCustomizer customizer) {
     customizer.addModelCustomizer(
         model -> {
+          if(model == null){
+            model = new OpenTelemetryConfigurationModel();
+          }
+
           customizeResources(model);
           customizeUserAgent(model);
           return model;

--- a/custom/src/main/java/co/elastic/otel/declarativeconfig/ElasticDeclarativeConfigurationCustomizer.java
+++ b/custom/src/main/java/co/elastic/otel/declarativeconfig/ElasticDeclarativeConfigurationCustomizer.java
@@ -62,7 +62,7 @@ public class ElasticDeclarativeConfigurationCustomizer
   public void customize(DeclarativeConfigurationCustomizer customizer) {
     customizer.addModelCustomizer(
         model -> {
-          if(model == null){
+          if (model == null) {
             model = new OpenTelemetryConfigurationModel();
           }
 

--- a/custom/src/main/resources/co/elastic/otel/config.yaml
+++ b/custom/src/main/resources/co/elastic/otel/config.yaml
@@ -1,0 +1,61 @@
+file_format: "1.0"
+resource:
+  attributes:
+  #     use this to set custom resource attributes
+  #    - name: custom.attribute
+  #      value: custom.attribute.value
+
+  # get attributes from OTEL_RESOURCE_ATTRIBUTES environment variable if set
+  attributes_list: ${OTEL_RESOURCE_ATTRIBUTES:-}
+
+  detection/development:
+    detectors:
+      # Enable cloud provider resource attributes detectors by default for easier onboarding.
+      # Those may slow down application startup, thus only the relevant ones should be enabled in production
+      - aws:
+      - azure:
+      - gcp:
+      # Provides 'process.*' attributes, including 'process.pid'
+      - process:
+      # Provides 'host.id'
+      - host:
+      # Provides 'container.id'
+      - container:
+      # Provides 'service.name' and 'service.instance.id'
+      - service:
+
+tracer_provider:
+  processors:
+    - batch:
+        exporter:
+          otlp_http:
+            # get endpoint from OTEL_EXPORTER_OTLP_ENDPOINT environment variable if set, otherwise fallback to local collector
+            endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT:-http://localhost:4318}/v1/traces
+            # get endpoint headers (like authentication) from OTEL_EXPORTER_OTLP_HEADERS environment variable if set
+            headers_list: ${OTEL_EXPORTER_OTLP_HEADERS}
+
+meter_provider:
+  readers:
+    - periodic:
+        exporter:
+          otlp_http:
+            # get endpoint from OTEL_EXPORTER_OTLP_ENDPOINT environment variable if set, otherwise fallback to local collector
+            endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT:-http://localhost:4318}/v1/metrics
+            # get endpoint headers (like authentication) from OTEL_EXPORTER_OTLP_HEADERS environment variable if set
+            headers_list: ${OTEL_EXPORTER_OTLP_HEADERS}
+
+logger_provider:
+  processors:
+    - batch:
+        exporter:
+          otlp_http:
+            # get endpoint from OTEL_EXPORTER_OTLP_ENDPOINT environment variable if set, otherwise fallback to local collector
+            endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT:-http://localhost:4318}/v1/logs
+            # get endpoint headers (like authentication) from OTEL_EXPORTER_OTLP_HEADERS environment variable if set
+            headers_list: ${OTEL_EXPORTER_OTLP_HEADERS}
+
+instrumentation/development:
+  java:
+    runtime_telemetry:
+      # emit not-yet stable runtime telemetry metrics which are currently part of semconv for java runtime
+      emit_experimental_metrics/development: true

--- a/custom/src/main/resources/co/elastic/otel/config.yaml
+++ b/custom/src/main/resources/co/elastic/otel/config.yaml
@@ -28,31 +28,43 @@ tracer_provider:
   processors:
     - batch:
         exporter:
+          # get endpoint from OTEL_EXPORTER_OTLP_ENDPOINT environment variable if set, otherwise fallback to local collector
+          # get endpoint headers (like authentication) from OTEL_EXPORTER_OTLP_HEADERS environment variable if set
           otlp_http:
-            # get endpoint from OTEL_EXPORTER_OTLP_ENDPOINT environment variable if set, otherwise fallback to local collector
             endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT:-http://localhost:4318}/v1/traces
-            # get endpoint headers (like authentication) from OTEL_EXPORTER_OTLP_HEADERS environment variable if set
             headers_list: ${OTEL_EXPORTER_OTLP_HEADERS}
+          # use the following for grpc
+          # otlp_grpc:
+          #  endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+          #  headers_list: ${OTEL_EXPORTER_OTLP_HEADERS}
 
 meter_provider:
   readers:
     - periodic:
         exporter:
-          otlp_http:
-            # get endpoint from OTEL_EXPORTER_OTLP_ENDPOINT environment variable if set, otherwise fallback to local collector
+          # get endpoint from OTEL_EXPORTER_OTLP_ENDPOINT environment variable if set, otherwise fallback to local collector
+          # get endpoint headers (like authentication) from OTEL_EXPORTER_OTLP_HEADERS environment variable if set
+          otlp_grpc:
             endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT:-http://localhost:4318}/v1/metrics
-            # get endpoint headers (like authentication) from OTEL_EXPORTER_OTLP_HEADERS environment variable if set
             headers_list: ${OTEL_EXPORTER_OTLP_HEADERS}
+          # use the following for grpc
+          # otlp_grpc:
+          #  endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+          #  headers_list: ${OTEL_EXPORTER_OTLP_HEADERS}
 
 logger_provider:
   processors:
     - batch:
         exporter:
-          otlp_http:
-            # get endpoint from OTEL_EXPORTER_OTLP_ENDPOINT environment variable if set, otherwise fallback to local collector
+          # get endpoint from OTEL_EXPORTER_OTLP_ENDPOINT environment variable if set, otherwise fallback to local collector
+          # get endpoint headers (like authentication) from OTEL_EXPORTER_OTLP_HEADERS environment variable if set
+          otlp_grpc:
             endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT:-http://localhost:4318}/v1/logs
-            # get endpoint headers (like authentication) from OTEL_EXPORTER_OTLP_HEADERS environment variable if set
             headers_list: ${OTEL_EXPORTER_OTLP_HEADERS}
+          # use the following for grpc
+          # otlp_grpc:
+          #  endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+          #  headers_list: ${OTEL_EXPORTER_OTLP_HEADERS}
 
 instrumentation/development:
   java:

--- a/custom/src/main/resources/co/elastic/otel/config.yaml
+++ b/custom/src/main/resources/co/elastic/otel/config.yaml
@@ -44,7 +44,7 @@ meter_provider:
         exporter:
           # get endpoint from OTEL_EXPORTER_OTLP_ENDPOINT environment variable if set, otherwise fallback to local collector
           # get endpoint headers (like authentication) from OTEL_EXPORTER_OTLP_HEADERS environment variable if set
-          otlp_grpc:
+          otlp_http:
             endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT:-http://localhost:4318}/v1/metrics
             headers_list: ${OTEL_EXPORTER_OTLP_HEADERS}
           # use the following for grpc
@@ -58,7 +58,7 @@ logger_provider:
         exporter:
           # get endpoint from OTEL_EXPORTER_OTLP_ENDPOINT environment variable if set, otherwise fallback to local collector
           # get endpoint headers (like authentication) from OTEL_EXPORTER_OTLP_HEADERS environment variable if set
-          otlp_grpc:
+          otlp_http:
             endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT:-http://localhost:4318}/v1/logs
             headers_list: ${OTEL_EXPORTER_OTLP_HEADERS}
           # use the following for grpc

--- a/custom/src/test/java/co/elastic/otel/declarativeconfig/DefaultDeclarativeConfigTest.java
+++ b/custom/src/test/java/co/elastic/otel/declarativeconfig/DefaultDeclarativeConfigTest.java
@@ -75,7 +75,7 @@ public class DefaultDeclarativeConfigTest {
 
           assertThat(config.getMeterProvider()).isNotNull();
           assertThat(assertThat(config.getMeterProvider().getReaders()).hasSize(1));
-          assertThatJson(json((config.getMeterProvider().getReaders().get(0))))
+          assertThatJson(json(config.getMeterProvider().getReaders().get(0)))
               .inPath("periodic.exporter.otlp_http")
               .isObject()
               .containsEntry("endpoint", "http://localhost:4318/v1/metrics");

--- a/custom/src/test/java/co/elastic/otel/declarativeconfig/DefaultDeclarativeConfigTest.java
+++ b/custom/src/test/java/co/elastic/otel/declarativeconfig/DefaultDeclarativeConfigTest.java
@@ -67,21 +67,21 @@ public class DefaultDeclarativeConfigTest {
               json("{\"host\":{}}"));
 
           assertThat(config.getTracerProvider()).isNotNull();
-          assertThat(assertThat(config.getTracerProvider().getProcessors()).hasSize(1));
+          assertThat(config.getTracerProvider().getProcessors()).hasSize(1);
           assertThatJson(json((config.getTracerProvider().getProcessors().get(0))))
               .inPath("batch.exporter.otlp_http")
               .isObject()
               .containsEntry("endpoint", "http://localhost:4318/v1/traces");
 
           assertThat(config.getMeterProvider()).isNotNull();
-          assertThat(assertThat(config.getMeterProvider().getReaders()).hasSize(1));
+          assertThat(config.getMeterProvider().getReaders()).hasSize(1);
           assertThatJson(json(config.getMeterProvider().getReaders().get(0)))
               .inPath("periodic.exporter.otlp_http")
               .isObject()
               .containsEntry("endpoint", "http://localhost:4318/v1/metrics");
 
           assertThat(config.getLoggerProvider()).isNotNull();
-          assertThat(assertThat(config.getLoggerProvider().getProcessors()).hasSize(1));
+          assertThat(config.getLoggerProvider().getProcessors()).hasSize(1);
           assertThatJson(json((config.getLoggerProvider().getProcessors().get(0))))
               .inPath("batch.exporter.otlp_http")
               .isObject()

--- a/custom/src/test/java/co/elastic/otel/declarativeconfig/DefaultDeclarativeConfigTest.java
+++ b/custom/src/test/java/co/elastic/otel/declarativeconfig/DefaultDeclarativeConfigTest.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.otel.declarativeconfig;
+
+import static co.elastic.otel.declarativeconfig.ElasticDeclarativeConfigurationCustomizerTest.*;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.json;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.javaagent.tooling.resources.ResourceCustomizerProvider;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.DeclarativeConfiguration;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.OpenTelemetryConfigurationModel;
+import java.io.InputStream;
+import java.util.function.Consumer;
+import net.javacrumbs.jsonunit.assertj.JsonListAssert;
+import org.junit.jupiter.api.Test;
+
+public class DefaultDeclarativeConfigTest {
+
+  // For now, we can't override env variable for testing, thus we just verify the default values
+  // in the configuration we provide.
+  @Test
+  void testDefaults() {
+    test(
+        (config) -> {
+          assertThat(config.getResource()).isNotNull();
+          assertThat(config.getResource().getAttributesList()).isNull();
+
+          assertThatJson(json(config.getResource())).inPath("attributes").isArray().isEmpty();
+          JsonListAssert detectorsAssert =
+              assertThatJson(json(config.getResource()))
+                  .inPath("detection/development.detectors")
+                  .isArray()
+                  .hasSize(9);
+
+          // those are the providers magically added by upstream and elastic distributions
+          detectorsAssert
+              .first()
+              .isEqualTo(json("{\"opentelemetry_javaagent_distribution\":null}"));
+          detectorsAssert.last().isEqualTo(json("{\"elastic_distribution\":null}"));
+
+          // those are the ones that should be included in the default configuration
+          detectorsAssert.contains(
+              json("{\"aws\":null}"),
+              json("{\"gcp\":null}"),
+              json("{\"azure\":null}"),
+              // TODO: maybe investigate why those are including empty objects
+              json("{\"process\":{}}}"),
+              json("{\"container\":{}}}"),
+              json("{\"service\":{}}}"),
+              json("{\"host\":{}}}"));
+
+          assertThat(config.getTracerProvider()).isNotNull();
+          assertThat(assertThat(config.getTracerProvider().getProcessors()).hasSize(1));
+          assertThatJson(json((config.getTracerProvider().getProcessors().get(0))))
+              .inPath("batch.exporter.otlp_http")
+              .isObject()
+              .containsEntry("endpoint", "http://localhost:4318/v1/traces");
+
+          assertThat(config.getMeterProvider()).isNotNull();
+          assertThat(assertThat(config.getMeterProvider().getReaders()).hasSize(1));
+          assertThatJson(json((config.getMeterProvider().getReaders().get(0))))
+              .inPath("periodic.exporter.otlp_http")
+              .isObject()
+              .containsEntry("endpoint", "http://localhost:4318/v1/metrics");
+
+          assertThat(config.getLoggerProvider()).isNotNull();
+          assertThat(assertThat(config.getLoggerProvider().getProcessors()).hasSize(1));
+          assertThatJson(json((config.getLoggerProvider().getProcessors().get(0))))
+              .inPath("batch.exporter.otlp_http")
+              .isObject()
+              .containsEntry("endpoint", "http://localhost:4318/v1/logs");
+
+          assertThatJson(json(config.getInstrumentationDevelopment()))
+              .describedAs("experimental jvm runtime telemetry metrics enabled by default")
+              .inPath("java.runtime_telemetry.emit_experimental_metrics/development")
+              .isBoolean()
+              .isTrue();
+        });
+  }
+
+  private static void test(Consumer<OpenTelemetryConfigurationModel> configChecks) {
+
+    InputStream input =
+        DefaultDeclarativeConfigTest.class
+            .getClassLoader()
+            .getResourceAsStream("co/elastic/otel/config.yaml");
+    assertThat(input).isNotNull();
+    OpenTelemetryConfigurationModel config = DeclarativeConfiguration.parse(input);
+
+    // manually apply config customization for simplicity
+    config = applyConfigCustomize(config, new ElasticDeclarativeConfigurationCustomizer());
+    config = applyConfigCustomize(config, new ResourceCustomizerProvider());
+
+    configChecks.accept(config);
+  }
+}

--- a/custom/src/test/java/co/elastic/otel/declarativeconfig/DefaultDeclarativeConfigTest.java
+++ b/custom/src/test/java/co/elastic/otel/declarativeconfig/DefaultDeclarativeConfigTest.java
@@ -61,10 +61,10 @@ public class DefaultDeclarativeConfigTest {
               json("{\"gcp\":null}"),
               json("{\"azure\":null}"),
               // TODO: maybe investigate why those are including empty objects
-              json("{\"process\":{}}}"),
-              json("{\"container\":{}}}"),
-              json("{\"service\":{}}}"),
-              json("{\"host\":{}}}"));
+              json("{\"process\":{}}"),
+              json("{\"container\":{}}"),
+              json("{\"service\":{}}"),
+              json("{\"host\":{}}"));
 
           assertThat(config.getTracerProvider()).isNotNull();
           assertThat(assertThat(config.getTracerProvider().getProcessors()).hasSize(1));

--- a/custom/src/test/java/co/elastic/otel/declarativeconfig/ElasticDeclarativeConfigurationCustomizerTest.java
+++ b/custom/src/test/java/co/elastic/otel/declarativeconfig/ElasticDeclarativeConfigurationCustomizerTest.java
@@ -29,9 +29,6 @@ import io.opentelemetry.sdk.extension.incubator.fileconfig.DeclarativeConfigurat
 import io.opentelemetry.sdk.extension.incubator.fileconfig.DeclarativeConfigurationCustomizerProvider;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.BatchLogRecordProcessorModel;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.BatchSpanProcessorModel;
-import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.ExperimentalInstrumentationModel;
-import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.ExperimentalLanguageSpecificInstrumentationModel;
-import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.ExperimentalLanguageSpecificInstrumentationPropertyModel;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.LogRecordExporterModel;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.LogRecordProcessorModel;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.LoggerProviderModel;
@@ -83,12 +80,6 @@ class ElasticDeclarativeConfigurationCustomizerTest {
     assertThat(model.getTracerProvider()).isNull();
     assertThat(model.getMeterProvider()).isNull();
     assertThat(model.getLoggerProvider()).isNull();
-
-    // java experimental runtime metrics enabled by default
-    assertThatJson(json(model.getInstrumentationDevelopment()))
-        .inPath("java.runtime_telemetry.emit_experimental_metrics/development")
-        .isBoolean()
-        .isTrue();
   }
 
   @ParameterizedTest
@@ -245,28 +236,6 @@ class ElasticDeclarativeConfigurationCustomizerTest {
         .contains("user-agent", "custom-user-Agent");
   }
 
-  @Test
-  void optOutExperimentalRuntimeMetrics() {
-    OpenTelemetryConfigurationModel model =
-        new OpenTelemetryConfigurationModel()
-            .withInstrumentationDevelopment(
-                new ExperimentalInstrumentationModel()
-                    .withJava(
-                        new ExperimentalLanguageSpecificInstrumentationModel()
-                            .withAdditionalProperty(
-                                "runtime_telemetry",
-                                new ExperimentalLanguageSpecificInstrumentationPropertyModel()
-                                    .withAdditionalProperty(
-                                        "emit_experimental_metrics/development", false))));
-
-    model = applyConfigCustomize(model, new ElasticDeclarativeConfigurationCustomizer());
-
-    assertThatJson(json(model.getInstrumentationDevelopment()))
-        .inPath("java.runtime_telemetry.emit_experimental_metrics/development")
-        .isBoolean()
-        .isFalse();
-  }
-
   @NotNull
   private static Map<String, String> userAgentHeader(String value) {
     Map<String, String> header = new HashMap<>();
@@ -275,7 +244,7 @@ class ElasticDeclarativeConfigurationCustomizerTest {
     return header;
   }
 
-  private OpenTelemetryConfigurationModel applyConfigCustomize(
+  static OpenTelemetryConfigurationModel applyConfigCustomize(
       OpenTelemetryConfigurationModel originalModel,
       DeclarativeConfigurationCustomizerProvider customizerProvider) {
     AtomicReference<OpenTelemetryConfigurationModel> resultModel = new AtomicReference<>();

--- a/smoke-tests/src/test/java/com/example/javaagent/smoketest/DeclarativeConfigSmokeTest.java
+++ b/smoke-tests/src/test/java/com/example/javaagent/smoketest/DeclarativeConfigSmokeTest.java
@@ -55,6 +55,9 @@ public class DeclarativeConfigSmokeTest extends TestAppSmokeTest {
               .redirectOutput(targetPath.toFile())
               .start();
       boolean processExit = process.waitFor(5, TimeUnit.SECONDS);
+      if (!processExit) {
+        process.destroyForcibly();
+      }
       if (!processExit || process.exitValue() != 0) {
         throw new IllegalStateException("failed to get default declarative config");
       }

--- a/smoke-tests/src/test/java/com/example/javaagent/smoketest/DeclarativeConfigSmokeTest.java
+++ b/smoke-tests/src/test/java/com/example/javaagent/smoketest/DeclarativeConfigSmokeTest.java
@@ -18,6 +18,17 @@
  */
 package com.example.javaagent.smoketest;
 
+import static io.opentelemetry.semconv.ServiceAttributes.SERVICE_INSTANCE_ID;
+import static io.opentelemetry.semconv.ServiceAttributes.SERVICE_NAME;
+import static io.opentelemetry.semconv.incubating.ContainerIncubatingAttributes.CONTAINER_ID;
+import static io.opentelemetry.semconv.incubating.HostIncubatingAttributes.HOST_ARCH;
+import static io.opentelemetry.semconv.incubating.HostIncubatingAttributes.HOST_NAME;
+import static io.opentelemetry.semconv.incubating.OsIncubatingAttributes.OS_TYPE;
+import static io.opentelemetry.semconv.incubating.OsIncubatingAttributes.OS_VERSION;
+import static io.opentelemetry.semconv.incubating.ProcessIncubatingAttributes.PROCESS_COMMAND_ARGS;
+import static io.opentelemetry.semconv.incubating.ProcessIncubatingAttributes.PROCESS_PID;
+import static io.opentelemetry.semconv.incubating.TelemetryIncubatingAttributes.TELEMETRY_DISTRO_NAME;
+import static io.opentelemetry.semconv.incubating.TelemetryIncubatingAttributes.TELEMETRY_DISTRO_VERSION;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
@@ -82,13 +93,18 @@ public class DeclarativeConfigSmokeTest extends TestAppSmokeTest {
             container
                 .withCopyFileToContainer(MountableFile.forHostPath(configFile), "/config.yaml")
                 .withEnv("OTEL_CONFIG_FILE", "/config.yaml")
-                .withEnv("OTEL_EXPORTER_OTLP_ENDPOINT", BACKEND_ENDPOINT),
+                .withEnv("OTEL_EXPORTER_OTLP_ENDPOINT", BACKEND_ENDPOINT)
+                .withEnv("OTEL_SERVICE_NAME", "my-service-name"),
         false);
   }
 
   @Test
-  void healthcheck() {
+  void resourceAttributes() {
     doRequest(getUrl("/health"), okResponseBody("Alive!"));
+
+    // This does not test that cloud resource providers are included in the config
+    // but at least we know that if they are added in the config their names are valid as otherwise
+    // the agent does not start with any missing component in config.
 
     List<ExportTraceServiceRequest> traces = waitForTraces();
     List<Span> spans = getSpans(traces).toList();
@@ -96,6 +112,22 @@ public class DeclarativeConfigSmokeTest extends TestAppSmokeTest {
         .hasSize(1)
         .extracting("name", "kind")
         .containsOnly(tuple("GET /health", Span.SpanKind.SPAN_KIND_SERVER));
+
+    assertThat(getResourceAttributes(traces))
+        .containsKey(HOST_NAME.getKey())
+        .containsKey(HOST_ARCH.getKey())
+        .containsKey(OS_TYPE.getKey())
+        .containsKey(OS_VERSION.getKey())
+        .containsKey(PROCESS_PID.getKey())
+        .containsKey(PROCESS_COMMAND_ARGS.getKey())
+        .containsKey(CONTAINER_ID.getKey())
+        // service name should be provided by the 'service' resource attribute detector which
+        // reads environment variables (here it's not env variable injected in declarative config).
+        .containsEntry(SERVICE_NAME.getKey(), attributeValue("my-service-name"))
+        .containsKey(SERVICE_INSTANCE_ID.getKey())
+        // ensures that we override the default distro resource attributes
+        .containsEntry(TELEMETRY_DISTRO_NAME.getKey(), attributeValue("elastic"))
+        .containsKey(TELEMETRY_DISTRO_VERSION.getKey());
   }
 
   @AfterAll

--- a/smoke-tests/src/test/java/com/example/javaagent/smoketest/DeclarativeConfigSmokeTest.java
+++ b/smoke-tests/src/test/java/com/example/javaagent/smoketest/DeclarativeConfigSmokeTest.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.example.javaagent.smoketest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
+import io.opentelemetry.proto.trace.v1.Span;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.utility.MountableFile;
+
+public class DeclarativeConfigSmokeTest extends TestAppSmokeTest {
+
+  private static void extractDeclarativeConfig(Path targetPath) {
+    try {
+      Process process =
+          new ProcessBuilder()
+              .command(JavaExecutable.getBinaryPath(), "-jar", AGENT_PATH, "--default-config-yaml")
+              .redirectOutput(targetPath.toFile())
+              .start();
+      boolean processExit = process.waitFor(5, TimeUnit.SECONDS);
+      if (!processExit || process.exitValue() != 0) {
+        throw new IllegalStateException("failed to get default declarative config");
+      }
+    } catch (InterruptedException | IOException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  @BeforeAll
+  static void start() throws IOException {
+
+    Path configFile = Files.createTempFile("tmp", ".yaml");
+    extractDeclarativeConfig(configFile);
+
+    // need to do some post-processing to switch from http to grpc by default
+    List<String> modifiedConfig =
+        Files.readAllLines(configFile).stream()
+            .map(
+                line -> {
+                  if (line.contains("otlp_http")) {
+                    // replace http exporter to grpc
+                    return line.replace("otlp_http", "otlp_grpc");
+                  } else if (line.contains("endpoint:")) {
+                    // for grpc the endpoint should not have a path like with HTTP
+                    int index = line.indexOf("endpoint:");
+                    return line.substring(0, index + 10) + "${OTEL_EXPORTER_OTLP_ENDPOINT}";
+                  } else {
+                    return line;
+                  }
+                })
+            .collect(Collectors.toList());
+    Files.write(configFile, modifiedConfig);
+
+    startTestApp(
+        (container) ->
+            container
+                .withCopyFileToContainer(MountableFile.forHostPath(configFile), "/config.yaml")
+                .withEnv("OTEL_CONFIG_FILE", "/config.yaml")
+                .withEnv("OTEL_EXPORTER_OTLP_ENDPOINT", BACKEND_ENDPOINT),
+        false);
+  }
+
+  @Test
+  void healthcheck() {
+    doRequest(getUrl("/health"), okResponseBody("Alive!"));
+
+    List<ExportTraceServiceRequest> traces = waitForTraces();
+    List<Span> spans = getSpans(traces).toList();
+    assertThat(spans)
+        .hasSize(1)
+        .extracting("name", "kind")
+        .containsOnly(tuple("GET /health", Span.SpanKind.SPAN_KIND_SERVER));
+  }
+
+  @AfterAll
+  static void end() {
+    stopApp();
+  }
+}

--- a/smoke-tests/src/test/java/com/example/javaagent/smoketest/JavaExecutable.java
+++ b/smoke-tests/src/test/java/com/example/javaagent/smoketest/JavaExecutable.java
@@ -81,6 +81,9 @@ public class JavaExecutable {
                   JavaExecutable.getBinaryPath(), jvmDebugArgument("localhost", port), "-version")
               .start();
       boolean processExit = process.waitFor(5, TimeUnit.SECONDS);
+      if (!processExit) {
+        process.destroyForcibly();
+      }
       return processExit && process.exitValue() == 0;
     } catch (InterruptedException | IOException e) {
       return false;

--- a/smoke-tests/src/test/java/com/example/javaagent/smoketest/SmokeTest.java
+++ b/smoke-tests/src/test/java/com/example/javaagent/smoketest/SmokeTest.java
@@ -385,10 +385,18 @@ abstract class SmokeTest {
   }
 
   protected Map<String, AnyValue> getResourceAttributes(List<ExportTraceServiceRequest> traces) {
-    return traces.stream()
+    Map<String,AnyValue>  attributes = new HashMap<>();
+    traces.stream()
         .flatMap(it -> it.getResourceSpansList().stream())
         .flatMap(it -> it.getResource().getAttributesList().stream())
-        .collect(Collectors.toMap(KeyValue::getKey, KeyValue::getValue));
+        .forEach(kv -> {
+          AnyValue existingEntry = attributes.putIfAbsent(kv.getKey(), kv.getValue());
+          if (existingEntry != null && !existingEntry.equals(kv.getValue())) {
+            throw new IllegalStateException(
+                "duplicate resource attribute key with distinct values" + kv.getKey());
+          }
+        });
+    return attributes;
   }
 
   protected static String bytesToHex(byte[] bytes) {

--- a/smoke-tests/src/test/java/com/example/javaagent/smoketest/SmokeTest.java
+++ b/smoke-tests/src/test/java/com/example/javaagent/smoketest/SmokeTest.java
@@ -385,17 +385,18 @@ abstract class SmokeTest {
   }
 
   protected Map<String, AnyValue> getResourceAttributes(List<ExportTraceServiceRequest> traces) {
-    Map<String,AnyValue>  attributes = new HashMap<>();
+    Map<String, AnyValue> attributes = new HashMap<>();
     traces.stream()
         .flatMap(it -> it.getResourceSpansList().stream())
         .flatMap(it -> it.getResource().getAttributesList().stream())
-        .forEach(kv -> {
-          AnyValue existingEntry = attributes.putIfAbsent(kv.getKey(), kv.getValue());
-          if (existingEntry != null && !existingEntry.equals(kv.getValue())) {
-            throw new IllegalStateException(
-                "duplicate resource attribute key with distinct values" + kv.getKey());
-          }
-        });
+        .forEach(
+            kv -> {
+              AnyValue existingEntry = attributes.putIfAbsent(kv.getKey(), kv.getValue());
+              if (existingEntry != null && !existingEntry.equals(kv.getValue())) {
+                throw new IllegalStateException(
+                    "duplicate resource attribute key with distinct values" + kv.getKey());
+              }
+            });
     return attributes;
   }
 

--- a/smoke-tests/src/test/java/com/example/javaagent/smoketest/SmokeTest.java
+++ b/smoke-tests/src/test/java/com/example/javaagent/smoketest/SmokeTest.java
@@ -72,6 +72,7 @@ abstract class SmokeTest {
   protected static final String MOCK_SERVER_HOST = "mock-server";
   // map to HTTPS port for kubernetes, mock server will handle both http and https on the same port
   protected static final int MOCK_SERVER_PORT = 443;
+  protected static final String BACKEND_ENDPOINT = "http://backend:8080";
 
   protected static OkHttpClient client = OkHttpUtils.client();
 
@@ -115,16 +116,7 @@ abstract class SmokeTest {
         new GenericContainer<>(image)
             .withNetwork(network)
             .withLogConsumer(new Slf4jLogConsumer(logger))
-            .withCopyFileToContainer(MountableFile.forHostPath(AGENT_PATH), JAVAAGENT_JAR_PATH)
-
-            // batch span processor: very small batch size for testing
-            .withEnv("OTEL_BSP_MAX_EXPORT_BATCH", "1")
-            // batch span processor: very short delay for testing
-            .withEnv("OTEL_BSP_SCHEDULE_DELAY", "10")
-            // use grpc endpoint as default is now http/protobuf with agent 2.x
-            .withEnv("OTEL_EXPORTER_OTLP_PROTOCOL", "grpc")
-            .withEnv("OTEL_PROPAGATORS", "tracecontext,baggage")
-            .withEnv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://backend:8080");
+            .withCopyFileToContainer(MountableFile.forHostPath(AGENT_PATH), JAVAAGENT_JAR_PATH);
 
     StringBuilder jvmArgs = new StringBuilder();
 
@@ -153,6 +145,18 @@ abstract class SmokeTest {
     startedContainers.add(target);
 
     return target;
+  }
+
+  protected static void setBaseEnvironmentVariables(GenericContainer<?> target) {
+    target
+        // batch span processor: very small batch size for testing
+        .withEnv("OTEL_BSP_MAX_EXPORT_BATCH", "1")
+        // batch span processor: very short delay for testing
+        .withEnv("OTEL_BSP_SCHEDULE_DELAY", "10")
+        // use grpc endpoint as default is now http/protobuf with agent 2.x
+        .withEnv("OTEL_EXPORTER_OTLP_PROTOCOL", "grpc")
+        .withEnv("OTEL_PROPAGATORS", "tracecontext,baggage")
+        .withEnv("OTEL_EXPORTER_OTLP_ENDPOINT", BACKEND_ENDPOINT);
   }
 
   private static GenericContainer<?> addDockerDebugHost(GenericContainer<?> target) {

--- a/smoke-tests/src/test/java/com/example/javaagent/smoketest/SmokeTest.java
+++ b/smoke-tests/src/test/java/com/example/javaagent/smoketest/SmokeTest.java
@@ -384,6 +384,13 @@ abstract class SmokeTest {
         .flatMap(it -> it.getSpansList().stream());
   }
 
+  protected Map<String, AnyValue> getResourceAttributes(List<ExportTraceServiceRequest> traces) {
+    return traces.stream()
+        .flatMap(it -> it.getResourceSpansList().stream())
+        .flatMap(it -> it.getResource().getAttributesList().stream())
+        .collect(Collectors.toMap(KeyValue::getKey, KeyValue::getValue));
+  }
+
   protected static String bytesToHex(byte[] bytes) {
     StringBuilder sb = new StringBuilder();
     for (int i = 0; i < bytes.length; i++) {

--- a/smoke-tests/src/test/java/com/example/javaagent/smoketest/TestAppSmokeTest.java
+++ b/smoke-tests/src/test/java/com/example/javaagent/smoketest/TestAppSmokeTest.java
@@ -31,14 +31,23 @@ public class TestAppSmokeTest extends SmokeTest {
   private static GenericContainer<?> target;
 
   public static void startTestApp(Consumer<GenericContainer<?>> customizeContainer) {
+    startTestApp(customizeContainer, true);
+  }
+
+  public static void startTestApp(
+      Consumer<GenericContainer<?>> customizeContainer, boolean defaultEnv) {
     target =
         startTarget(
             TEST_APP_IMAGE,
             customizeContainer.andThen(
-                container ->
-                    container
-                        .withExposedPorts(PORT)
-                        .waitingFor(Wait.forHttp("/health").forPort(PORT))));
+                container -> {
+                  if (defaultEnv) {
+                    setBaseEnvironmentVariables(container);
+                  }
+                  container
+                      .withExposedPorts(PORT)
+                      .waitingFor(Wait.forHttp("/health").forPort(PORT));
+                }));
   }
 
   protected static String getContainerId() {


### PR DESCRIPTION
part of #1054 

- removing the "magic" modification of runtime declarative configuration
  - keep the user-agent modification for now
  - keep the distribution attribute provider added transparently as it does not make sense to expose this to user-visible configuration and might create issues if not properly defined/used.
- provide a static yaml configuration included in the agent jar
- provide simple testing of yaml file
- add `--default-config-yaml` CLI option to access the embedded yaml configuration in agent jar.

possible follow-up:
- [x] add integration test to ensure the configuration is 100% correct and can be loaded by the agent, for example we can easily add a missing resource attribute provider without any failure with this implementation.
