### PR TITLE
normalize changelog bundle content

### DIFF
--- a/docs/releases/1.0.0.yaml
+++ b/docs/releases/1.0.0.yaml
@@ -13,5 +13,3 @@ entries:
   title: first GA release
   products:
   - product: edot-java
-    target: 1.0.0
-    lifecycle: ga

--- a/docs/releases/1.0.0.yaml
+++ b/docs/releases/1.0.0.yaml
@@ -4,7 +4,7 @@ products:
   lifecycle: ga
   repo: elastic-otel-java
   owner: elastic
-release-date: '2024-09-02'
+release-date: 2024-09-02
 entries:
 - file:
     name: 1774534599-first-ga-release.yaml

--- a/docs/releases/1.1.0.yaml
+++ b/docs/releases/1.1.0.yaml
@@ -4,7 +4,7 @@ products:
   lifecycle: ga
   repo: elastic-otel-java
   owner: elastic
-release-date: '2024-11-21'
+release-date: 2024-11-21
 description: |-
   This release is based on the following upstream versions:
 

--- a/docs/releases/1.1.0.yaml
+++ b/docs/releases/1.1.0.yaml
@@ -20,8 +20,6 @@ entries:
   title: update upstream 2.10.0
   products:
   - product: edot-java
-    target: 1.1.0
-    lifecycle: ga
   prs:
   - https://github.com/elastic/elastic-otel-java/pull/455
 - file:
@@ -31,7 +29,5 @@ entries:
   title: Fix missing transitive dependencies when using universal profiling integration
   products:
   - product: edot-java
-    target: 1.1.0
-    lifecycle: ga
   prs:
   - https://github.com/elastic/elastic-otel-java/pull/423

--- a/docs/releases/1.10.0.yaml
+++ b/docs/releases/1.10.0.yaml
@@ -4,7 +4,7 @@ products:
   lifecycle: ga
   repo: elastic-otel-java
   owner: elastic
-release-date: '2026-03-24'
+release-date: 2026-03-24
 description: |-
   This release is based on the following upstream versions:
 

--- a/docs/releases/1.10.0.yaml
+++ b/docs/releases/1.10.0.yaml
@@ -20,7 +20,5 @@ entries:
   title: Update upstream OpenTelemetry agent dependencies to 2.26.1
   products:
   - product: edot-java
-    target: 1.10.0
-    lifecycle: ga
   prs:
   - https://github.com/elastic/elastic-otel-java/pull/1017

--- a/docs/releases/1.2.0.yaml
+++ b/docs/releases/1.2.0.yaml
@@ -4,7 +4,7 @@ products:
   lifecycle: ga
   repo: elastic-otel-java
   owner: elastic
-release-date: '2025-01-20'
+release-date: 2025-01-20
 description: |-
   This release is based on the following upstream versions:
 

--- a/docs/releases/1.2.0.yaml
+++ b/docs/releases/1.2.0.yaml
@@ -20,8 +20,6 @@ entries:
   title: Add experimental instrumentation for OpenAI client
   products:
   - product: edot-java
-    target: 1.2.0
-    lifecycle: ga
   prs:
   - https://github.com/elastic/elastic-otel-java/pull/497
 - file:
@@ -31,8 +29,6 @@ entries:
   title: add stop-sending option
   products:
   - product: edot-java
-    target: 1.2.0
-    lifecycle: ga
   prs:
   - https://github.com/elastic/elastic-otel-java/pull/474
 - file:
@@ -42,8 +38,6 @@ entries:
   title: add disable all instrumentations option
   products:
   - product: edot-java
-    target: 1.2.0
-    lifecycle: ga
   prs:
   - https://github.com/elastic/elastic-otel-java/pull/471
 - file:
@@ -53,8 +47,6 @@ entries:
   title: add dynamically disabled instrumentation capability
   products:
   - product: edot-java
-    target: 1.2.0
-    lifecycle: ga
   prs:
   - https://github.com/elastic/elastic-otel-java/pull/422
 - file:
@@ -64,7 +56,5 @@ entries:
   title: Update upstream OpenTelemetry agent dependencies to 2.12.0
   products:
   - product: edot-java
-    target: 1.2.0
-    lifecycle: ga
   prs:
   - https://github.com/elastic/elastic-otel-java/pull/500

--- a/docs/releases/1.2.1.yaml
+++ b/docs/releases/1.2.1.yaml
@@ -4,7 +4,7 @@ products:
   lifecycle: ga
   repo: elastic-otel-java
   owner: elastic
-release-date: '2025-01-23'
+release-date: 2025-01-23
 description: |-
   This release is based on the following upstream versions:
 

--- a/docs/releases/1.2.1.yaml
+++ b/docs/releases/1.2.1.yaml
@@ -20,7 +20,5 @@ entries:
   title: Add support for OpenAI client 0.13.0
   products:
   - product: edot-java
-    target: 1.2.1
-    lifecycle: ga
   prs:
   - https://github.com/elastic/elastic-otel-java/pull/514

--- a/docs/releases/1.3.0.yaml
+++ b/docs/releases/1.3.0.yaml
@@ -20,8 +20,6 @@ entries:
   title: Add support for OpenAI client 0.22 to 0.31
   products:
   - product: edot-java
-    target: 1.3.0
-    lifecycle: ga
   prs:
   - https://github.com/elastic/elastic-otel-java/pull/564
 - file:
@@ -31,8 +29,6 @@ entries:
   title: fix upstream otel update for 2.13.3
   products:
   - product: edot-java
-    target: 1.3.0
-    lifecycle: ga
   prs:
   - https://github.com/elastic/elastic-otel-java/pull/561
 - file:
@@ -42,8 +38,6 @@ entries:
   title: Fix support for OpenAI developer messages
   products:
   - product: edot-java
-    target: 1.3.0
-    lifecycle: ga
   prs:
   - https://github.com/elastic/elastic-otel-java/pull/539
   issues:
@@ -55,7 +49,5 @@ entries:
   title: Fix instrumentation support for OpenAI client 0.14+
   products:
   - product: edot-java
-    target: 1.3.0
-    lifecycle: ga
   prs:
   - https://github.com/elastic/elastic-otel-java/pull/531

--- a/docs/releases/1.3.0.yaml
+++ b/docs/releases/1.3.0.yaml
@@ -4,7 +4,7 @@ products:
   lifecycle: ga
   repo: elastic-otel-java
   owner: elastic
-release-date: '2025-03-10'
+release-date: 2025-03-10
 description: |-
   This release is based on the following upstream versions:
 

--- a/docs/releases/1.4.0.yaml
+++ b/docs/releases/1.4.0.yaml
@@ -20,8 +20,6 @@ entries:
   title: Change default metric temporality to delta
   products:
   - product: edot-java
-    target: 1.4.0
-    lifecycle: ga
   prs:
   - https://github.com/elastic/elastic-otel-java/pull/583
   issues:
@@ -33,8 +31,6 @@ entries:
   title: Add support for openAI client 1.1+, drop support for older versions
   products:
   - product: edot-java
-    target: 1.4.0
-    lifecycle: ga
   prs:
   - https://github.com/elastic/elastic-otel-java/pull/607
 - file:
@@ -44,8 +40,6 @@ entries:
   title: Override user agent header for otlp exporters
   products:
   - product: edot-java
-    target: 1.4.0
-    lifecycle: ga
   prs:
   - https://github.com/elastic/elastic-otel-java/pull/593
   issues:
@@ -57,8 +51,6 @@ entries:
   title: enable azure provider by default when available
   products:
   - product: edot-java
-    target: 1.4.0
-    lifecycle: ga
   prs:
   - https://github.com/elastic/elastic-otel-java/pull/596
 - file:
@@ -68,7 +60,5 @@ entries:
   title: Update upstream OpenTelemetry agent dependencies to 2.15.0
   products:
   - product: edot-java
-    target: 1.4.0
-    lifecycle: ga
   prs:
   - https://github.com/elastic/elastic-otel-java/pull/603

--- a/docs/releases/1.4.0.yaml
+++ b/docs/releases/1.4.0.yaml
@@ -4,7 +4,7 @@ products:
   lifecycle: ga
   repo: elastic-otel-java
   owner: elastic
-release-date: '2025-04-15'
+release-date: 2025-04-15
 description: |-
   This release is based on the following upstream versions:
 

--- a/docs/releases/1.4.1.yaml
+++ b/docs/releases/1.4.1.yaml
@@ -20,7 +20,5 @@ entries:
   title: Workaround for temporality configuration not being possible
   products:
   - product: edot-java
-    target: 1.4.1
-    lifecycle: ga
   prs:
   - https://github.com/elastic/elastic-otel-java/pull/610

--- a/docs/releases/1.4.1.yaml
+++ b/docs/releases/1.4.1.yaml
@@ -4,7 +4,7 @@ products:
   lifecycle: ga
   repo: elastic-otel-java
   owner: elastic
-release-date: '2025-04-16'
+release-date: 2025-04-16
 description: |-
   This release is based on the following upstream versions:
 

--- a/docs/releases/1.5.0.yaml
+++ b/docs/releases/1.5.0.yaml
@@ -4,7 +4,7 @@ products:
   lifecycle: ga
   repo: elastic-otel-java
   owner: elastic
-release-date: '2025-07-28'
+release-date: 2025-07-28
 description: |-
   This release is based on the following upstream versions:
 

--- a/docs/releases/1.5.0.yaml
+++ b/docs/releases/1.5.0.yaml
@@ -20,8 +20,6 @@ entries:
   title: tech preview release of central configuration support for dynamically changing instrumentation and sending, using OpAMP protocol
   products:
   - product: edot-java
-    target: 1.5.0
-    lifecycle: ga
 - file:
     name: 726.yaml
     checksum: 79e5d8d4d78f2a1c030441ed0c306d6c7758fbc8
@@ -29,8 +27,6 @@ entries:
   title: add option to bypass certificate validation
   products:
   - product: edot-java
-    target: 1.5.0
-    lifecycle: ga
   prs:
   - https://github.com/elastic/elastic-otel-java/pull/726
   issues:
@@ -42,7 +38,5 @@ entries:
   title: Update upstream OpenTelemetry agent dependencies to 2.17.1
   products:
   - product: edot-java
-    target: 1.5.0
-    lifecycle: ga
   prs:
   - https://github.com/elastic/elastic-otel-java/pull/729

--- a/docs/releases/1.6.0.yaml
+++ b/docs/releases/1.6.0.yaml
@@ -4,7 +4,7 @@ products:
   lifecycle: ga
   repo: elastic-otel-java
   owner: elastic
-release-date: '2025-10-06'
+release-date: 2025-10-06
 description: |-
   This release is based on the following upstream versions:
 

--- a/docs/releases/1.6.0.yaml
+++ b/docs/releases/1.6.0.yaml
@@ -20,8 +20,6 @@ entries:
   title: Add 9.2 supported dynamic config options
   products:
   - product: edot-java
-    target: 1.6.0
-    lifecycle: ga
   prs:
   - https://github.com/elastic/elastic-otel-java/pull/818
 - file:
@@ -31,8 +29,6 @@ entries:
   title: Opamp migration
   products:
   - product: edot-java
-    target: 1.6.0
-    lifecycle: ga
   prs:
   - https://github.com/elastic/elastic-otel-java/pull/789
   issues:
@@ -44,8 +40,6 @@ entries:
   title: switch to 2.18.1, and switch openai to upstream
   products:
   - product: edot-java
-    target: 1.6.0
-    lifecycle: ga
   prs:
   - https://github.com/elastic/elastic-otel-java/pull/763
 - file:
@@ -55,7 +49,5 @@ entries:
   title: Update upstream OpenTelemetry agent dependencies to 2.20.1
   products:
   - product: edot-java
-    target: 1.6.0
-    lifecycle: ga
   prs:
   - https://github.com/elastic/elastic-otel-java/pull/803

--- a/docs/releases/1.7.0.yaml
+++ b/docs/releases/1.7.0.yaml
@@ -20,8 +20,6 @@ entries:
   title: add config logging on agent startup
   products:
   - product: edot-java
-    target: 1.7.0
-    lifecycle: ga
   prs:
   - https://github.com/elastic/elastic-otel-java/pull/835
   issues:
@@ -33,8 +31,6 @@ entries:
   title: add support for elastic.otel.opamp.headers config
   products:
   - product: edot-java
-    target: 1.7.0
-    lifecycle: ga
   prs:
   - https://github.com/elastic/elastic-otel-java/pull/848
   issues:
@@ -46,8 +42,6 @@ entries:
   title: add infer-spans dynamoic central config handling
   products:
   - product: edot-java
-    target: 1.7.0
-    lifecycle: ga
   prs:
   - https://github.com/elastic/elastic-otel-java/pull/838
   issues:
@@ -59,7 +53,5 @@ entries:
   title: Update upstream OpenTelemetry agent dependencies to 2.21.0
   products:
   - product: edot-java
-    target: 1.7.0
-    lifecycle: ga
   prs:
   - https://github.com/elastic/elastic-otel-java/pull/844

--- a/docs/releases/1.7.0.yaml
+++ b/docs/releases/1.7.0.yaml
@@ -4,7 +4,7 @@ products:
   lifecycle: ga
   repo: elastic-otel-java
   owner: elastic
-release-date: '2025-11-05'
+release-date: 2025-11-05
 description: |-
   This release is based on the following upstream versions:
 

--- a/docs/releases/1.8.0.yaml
+++ b/docs/releases/1.8.0.yaml
@@ -4,7 +4,7 @@ products:
   lifecycle: ga
   repo: elastic-otel-java
   owner: elastic
-release-date: '2025-12-09'
+release-date: 2025-12-09
 entries:
 - file:
     name: 899.yaml

--- a/docs/releases/1.8.0.yaml
+++ b/docs/releases/1.8.0.yaml
@@ -13,8 +13,6 @@ entries:
   title: enable indy by default
   products:
   - product: edot-java
-    target: 1.8.0
-    lifecycle: ga
   prs:
   - https://github.com/elastic/elastic-otel-java/pull/899
 - file:
@@ -24,7 +22,5 @@ entries:
   title: Update upstream OpenTelemetry agent dependencies to 2.22.0
   products:
   - product: edot-java
-    target: 1.8.0
-    lifecycle: ga
   prs:
   - https://github.com/elastic/elastic-otel-java/pull/898

--- a/docs/releases/1.9.0.yaml
+++ b/docs/releases/1.9.0.yaml
@@ -4,7 +4,7 @@ products:
   lifecycle: ga
   repo: elastic-otel-java
   owner: elastic
-release-date: '2026-02-09'
+release-date: 2026-02-09
 entries:
 - file:
     name: 958.yaml

--- a/docs/releases/1.9.0.yaml
+++ b/docs/releases/1.9.0.yaml
@@ -13,8 +13,6 @@ entries:
   title: document universal profiling as opt-in
   products:
   - product: edot-java
-    target: 1.9.0
-    lifecycle: ga
   prs:
   - https://github.com/elastic/elastic-otel-java/pull/958
 - file:
@@ -24,7 +22,5 @@ entries:
   title: Update upstream OpenTelemetry agent dependencies to 2.24.0
   products:
   - product: edot-java
-    target: 1.9.0
-    lifecycle: ga
   prs:
   - https://github.com/elastic/elastic-otel-java/pull/932


### PR DESCRIPTION
- remove quotes around release dates as [suggested here by copilot](https://github.com/elastic/elastic-otel-java/pull/1075#discussion_r3148357515)
- for existing releases, remove the `target` and `lifecycle` attributes in changelog entries as they are redundant from the bundle (also they aren't populated for changelog entries as the release version is not known when they are merged).