### PR TITLE
declarative config: indy, propagator, stack trace, sampler

### DIFF
--- a/custom/src/main/resources/co/elastic/otel/config.yaml
+++ b/custom/src/main/resources/co/elastic/otel/config.yaml
@@ -45,6 +45,21 @@ tracer_provider:
     - stacktrace/development:
         min_duration: 5 # minimal duration in ms, default is 5
         filter: co.elastic.otel.SpanStackTraceFilter
+  # sampler, parent-based with 100% sampling rate by default
+  sampler:
+    parent_based:
+      root:
+        # using the consistent sampler implementation
+        probability/development:
+          ratio: 1.0
+      remote_parent_sampled:
+        always_on:
+      remote_parent_not_sampled:
+        always_off:
+      local_parent_sampled:
+        always_on:
+      local_parent_not_sampled:
+        always_off:
 
 meter_provider:
   readers:

--- a/custom/src/main/resources/co/elastic/otel/config.yaml
+++ b/custom/src/main/resources/co/elastic/otel/config.yaml
@@ -73,3 +73,7 @@ instrumentation/development:
     runtime_telemetry:
       # emit not-yet stable runtime telemetry metrics which are currently part of semconv for java runtime
       emit_experimental_metrics/development: ${OTEL_INSTRUMENTATION_RUNTIME_TELEMETRY_EMIT_EXPERIMENTAL_METRICS:-true}
+    agent:
+      experimental:
+        # enable experimental indy instrumentation
+        indy: true

--- a/custom/src/main/resources/co/elastic/otel/config.yaml
+++ b/custom/src/main/resources/co/elastic/otel/config.yaml
@@ -24,7 +24,6 @@ resource:
       # Provides 'service.name' and 'service.instance.id'
       - service:
 
-# default propagators
 propagator:
   composite:
     - tracecontext:
@@ -44,7 +43,7 @@ tracer_provider:
           #  endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT}
           #  headers_list: ${OTEL_EXPORTER_OTLP_HEADERS}
     - stacktrace/development:
-        min_duration: 5 # minimal duration in ms, default is 5, MUST be an integer
+        min_duration: 5 # minimal duration in ms, default is 5
         filter: co.elastic.otel.SpanStackTraceFilter
 
 meter_provider:

--- a/custom/src/main/resources/co/elastic/otel/config.yaml
+++ b/custom/src/main/resources/co/elastic/otel/config.yaml
@@ -24,6 +24,12 @@ resource:
       # Provides 'service.name' and 'service.instance.id'
       - service:
 
+# default propagators
+propagator:
+  composite:
+    - tracecontext:
+    - baggage:
+
 tracer_provider:
   processors:
     - batch:

--- a/custom/src/main/resources/co/elastic/otel/config.yaml
+++ b/custom/src/main/resources/co/elastic/otel/config.yaml
@@ -43,6 +43,9 @@ tracer_provider:
           # otlp_grpc:
           #  endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT}
           #  headers_list: ${OTEL_EXPORTER_OTLP_HEADERS}
+    - stacktrace/development:
+        min_duration: 5 # minimal duration in ms, default is 5, MUST be an integer
+        filter: co.elastic.otel.SpanStackTraceFilter
 
 meter_provider:
   readers:

--- a/custom/src/test/java/co/elastic/otel/declarativeconfig/DefaultDeclarativeConfigTest.java
+++ b/custom/src/test/java/co/elastic/otel/declarativeconfig/DefaultDeclarativeConfigTest.java
@@ -25,6 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.javaagent.tooling.resources.ResourceCustomizerProvider;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.DeclarativeConfiguration;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.ExperimentalLanguageSpecificInstrumentationModel;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.OpenTelemetryConfigurationModel;
 import java.io.InputStream;
 import java.util.function.Consumer;
@@ -66,15 +67,12 @@ public class DefaultDeclarativeConfigTest {
               json("{\"service\":{}}"),
               json("{\"host\":{}}"));
 
-          assertThat(config.getPropagator())
-              .describedAs("missing propagator")
-              .isNotNull();
-          assertThatJson(json(config.getPropagator())).inPath("composite")
+          assertThat(config.getPropagator()).describedAs("missing propagator").isNotNull();
+          assertThatJson(json(config.getPropagator()))
+              .inPath("composite")
               .isArray()
               .describedAs("propagators should contain tracecontext and baggage by default")
-              .containsExactlyInAnyOrder(
-                  json("{\"tracecontext\":{}}"),
-                  json("{\"baggage\":{}}"));
+              .containsExactlyInAnyOrder(json("{\"tracecontext\":{}}"), json("{\"baggage\":{}}"));
 
           assertThat(config.getTracerProvider()).isNotNull();
           assertThat(config.getTracerProvider().getProcessors()).hasSize(1);
@@ -98,9 +96,18 @@ public class DefaultDeclarativeConfigTest {
               .isObject()
               .containsEntry("endpoint", "http://localhost:4318/v1/logs");
 
-          assertThatJson(json(config.getInstrumentationDevelopment()))
+          assertThat(config.getInstrumentationDevelopment()).isNotNull();
+          ExperimentalLanguageSpecificInstrumentationModel java =
+              config.getInstrumentationDevelopment().getJava();
+          assertThat(java).isNotNull();
+          assertThatJson(json(java))
               .describedAs("experimental jvm runtime telemetry metrics enabled by default")
-              .inPath("java.runtime_telemetry.emit_experimental_metrics/development")
+              .inPath("runtime_telemetry.emit_experimental_metrics/development")
+              .isBoolean()
+              .isTrue();
+          assertThatJson(json(java))
+              .describedAs("experimental indy is enabled by default")
+              .inPath("agent.experimental.indy")
               .isBoolean()
               .isTrue();
         });

--- a/custom/src/test/java/co/elastic/otel/declarativeconfig/DefaultDeclarativeConfigTest.java
+++ b/custom/src/test/java/co/elastic/otel/declarativeconfig/DefaultDeclarativeConfigTest.java
@@ -75,11 +75,16 @@ public class DefaultDeclarativeConfigTest {
               .containsExactlyInAnyOrder(json("{\"tracecontext\":{}}"), json("{\"baggage\":{}}"));
 
           assertThat(config.getTracerProvider()).isNotNull();
-          assertThat(config.getTracerProvider().getProcessors()).hasSize(1);
+          assertThat(config.getTracerProvider().getProcessors()).hasSize(2);
           assertThatJson(json((config.getTracerProvider().getProcessors().get(0))))
               .inPath("batch.exporter.otlp_http")
               .isObject()
               .containsEntry("endpoint", "http://localhost:4318/v1/traces");
+
+          assertThatJson(json((config.getTracerProvider().getProcessors().get(1))))
+              .inPath("stacktrace/development")
+              .isObject()
+              .containsEntry("filter", "co.elastic.otel.SpanStackTraceFilter");
 
           assertThat(config.getMeterProvider()).isNotNull();
           assertThat(config.getMeterProvider().getReaders()).hasSize(1);

--- a/custom/src/test/java/co/elastic/otel/declarativeconfig/DefaultDeclarativeConfigTest.java
+++ b/custom/src/test/java/co/elastic/otel/declarativeconfig/DefaultDeclarativeConfigTest.java
@@ -27,6 +27,7 @@ import io.opentelemetry.javaagent.tooling.resources.ResourceCustomizerProvider;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.DeclarativeConfiguration;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.ExperimentalLanguageSpecificInstrumentationModel;
 import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.OpenTelemetryConfigurationModel;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.SamplerModel;
 import java.io.InputStream;
 import java.util.function.Consumer;
 import net.javacrumbs.jsonunit.assertj.JsonListAssert;
@@ -100,6 +101,26 @@ public class DefaultDeclarativeConfigTest {
               .inPath("batch.exporter.otlp_http")
               .isObject()
               .containsEntry("endpoint", "http://localhost:4318/v1/logs");
+
+          SamplerModel sampler = config.getTracerProvider().getSampler();
+          assertThat(sampler).isNotNull();
+
+          assertThatJson(json(sampler))
+              .inPath("parent_based.root.probability/development.ratio")
+              .isNumber()
+              .isEqualByComparingTo("1.0");
+          assertThatJson(json(sampler))
+              .inPath("parent_based.remote_parent_sampled.always_on")
+              .isObject();
+          assertThatJson(json(sampler))
+              .inPath("parent_based.remote_parent_not_sampled.always_off")
+              .isObject();
+          assertThatJson(json(sampler))
+              .inPath("parent_based.local_parent_sampled.always_on")
+              .isObject();
+          assertThatJson(json(sampler))
+              .inPath("parent_based.local_parent_not_sampled.always_off")
+              .isObject();
 
           assertThat(config.getInstrumentationDevelopment()).isNotNull();
           ExperimentalLanguageSpecificInstrumentationModel java =

--- a/custom/src/test/java/co/elastic/otel/declarativeconfig/DefaultDeclarativeConfigTest.java
+++ b/custom/src/test/java/co/elastic/otel/declarativeconfig/DefaultDeclarativeConfigTest.java
@@ -66,6 +66,16 @@ public class DefaultDeclarativeConfigTest {
               json("{\"service\":{}}"),
               json("{\"host\":{}}"));
 
+          assertThat(config.getPropagator())
+              .describedAs("missing propagator")
+              .isNotNull();
+          assertThatJson(json(config.getPropagator())).inPath("composite")
+              .isArray()
+              .describedAs("propagators should contain tracecontext and baggage by default")
+              .containsExactlyInAnyOrder(
+                  json("{\"tracecontext\":{}}"),
+                  json("{\"baggage\":{}}"));
+
           assertThat(config.getTracerProvider()).isNotNull();
           assertThat(config.getTracerProvider().getProcessors()).hasSize(1);
           assertThatJson(json((config.getTracerProvider().getProcessors().get(0))))


### PR DESCRIPTION
Part of #1054 

- enable indy by default
- add default propagators
- configure span stacktrace
- configure sampler: parent-based consistent sampler (should be equivalent to the one we use from contrib).

