### PR TITLE
release changelog bundle description

### DIFF
--- a/.ci/changelog-bundle-description.sh
+++ b/.ci/changelog-bundle-description.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# this script generates the changelog bundle description content
+
+echo "This release is based on the following upstream versions:"
+./gradlew -q printUpstreamDependenciesMarkdown

--- a/.ci/changelog-upstream-update.sh
+++ b/.ci/changelog-upstream-update.sh
@@ -6,14 +6,12 @@ set -euo pipefail
 #   PR_URL: pull-request URL (used in the changelog entry to link to the PR)
 #   PR_NUMBER: pull-request number (used to name the changelog entry file)
 
-description="- $("./gradlew" -q changelogUpstreamDependenciesOneLiner)"
 docs-builder changelog add \
   --concise \
   --title "${PR_TITLE}" \
   --type enhancement \
   --prs "${PR_URL}" \
   --products "edot-java" \
-  --description "${description}"
 
 # will overwrite any prior update, if there is any
 mv -v "./docs/changelog/${PR_NUMBER}.yaml" "./docs/changelog/upstream-update.yaml"

--- a/.github/workflows/pre-post-release.yml
+++ b/.github/workflows/pre-post-release.yml
@@ -100,8 +100,11 @@ jobs:
 
       - name: Generate documentation changelog bundle (post release)
         if: inputs.phase == 'post'
+        # we should use the 'edot-java-release' profile to generate the bundle:
+        #   docs-builder changelog bundle edot-java-release ${{ env.RELEASE_VERSION }}
+        # this does not yet allow to provide the generated content for description, so we have to use the explicit arguments.
         run: |
-          docs-builder changelog bundle edot-java-release ${{ env.RELEASE_VERSION }}
+          docs-builder changelog bundle --input-products 'edot-java * *' --output-products 'edot-java ${{ env.RELEASE_VERSION }} ga' --output docs/releases/${{ env.RELEASE_VERSION }}.yaml --description "$(.ci/changelog-bundle-description.sh)"
           docs-builder changelog remove edot-java-release
   
       - name: Push the ${{ inputs.phase }} release branch

--- a/.github/workflows/pre-post-release.yml
+++ b/.github/workflows/pre-post-release.yml
@@ -104,7 +104,11 @@ jobs:
         #   docs-builder changelog bundle edot-java-release ${{ env.RELEASE_VERSION }}
         # this does not yet allow to provide the generated content for description, so we have to use the explicit arguments.
         run: |
-          docs-builder changelog bundle --input-products 'edot-java * *' --output-products 'edot-java ${{ env.RELEASE_VERSION }} ga' --output docs/releases/${{ env.RELEASE_VERSION }}.yaml --description "$(.ci/changelog-bundle-description.sh)"
+          docs-builder changelog bundle \
+            --input-products 'edot-java * *' \
+            --output-products 'edot-java ${{ env.RELEASE_VERSION }} ga' \
+            --output docs/releases/${{ env.RELEASE_VERSION }}.yaml \
+            --description "$(.ci/changelog-bundle-description.sh)"
           docs-builder changelog remove edot-java-release
   
       - name: Push the ${{ inputs.phase }} release branch

--- a/.github/workflows/pre-post-release.yml
+++ b/.github/workflows/pre-post-release.yml
@@ -104,11 +104,12 @@ jobs:
         #   docs-builder changelog bundle edot-java-release ${{ env.RELEASE_VERSION }}
         # this does not yet allow to provide the generated content for description, so we have to use the explicit arguments.
         run: |
+          description="$(.ci/changelog-bundle-description.sh)"
           docs-builder changelog bundle \
             --input-products 'edot-java * *' \
             --output-products 'edot-java ${{ env.RELEASE_VERSION }} ga' \
             --output docs/releases/${{ env.RELEASE_VERSION }}.yaml \
-            --description "$(.ci/changelog-bundle-description.sh)"
+            --description "${description}"
           docs-builder changelog remove edot-java-release
   
       - name: Push the ${{ inputs.phase }} release branch

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -59,9 +59,9 @@ tasks {
       val sdkVer = getResolvedDependency("io.opentelemetry:opentelemetry-sdk")!!.version
       val semconvVer = libs.versions.opentelemetrySemconv.get()
       val contribVer = libs.versions.opentelemetryContribAlpha.get().replace("-alpha", "") // -alpha suffix is only on artifact, not release tag
-      println("* opentelemetry-javaagent: [$agentVer](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v$agentVer)")
-      println("* opentelemetry-sdk: [$sdkVer](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v$sdkVer)")
-      println("* opentelemetry-semconv: [$semconvVer](https://github.com/open-telemetry/semantic-conventions-java/releases/tag/v$semconvVer)")
+      println("* opentelemetry-java-instrumentation: [$agentVer](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v$agentVer)")
+      println("* opentelemetry-java: [$sdkVer](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v$sdkVer)")
+      println("* semantic-conventions-java: [$semconvVer](https://github.com/open-telemetry/semantic-conventions-java/releases/tag/v$semconvVer)")
       println("* opentelemetry-java-contrib: [$contribVer](https://github.com/open-telemetry/opentelemetry-java-contrib/releases/tag/v$contribVer)")
     }
   }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -66,25 +66,6 @@ tasks {
     }
   }
 
-  /**
-   * Used from within our release automation as part of the changelog generation.
-   */
-  register("changelogUpstreamDependenciesOneLiner") {
-    dependsOn(printDependencyVersions)
-    doLast {
-      val agentVer = getResolvedDependency("io.opentelemetry.javaagent:opentelemetry-javaagent")!!.version
-      val sdkVer = getResolvedDependency("io.opentelemetry:opentelemetry-sdk")!!.version
-      val semconvVer = libs.versions.opentelemetrySemconv.get()
-      val contribVer = libs.versions.opentelemetryContribAlpha.get().replace("-alpha", "") // -alpha suffix is only on artifact, not release tag
-      var result = ""
-      result += "javaagent:[$agentVer](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v$agentVer)"
-      result += " sdk:[$sdkVer](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v$sdkVer)"
-      result += " semconv:[$semconvVer](https://github.com/open-telemetry/semantic-conventions-java/releases/tag/v$semconvVer)"
-      result += " contrib:[$contribVer](https://github.com/open-telemetry/opentelemetry-java-contrib/releases/tag/v$contribVer)"
-      println(result)
-    }
-  }
-
   register("currentVersion") {
     doLast {
       println(project.version)

--- a/docs/changelog/upstream-update.yaml
+++ b/docs/changelog/upstream-update.yaml
@@ -4,4 +4,3 @@ type: enhancement
 products:
 - product: edot-java
 title: Update upstream OpenTelemetry agent dependencies to 2.27.0
-description: '- javaagent:[2.27.0](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v2.27.0) sdk:[1.61.0](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.61.0) semconv:[1.40.0](https://github.com/open-telemetry/semantic-conventions-java/releases/tag/v1.40.0) contrib:[1.55.0](https://github.com/open-telemetry/opentelemetry-java-contrib/releases/tag/v1.55.0)'

--- a/docs/releases/1.1.0.yaml
+++ b/docs/releases/1.1.0.yaml
@@ -10,7 +10,7 @@ description: |-
 
   * opentelemetry-java-instrumentation: [2.10.0](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v2.10.0).
   * opentelemetry-java: [1.44.1](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.44.1).
-  * opentelemetry-java-semconv: [1.28.0](https://github.com/open-telemetry/semantic-conventions-java/releases/tag/v1.28.0).
+  * semantic-conventions-java: [1.28.0](https://github.com/open-telemetry/semantic-conventions-java/releases/tag/v1.28.0).
   * opentelemetry-java-contrib: [1.40.0](https://github.com/open-telemetry/opentelemetry-java-contrib/releases/tag/v1.40.0).
 entries:
 - file:

--- a/docs/releases/1.1.0.yaml
+++ b/docs/releases/1.1.0.yaml
@@ -8,9 +8,9 @@ release-date: '2024-11-21'
 description: |-
   This release is based on the following upstream versions:
 
-  * opentelemetry-javaagent: [2.10.0](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v2.10.0).
-  * opentelemetry-sdk: [1.44.1](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.44.1).
-  * opentelemetry-semconv: [1.28.0](https://github.com/open-telemetry/semantic-conventions-java/releases/tag/v1.28.0).
+  * opentelemetry-java-instrumentation: [2.10.0](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v2.10.0).
+  * opentelemetry-java: [1.44.1](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.44.1).
+  * opentelemetry-java-semconv: [1.28.0](https://github.com/open-telemetry/semantic-conventions-java/releases/tag/v1.28.0).
   * opentelemetry-java-contrib: [1.40.0](https://github.com/open-telemetry/opentelemetry-java-contrib/releases/tag/v1.40.0).
 entries:
 - file:

--- a/docs/releases/1.10.0.yaml
+++ b/docs/releases/1.10.0.yaml
@@ -10,7 +10,7 @@ description: |-
 
   * opentelemetry-java-instrumentation: [2.26.1](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v2.26.1)
   * opentelemetry-java: [1.60.1](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.60.1)
-  * opentelemetry-java-semconv: [1.40.0](https://github.com/open-telemetry/semantic-conventions-java/releases/tag/v1.40.0)
+  * semantic-conventions-java: [1.40.0](https://github.com/open-telemetry/semantic-conventions-java/releases/tag/v1.40.0)
   * opentelemetry-java-contrib: [1.54.0](https://github.com/open-telemetry/opentelemetry-java-contrib/releases/tag/v1.54.0)
 entries:
 - file:

--- a/docs/releases/1.10.0.yaml
+++ b/docs/releases/1.10.0.yaml
@@ -22,6 +22,5 @@ entries:
   - product: edot-java
     target: 1.10.0
     lifecycle: ga
-  description: '- javaagent:[2.26.1](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v2.26.1) sdk:[1.60.1](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.60.1) semconv:[1.40.0](https://github.com/open-telemetry/semantic-conventions-java/releases/tag/v1.40.0) contrib:[1.54.0](https://github.com/open-telemetry/opentelemetry-java-contrib/releases/tag/v1.54.0)'
   prs:
   - https://github.com/elastic/elastic-otel-java/pull/1017

--- a/docs/releases/1.10.0.yaml
+++ b/docs/releases/1.10.0.yaml
@@ -8,9 +8,9 @@ release-date: '2026-03-24'
 description: |-
   This release is based on the following upstream versions:
 
-  * opentelemetry-javaagent: [2.26.1](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v2.26.1)
-  * opentelemetry-sdk: [1.60.1](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.60.1)
-  * opentelemetry-semconv: [1.40.0](https://github.com/open-telemetry/semantic-conventions-java/releases/tag/v1.40.0)
+  * opentelemetry-java-instrumentation: [2.26.1](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v2.26.1)
+  * opentelemetry-java: [1.60.1](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.60.1)
+  * opentelemetry-java-semconv: [1.40.0](https://github.com/open-telemetry/semantic-conventions-java/releases/tag/v1.40.0)
   * opentelemetry-java-contrib: [1.54.0](https://github.com/open-telemetry/opentelemetry-java-contrib/releases/tag/v1.54.0)
 entries:
 - file:

--- a/docs/releases/1.2.0.yaml
+++ b/docs/releases/1.2.0.yaml
@@ -10,7 +10,7 @@ description: |-
 
   * opentelemetry-java-instrumentation: [2.12.0](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v2.12.0).
   * opentelemetry-java: [1.46.0](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.46.0)
-  * opentelemetry-java-semconv: [1.29.0](https://github.com/open-telemetry/semantic-conventions-java/releases/tag/v1.29.0).
+  * semantic-conventions-java: [1.29.0](https://github.com/open-telemetry/semantic-conventions-java/releases/tag/v1.29.0).
   * opentelemetry-java-contrib: [1.42.0](https://github.com/open-telemetry/opentelemetry-java-contrib/releases/tag/v1.42.0).
 entries:
 - file:

--- a/docs/releases/1.2.0.yaml
+++ b/docs/releases/1.2.0.yaml
@@ -66,6 +66,5 @@ entries:
   - product: edot-java
     target: 1.2.0
     lifecycle: ga
-  description: '- javaagent:[2.12.0](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v2.12.0) sdk:[1.46.0](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.46.0) semconv:[1.29.0](https://github.com/open-telemetry/semantic-conventions-java/releases/tag/v1.29.0) contrib:[1.42.0](https://github.com/open-telemetry/opentelemetry-java-contrib/releases/tag/v1.42.0)'
   prs:
   - https://github.com/elastic/elastic-otel-java/pull/500

--- a/docs/releases/1.2.0.yaml
+++ b/docs/releases/1.2.0.yaml
@@ -8,9 +8,9 @@ release-date: '2025-01-20'
 description: |-
   This release is based on the following upstream versions:
 
-  * opentelemetry-javaagent: [2.12.0](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v2.12.0).
-  * opentelemetry-sdk: [1.46.0](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.46.0)
-  * opentelemetry-semconv: [1.29.0](https://github.com/open-telemetry/semantic-conventions-java/releases/tag/v1.29.0).
+  * opentelemetry-java-instrumentation: [2.12.0](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v2.12.0).
+  * opentelemetry-java: [1.46.0](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.46.0)
+  * opentelemetry-java-semconv: [1.29.0](https://github.com/open-telemetry/semantic-conventions-java/releases/tag/v1.29.0).
   * opentelemetry-java-contrib: [1.42.0](https://github.com/open-telemetry/opentelemetry-java-contrib/releases/tag/v1.42.0).
 entries:
 - file:

--- a/docs/releases/1.2.1.yaml
+++ b/docs/releases/1.2.1.yaml
@@ -10,7 +10,7 @@ description: |-
 
   * opentelemetry-java-instrumentation: [2.12.0](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v2.12.0).
   * opentelemetry-java: [1.46.0](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.46.0).
-  * opentelemetry-java-semconv: [1.29.0](https://github.com/open-telemetry/semantic-conventions-java/releases/tag/v1.29.0).
+  * semantic-conventions-java: [1.29.0](https://github.com/open-telemetry/semantic-conventions-java/releases/tag/v1.29.0).
   * opentelemetry-java-contrib: [1.42.0](https://github.com/open-telemetry/opentelemetry-java-contrib/releases/tag/v1.42.0).
 entries:
 - file:

--- a/docs/releases/1.2.1.yaml
+++ b/docs/releases/1.2.1.yaml
@@ -8,9 +8,9 @@ release-date: '2025-01-23'
 description: |-
   This release is based on the following upstream versions:
 
-  * opentelemetry-javaagent: [2.12.0](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v2.12.0).
-  * opentelemetry-sdk: [1.46.0](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.46.0).
-  * opentelemetry-semconv: [1.29.0](https://github.com/open-telemetry/semantic-conventions-java/releases/tag/v1.29.0).
+  * opentelemetry-java-instrumentation: [2.12.0](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v2.12.0).
+  * opentelemetry-java: [1.46.0](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.46.0).
+  * opentelemetry-java-semconv: [1.29.0](https://github.com/open-telemetry/semantic-conventions-java/releases/tag/v1.29.0).
   * opentelemetry-java-contrib: [1.42.0](https://github.com/open-telemetry/opentelemetry-java-contrib/releases/tag/v1.42.0).
 entries:
 - file:

--- a/docs/releases/1.3.0.yaml
+++ b/docs/releases/1.3.0.yaml
@@ -10,7 +10,7 @@ description: |-
 
   * opentelemetry-java-instrumentation: [2.13.3](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v2.13.3).
   * opentelemetry-java: [1.47.0](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.47.0).
-  * opentelemetry-java-semconv: [1.30.0-rc.1](https://github.com/open-telemetry/semantic-conventions-java/releases/tag/v1.30.0-rc.1).
+  * semantic-conventions-java: [1.30.0-rc.1](https://github.com/open-telemetry/semantic-conventions-java/releases/tag/v1.30.0-rc.1).
   * opentelemetry-java-contrib: [1.44.0](https://github.com/open-telemetry/opentelemetry-java-contrib/releases/tag/v1.44.0).
 entries:
 - file:

--- a/docs/releases/1.3.0.yaml
+++ b/docs/releases/1.3.0.yaml
@@ -8,9 +8,9 @@ release-date: '2025-03-10'
 description: |-
   This release is based on the following upstream versions:
 
-  * opentelemetry-javaagent: [2.13.3](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v2.13.3).
-  * opentelemetry-sdk: [1.47.0](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.47.0).
-  * opentelemetry-semconv: [1.30.0-rc.1](https://github.com/open-telemetry/semantic-conventions-java/releases/tag/v1.30.0-rc.1).
+  * opentelemetry-java-instrumentation: [2.13.3](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v2.13.3).
+  * opentelemetry-java: [1.47.0](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.47.0).
+  * opentelemetry-java-semconv: [1.30.0-rc.1](https://github.com/open-telemetry/semantic-conventions-java/releases/tag/v1.30.0-rc.1).
   * opentelemetry-java-contrib: [1.44.0](https://github.com/open-telemetry/opentelemetry-java-contrib/releases/tag/v1.44.0).
 entries:
 - file:

--- a/docs/releases/1.4.0.yaml
+++ b/docs/releases/1.4.0.yaml
@@ -8,9 +8,9 @@ release-date: '2025-04-15'
 description: |-
   This release is based on the following upstream versions:
 
-  * opentelemetry-javaagent: [2.15.0](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v2.15.0).
-  * opentelemetry-sdk: [1.49.0](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.49.0).
-  * opentelemetry-semconv: [1.32.0](https://github.com/open-telemetry/semantic-conventions-java/releases/tag/v1.32.0).
+  * opentelemetry-java-instrumentation: [2.15.0](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v2.15.0).
+  * opentelemetry-java: [1.49.0](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.49.0).
+  * opentelemetry-java-semconv: [1.32.0](https://github.com/open-telemetry/semantic-conventions-java/releases/tag/v1.32.0).
   * opentelemetry-java-contrib: [1.45.0](https://github.com/open-telemetry/opentelemetry-java-contrib/releases/tag/v1.45.0).
 entries:
 - file:

--- a/docs/releases/1.4.0.yaml
+++ b/docs/releases/1.4.0.yaml
@@ -10,7 +10,7 @@ description: |-
 
   * opentelemetry-java-instrumentation: [2.15.0](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v2.15.0).
   * opentelemetry-java: [1.49.0](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.49.0).
-  * opentelemetry-java-semconv: [1.32.0](https://github.com/open-telemetry/semantic-conventions-java/releases/tag/v1.32.0).
+  * semantic-conventions-java: [1.32.0](https://github.com/open-telemetry/semantic-conventions-java/releases/tag/v1.32.0).
   * opentelemetry-java-contrib: [1.45.0](https://github.com/open-telemetry/opentelemetry-java-contrib/releases/tag/v1.45.0).
 entries:
 - file:

--- a/docs/releases/1.4.0.yaml
+++ b/docs/releases/1.4.0.yaml
@@ -70,6 +70,5 @@ entries:
   - product: edot-java
     target: 1.4.0
     lifecycle: ga
-  description: '- javaagent:[2.15.0](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v2.15.0) sdk:[1.49.0](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.49.0) semconv:[1.32.0](https://github.com/open-telemetry/semantic-conventions-java/releases/tag/v1.32.0) contrib:[1.45.0](https://github.com/open-telemetry/opentelemetry-java-contrib/releases/tag/v1.45.0)'
   prs:
   - https://github.com/elastic/elastic-otel-java/pull/603

--- a/docs/releases/1.4.1.yaml
+++ b/docs/releases/1.4.1.yaml
@@ -10,7 +10,7 @@ description: |-
 
   * opentelemetry-java-instrumentation: [2.15.0](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v2.15.0).
   * opentelemetry-java: [1.49.0](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.49.0).
-  * opentelemetry-java-semconv: [1.32.0](https://github.com/open-telemetry/semantic-conventions-java/releases/tag/v1.32.0).
+  * semantic-conventions-java: [1.32.0](https://github.com/open-telemetry/semantic-conventions-java/releases/tag/v1.32.0).
   * opentelemetry-java-contrib: [1.45.0](https://github.com/open-telemetry/opentelemetry-java-contrib/releases/tag/v1.45.0).
 entries:
 - file:

--- a/docs/releases/1.4.1.yaml
+++ b/docs/releases/1.4.1.yaml
@@ -8,9 +8,9 @@ release-date: '2025-04-16'
 description: |-
   This release is based on the following upstream versions:
 
-  * opentelemetry-javaagent: [2.15.0](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v2.15.0).
-  * opentelemetry-sdk: [1.49.0](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.49.0).
-  * opentelemetry-semconv: [1.32.0](https://github.com/open-telemetry/semantic-conventions-java/releases/tag/v1.32.0).
+  * opentelemetry-java-instrumentation: [2.15.0](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v2.15.0).
+  * opentelemetry-java: [1.49.0](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.49.0).
+  * opentelemetry-java-semconv: [1.32.0](https://github.com/open-telemetry/semantic-conventions-java/releases/tag/v1.32.0).
   * opentelemetry-java-contrib: [1.45.0](https://github.com/open-telemetry/opentelemetry-java-contrib/releases/tag/v1.45.0).
 entries:
 - file:

--- a/docs/releases/1.5.0.yaml
+++ b/docs/releases/1.5.0.yaml
@@ -44,6 +44,5 @@ entries:
   - product: edot-java
     target: 1.5.0
     lifecycle: ga
-  description: '- javaagent:[2.17.1](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v2.17.1) sdk:[1.51.0](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.51.0) semconv:[1.34.0](https://github.com/open-telemetry/semantic-conventions-java/releases/tag/v1.34.0) contrib:[1.46.0](https://github.com/open-telemetry/opentelemetry-java-contrib/releases/tag/v1.46.0)'
   prs:
   - https://github.com/elastic/elastic-otel-java/pull/729

--- a/docs/releases/1.5.0.yaml
+++ b/docs/releases/1.5.0.yaml
@@ -8,9 +8,9 @@ release-date: '2025-07-28'
 description: |-
   This release is based on the following upstream versions:
 
-  * opentelemetry-javaagent: [2.17.1](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v2.17.1)
-  * opentelemetry-sdk: [1.51.0](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.51.0)
-  * opentelemetry-semconv: [1.34.0](https://github.com/open-telemetry/semantic-conventions-java/releases/tag/v1.34.0)
+  * opentelemetry-java-instrumentation: [2.17.1](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v2.17.1)
+  * opentelemetry-java: [1.51.0](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.51.0)
+  * opentelemetry-java-semconv: [1.34.0](https://github.com/open-telemetry/semantic-conventions-java/releases/tag/v1.34.0)
   * opentelemetry-java-contrib: [1.46.0](https://github.com/open-telemetry/opentelemetry-java-contrib/releases/tag/v1.46.0)
 entries:
 - file:

--- a/docs/releases/1.5.0.yaml
+++ b/docs/releases/1.5.0.yaml
@@ -10,7 +10,7 @@ description: |-
 
   * opentelemetry-java-instrumentation: [2.17.1](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v2.17.1)
   * opentelemetry-java: [1.51.0](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.51.0)
-  * opentelemetry-java-semconv: [1.34.0](https://github.com/open-telemetry/semantic-conventions-java/releases/tag/v1.34.0)
+  * semantic-conventions-java: [1.34.0](https://github.com/open-telemetry/semantic-conventions-java/releases/tag/v1.34.0)
   * opentelemetry-java-contrib: [1.46.0](https://github.com/open-telemetry/opentelemetry-java-contrib/releases/tag/v1.46.0)
 entries:
 - file:

--- a/docs/releases/1.6.0.yaml
+++ b/docs/releases/1.6.0.yaml
@@ -8,9 +8,9 @@ release-date: '2025-10-06'
 description: |-
   This release is based on the following upstream versions:
 
-  * opentelemetry-javaagent: [2.20.1](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v2.20.1)
-  * opentelemetry-sdk: [1.54.1](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.54.1)
-  * opentelemetry-semconv: [1.37.0](https://github.com/open-telemetry/semantic-conventions-java/releases/tag/v1.37.0)
+  * opentelemetry-java-instrumentation: [2.20.1](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v2.20.1)
+  * opentelemetry-java: [1.54.1](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.54.1)
+  * opentelemetry-java-semconv: [1.37.0](https://github.com/open-telemetry/semantic-conventions-java/releases/tag/v1.37.0)
   * opentelemetry-java-contrib: [1.49.0](https://github.com/open-telemetry/opentelemetry-java-contrib/releases/tag/v1.49.0)
 entries:
 - file:

--- a/docs/releases/1.6.0.yaml
+++ b/docs/releases/1.6.0.yaml
@@ -10,7 +10,7 @@ description: |-
 
   * opentelemetry-java-instrumentation: [2.20.1](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v2.20.1)
   * opentelemetry-java: [1.54.1](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.54.1)
-  * opentelemetry-java-semconv: [1.37.0](https://github.com/open-telemetry/semantic-conventions-java/releases/tag/v1.37.0)
+  * semantic-conventions-java: [1.37.0](https://github.com/open-telemetry/semantic-conventions-java/releases/tag/v1.37.0)
   * opentelemetry-java-contrib: [1.49.0](https://github.com/open-telemetry/opentelemetry-java-contrib/releases/tag/v1.49.0)
 entries:
 - file:

--- a/docs/releases/1.6.0.yaml
+++ b/docs/releases/1.6.0.yaml
@@ -57,6 +57,5 @@ entries:
   - product: edot-java
     target: 1.6.0
     lifecycle: ga
-  description: '- javaagent:[2.20.1](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v2.20.1) sdk:[1.54.1](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.54.1) semconv:[1.37.0](https://github.com/open-telemetry/semantic-conventions-java/releases/tag/v1.37.0) contrib:[1.49.0](https://github.com/open-telemetry/opentelemetry-java-contrib/releases/tag/v1.49.0)'
   prs:
   - https://github.com/elastic/elastic-otel-java/pull/803

--- a/docs/releases/1.7.0.yaml
+++ b/docs/releases/1.7.0.yaml
@@ -10,7 +10,7 @@ description: |-
 
   * opentelemetry-java-instrumentation: [2.21.0](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v2.21.0)
   * opentelemetry-java: [1.55.0](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.55.0)
-  * opentelemetry-java-semconv: [1.37.0](https://github.com/open-telemetry/semantic-conventions-java/releases/tag/v1.37.0)
+  * semantic-conventions-java: [1.37.0](https://github.com/open-telemetry/semantic-conventions-java/releases/tag/v1.37.0)
   * opentelemetry-java-contrib: [1.50.0](https://github.com/open-telemetry/opentelemetry-java-contrib/releases/tag/v1.50.0)
 entries:
 - file:

--- a/docs/releases/1.7.0.yaml
+++ b/docs/releases/1.7.0.yaml
@@ -8,9 +8,9 @@ release-date: '2025-11-05'
 description: |-
   This release is based on the following upstream versions:
 
-  * opentelemetry-javaagent: [2.21.0](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v2.21.0)
-  * opentelemetry-sdk: [1.55.0](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.55.0)
-  * opentelemetry-semconv: [1.37.0](https://github.com/open-telemetry/semantic-conventions-java/releases/tag/v1.37.0)
+  * opentelemetry-java-instrumentation: [2.21.0](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v2.21.0)
+  * opentelemetry-java: [1.55.0](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.55.0)
+  * opentelemetry-java-semconv: [1.37.0](https://github.com/open-telemetry/semantic-conventions-java/releases/tag/v1.37.0)
   * opentelemetry-java-contrib: [1.50.0](https://github.com/open-telemetry/opentelemetry-java-contrib/releases/tag/v1.50.0)
 entries:
 - file:

--- a/docs/releases/1.7.0.yaml
+++ b/docs/releases/1.7.0.yaml
@@ -61,6 +61,5 @@ entries:
   - product: edot-java
     target: 1.7.0
     lifecycle: ga
-  description: '- javaagent:[2.21.0](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v2.21.0) sdk:[1.55.0](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.55.0) semconv:[1.37.0](https://github.com/open-telemetry/semantic-conventions-java/releases/tag/v1.37.0) contrib:[1.50.0](https://github.com/open-telemetry/opentelemetry-java-contrib/releases/tag/v1.50.0)'
   prs:
   - https://github.com/elastic/elastic-otel-java/pull/844

--- a/docs/releases/1.8.0.yaml
+++ b/docs/releases/1.8.0.yaml
@@ -26,6 +26,5 @@ entries:
   - product: edot-java
     target: 1.8.0
     lifecycle: ga
-  description: '- javaagent:[2.22.0](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v2.22.0) sdk:[1.56.0](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.56.0) semconv:[1.37.0](https://github.com/open-telemetry/semantic-conventions-java/releases/tag/v1.37.0) contrib:[1.52.0](https://github.com/open-telemetry/opentelemetry-java-contrib/releases/tag/v1.52.0)'
   prs:
   - https://github.com/elastic/elastic-otel-java/pull/898

--- a/docs/releases/1.9.0.yaml
+++ b/docs/releases/1.9.0.yaml
@@ -26,6 +26,5 @@ entries:
   - product: edot-java
     target: 1.9.0
     lifecycle: ga
-  description: '- javaagent:[2.24.0](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v2.24.0) sdk:[1.58.0](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.58.0) semconv:[1.37.0](https://github.com/open-telemetry/semantic-conventions-java/releases/tag/v1.37.0) contrib:[1.52.0](https://github.com/open-telemetry/opentelemetry-java-contrib/releases/tag/v1.52.0)'
   prs:
   - https://github.com/elastic/elastic-otel-java/pull/932


### PR DESCRIPTION
Fixes #1049

adds a new shell script to generate changelog: `.ci/changelog-bundle-description.sh`

Example output in the current state of `main` (output is in markdown)
```markdown
This release is based on the following upstream versions:
* opentelemetry-java-instrumentation: [2.27.0](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v2.27.0)
* opentelemetry-java: [1.61.0](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.61.0)
* semantic-conventions-java: [1.40.0](https://github.com/open-telemetry/semantic-conventions-java/releases/tag/v1.40.0)
* opentelemetry-java-contrib: [1.55.0](https://github.com/open-telemetry/opentelemetry-java-contrib/releases/tag/v1.55.0)
```

This markdown is used at release time to generate the changelog bundle description using the `--description` argument of `docs-builder changelog bundle` command

The following command will generate the release bundle for `1.11.0` release:
```bash
docs-builder changelog bundle \
  --input-products 'edot-java * *' \
  --output-products 'edot-java 1.11.0 ga' \
  --output docs/releases/1.11.0.yaml \
  --description "$(.ci/changelog-bundle-description.sh)"
```

content of `./docs/releases/1.11.0.yaml`:

```markdown
﻿products:
- product: edot-java
  target: 1.11.0
  lifecycle: ga
  repo: elastic-otel-java
  owner: elastic
description: >-
  This release is based on the following upstream versions:

  * opentelemetry-java-instrumentation: [2.27.0](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v2.27.0)

  * opentelemetry-java: [1.61.0](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.61.0)

  * semantic-conventions-java: [1.40.0](https://github.com/open-telemetry/semantic-conventions-java/releases/tag/v1.40.0)

  * opentelemetry-java-contrib: [1.55.0](https://github.com/open-telemetry/opentelemetry-java-contrib/releases/tag/v1.55.0)
release-date: 2026-04-23
entries:
- file:
    name: upstream-update.yaml
    checksum: 3a0887aa3976c53f032f3952f33a95238fb55fa9
  type: enhancement
  title: Update upstream OpenTelemetry agent dependencies to 2.27.0
  products:
  - product: edot-java
  prs:
  - https://github.com/elastic/elastic-otel-java/pull/1063

```

I don't know why do we get extra lines in the generated bundle yaml, and there should probably be a better way to provide the value for `description`, but this would likely require a few changes in docs-builder to improve that.

Because the dependencies are now described at release time, we don't have to generate a description when adding upstream updates changelog entries. We do still keep the dedicated upstream update workflow as it allows to avoid duplicates, but we could also decide to remove it to simplify.

Changes to existing bundles:
- align the bundle descriptions with example above (name of dependencies did not reflect their repository names)
- remove the `description` fields for the upstream update PRs as they are no longer needed


