### PR TITLE
move logger init to avoid ClassCircularityError

### DIFF
--- a/internal-logging/src/main/java/co/elastic/otel/logging/AgentLog.java
+++ b/internal-logging/src/main/java/co/elastic/otel/logging/AgentLog.java
@@ -63,9 +63,9 @@ public class AgentLog {
    * @param usePlainTextLog {@literal true} to use plain text logging, `{@literal false} to use JSON
    * @param initialLevel initial log level to configure
    */
-  public static void init(boolean usePlainTextLog, Level initialLevel) {
+  public static void init(boolean usePlainTextLog, String initialLevel) {
     internalInit();
-    setLevel(initialLevel);
+    setLevel(Level.getLevel(initialLevel));
     logPlainText = usePlainTextLog;
   }
 

--- a/internal-logging/src/main/java/co/elastic/otel/logging/AgentLog.java
+++ b/internal-logging/src/main/java/co/elastic/otel/logging/AgentLog.java
@@ -30,6 +30,7 @@ import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 import java.util.Collection;
 import java.util.List;
+import java.util.Locale;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.config.Configurator;
@@ -65,7 +66,12 @@ public class AgentLog {
    */
   public static void init(boolean usePlainTextLog, String initialLevel) {
     internalInit();
-    setLevel(Level.getLevel(initialLevel));
+    initialLevel = initialLevel.toUpperCase(Locale.ROOT);
+    Level level = Level.getLevel(initialLevel);
+    if (level == null) {
+      level = Level.INFO;
+    }
+    setLevel(level);
     logPlainText = usePlainTextLog;
   }
 

--- a/internal-logging/src/main/java/co/elastic/otel/logging/ElasticLoggingCustomizer.java
+++ b/internal-logging/src/main/java/co/elastic/otel/logging/ElasticLoggingCustomizer.java
@@ -23,8 +23,6 @@ import io.opentelemetry.javaagent.bootstrap.InternalLogger;
 import io.opentelemetry.javaagent.tooling.LoggingCustomizer;
 import io.opentelemetry.javaagent.tooling.config.EarlyInitAgentConfig;
 import java.util.Optional;
-import org.apache.logging.log4j.Level;
-import org.slf4j.LoggerFactory;
 
 @AutoService(LoggingCustomizer.class)
 public class ElasticLoggingCustomizer implements LoggingCustomizer {
@@ -39,23 +37,19 @@ public class ElasticLoggingCustomizer implements LoggingCustomizer {
   public void init() {
     EarlyInitAgentConfig earlyConfig = EarlyInitAgentConfig.get();
 
-    // trigger loading the slf4j provider from the agent CL, this should load log4j implementation
-    LoggerFactory.getILoggerFactory();
-
     // make the agent internal logger delegate to slf4j, which will delegate to log4j
     InternalLogger.initialize(Slf4jInternalLogger::create);
 
     boolean upstreamDebugEnabled = earlyConfig.isDebug();
-    Level level;
+    String level;
     if (upstreamDebugEnabled) {
       // set debug logging when enabled through configuration to behave like the upstream
       // distribution
-      level = Level.DEBUG;
+      level = "DEBUG";
     } else {
       level =
           Optional.ofNullable(earlyConfig.getString("elastic.otel.javaagent.log.level"))
-              .map(Level::getLevel)
-              .orElse(Level.INFO);
+              .orElse("INFO");
     }
     AgentLog.init(upstreamDebugEnabled, level);
   }

--- a/internal-logging/src/main/java/co/elastic/otel/logging/Slf4jInternalLogger.java
+++ b/internal-logging/src/main/java/co/elastic/otel/logging/Slf4jInternalLogger.java
@@ -30,6 +30,8 @@ public class Slf4jInternalLogger implements InternalLogger {
   private static volatile boolean initializationComplete = false;
 
   static void setInitializationComplete() {
+    // trigger loading the slf4j provider from the agent CL, this should load log4j implementation
+    LoggerFactory.getILoggerFactory();
     initializationComplete = true;
   }
 


### PR DESCRIPTION
Following upstream update to 2.27.0 we get some `ClassCircularityError` when the agent starts with java 17 (and surprisingly not with other JDK versions).

This PR moves the logger initialization to a latter stage to avoid the issue.

It's technically a bug, but hasn't been released yet.