### PR TITLE
[ci] another fix in the release changelog generation

### DIFF
--- a/.github/workflows/release-step-3.yml
+++ b/.github/workflows/release-step-3.yml
@@ -230,7 +230,11 @@ jobs:
         run: |
           echo 'notes<<RELNOTESEOF' >> $GITHUB_OUTPUT
           tmp="$(mktemp -d)"
-          docs-builder changelog render --input "${tmp}/${{ env.RELEASE_VERSION }}" --output "${tmp}"
+          docs-builder changelog render
+            --input "docs/releases/${{ env.RELEASE_VERSION }}.yaml" \
+            --output "${tmp}" \
+            1>/dev/null
+          cat "${tmp}/${{ env.RELEASE_VERSION }}/index.md" \
           cat "${tmp}/${{ env.RELEASE_VERSION }}/index.md" \
             | sed -e "/## ${{ env.RELEASE_VERSION }} \[elastic-release-notes-${{ env.RELEASE_VERSION }}/d" \
             | sed -e "/###/s/ \[elastic-${{ env.RELEASE_VERSION }}.*$//g" >> $GITHUB_OUTPUT

--- a/.github/workflows/release-step-3.yml
+++ b/.github/workflows/release-step-3.yml
@@ -235,7 +235,6 @@ jobs:
             --output "${tmp}" \
             1>/dev/null
           cat "${tmp}/${{ env.RELEASE_VERSION }}/index.md" \
-          cat "${tmp}/${{ env.RELEASE_VERSION }}/index.md" \
             | sed -e "/## ${{ env.RELEASE_VERSION }} \[elastic-release-notes-${{ env.RELEASE_VERSION }}/d" \
             | sed -e "/###/s/ \[elastic-${{ env.RELEASE_VERSION }}.*$//g" >> $GITHUB_OUTPUT
           echo 'RELNOTESEOF' >> $GITHUB_OUTPUT

--- a/.github/workflows/release-step-3.yml
+++ b/.github/workflows/release-step-3.yml
@@ -230,7 +230,7 @@ jobs:
         run: |
           echo 'notes<<RELNOTESEOF' >> $GITHUB_OUTPUT
           tmp="$(mktemp -d)"
-          docs-builder changelog render
+          docs-builder changelog render \
             --input "docs/releases/${{ env.RELEASE_VERSION }}.yaml" \
             --output "${tmp}" \
             1>/dev/null


### PR DESCRIPTION
should fix https://github.com/elastic/elastic-otel-java/actions/runs/25006685693/job/73231276957

- invalid input path for the release yaml
- standard output of `doc-builder` invocation should be removed