### PR TITLE
add jdk 26 test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -125,10 +125,15 @@ jobs:
 
   jdk-test:
     runs-on: ubuntu-latest
+    if: always()
     needs:
       - jdk-matrix
     steps:
-      - run: echo "no test to run, this job depends on the results of jdk-matrix"
+      - name: Check jdk-matrix result
+        run: |
+          result="${{ needs.jdk-matrix.result }}"
+          echo "jdk-matrix result: $result"
+          [[ "$result" == "success" ]] || exit 1
 
   muzzle-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
           path: |
             ./agentextension/build/libs/elastic-otel-agentextension-*.jar
 
-  jdk-test:
+  jdk-test-matrix:
     runs-on: ubuntu-latest
     needs:
       - build
@@ -122,6 +122,13 @@ jobs:
         with:
           name: test-results-${{ matrix.version }}-${{ matrix.vm }}
           path: '**/build/test-results/test/TEST-*.xml'
+
+  jdk-test:
+    runs-on: ubuntu-latest
+    needs:
+      - jdk-test-matrix
+    steps:
+      - run: echo "no test to run, this job depends on the results of jdk-test-matrix"
 
   muzzle-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
           path: |
             ./agentextension/build/libs/elastic-otel-agentextension-*.jar
 
-  test:
+  jdk-test:
     runs-on: ubuntu-latest
     needs:
       - build
@@ -80,11 +80,15 @@ jobs:
             vm: 'hotspot'
           - version: 25
             vm: 'hotspot'
+          - version: 26
+            vm: 'hotspot'
           - version: 11
             vm: 'openj9'
           - version: 21
             vm: 'openj9'
           - version: 25
+            vm: 'openj9'
+          - version: 26
             vm: 'openj9'
     steps:
       # We use the cached working directory so that we don't have to recompile everything

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
           path: |
             ./agentextension/build/libs/elastic-otel-agentextension-*.jar
 
-  jdk-test-matrix:
+  jdk-matrix:
     runs-on: ubuntu-latest
     needs:
       - build
@@ -126,9 +126,9 @@ jobs:
   jdk-test:
     runs-on: ubuntu-latest
     needs:
-      - jdk-test-matrix
+      - jdk-matrix
     steps:
-      - run: echo "no test to run, this job depends on the results of jdk-test-matrix"
+      - run: echo "no test to run, this job depends on the results of jdk-matrix"
 
   muzzle-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- rename jdk test to `jdk-test` to easily identify JDK tests and make it easier to add them as branch protection rules required checks.
- addk JDK 26 to the test matrix