### PR TITLE
service.namespace is stable

### DIFF
--- a/universal-profiling-integration/src/main/java/co/elastic/otel/ProfilerSharedMemoryWriter.java
+++ b/universal-profiling-integration/src/main/java/co/elastic/otel/ProfilerSharedMemoryWriter.java
@@ -52,8 +52,7 @@ public class ProfilerSharedMemoryWriter {
     if (serviceName == null) {
       throw new IllegalStateException("A service name must be configured!");
     }
-    String environment =
-        serviceResource.getAttribute(UniversalProfilingIncubatingAttributes.SERVICE_NAMESPACE);
+    String environment = serviceResource.getAttribute(ServiceAttributes.SERVICE_NAMESPACE);
 
     ByteBuffer buffer = ByteBuffer.allocateDirect(4096);
     buffer.order(ByteOrder.nativeOrder());

--- a/universal-profiling-integration/src/main/java/co/elastic/otel/UniversalProfilingIncubatingAttributes.java
+++ b/universal-profiling-integration/src/main/java/co/elastic/otel/UniversalProfilingIncubatingAttributes.java
@@ -26,7 +26,5 @@ public class UniversalProfilingIncubatingAttributes {
 
   // not yet part of stable semantic conventions, inlined here to prevent dependency issues
 
-  public static final AttributeKey<String> SERVICE_NAMESPACE =
-      AttributeKey.stringKey("service.namespace");
   public static final AttributeKey<String> HOST_ID = AttributeKey.stringKey("host.id");
 }

--- a/universal-profiling-integration/src/test/java/co/elastic/otel/UniversalProfilingIncubatingAttributesTest.java
+++ b/universal-profiling-integration/src/test/java/co/elastic/otel/UniversalProfilingIncubatingAttributesTest.java
@@ -22,17 +22,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.semconv.incubating.HostIncubatingAttributes;
-import io.opentelemetry.semconv.incubating.ServiceIncubatingAttributes;
 import org.junit.jupiter.api.Test;
 
 public class UniversalProfilingIncubatingAttributesTest {
-
-  @Test
-  void serviceNamespace() {
-    check(
-        UniversalProfilingIncubatingAttributes.SERVICE_NAMESPACE,
-        ServiceIncubatingAttributes.SERVICE_NAMESPACE);
-  }
 
   @Test
   void hostId() {

--- a/universal-profiling-integration/src/test/java/co/elastic/otel/UniversalProfilingProcessorTest.java
+++ b/universal-profiling-integration/src/test/java/co/elastic/otel/UniversalProfilingProcessorTest.java
@@ -49,7 +49,6 @@ import io.opentelemetry.sdk.trace.samplers.Sampler;
 import io.opentelemetry.sdk.trace.samplers.SamplingResult;
 import io.opentelemetry.semconv.ServiceAttributes;
 import io.opentelemetry.semconv.incubating.HostIncubatingAttributes;
-import io.opentelemetry.semconv.incubating.ServiceIncubatingAttributes;
 import java.lang.ref.WeakReference;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -254,7 +253,7 @@ public class UniversalProfilingProcessorTest {
       Resource withNamespace =
           Resource.builder()
               .put(ServiceAttributes.SERVICE_NAME, "service Ä 1")
-              .put(ServiceIncubatingAttributes.SERVICE_NAMESPACE, "my nameßspace")
+              .put(ServiceAttributes.SERVICE_NAMESPACE, "my nameßspace")
               .build();
       try (OpenTelemetrySdk sdk = initSdk(withNamespace, b -> {}, Sampler.alwaysOn())) {
         checkProcessStorage("service Ä 1", "my nameßspace");


### PR DESCRIPTION
`service.namespace` is now [stable](https://opentelemetry.io/docs/specs/semconv/registry/attributes/service/#service-namespace), we can remove our duplicated attribute for it.