### PR TITLE
use stable semconv in tests

### DIFF
--- a/custom/src/test/java/co/elastic/otel/ElasticAutoConfigurationCustomizerProviderTest.java
+++ b/custom/src/test/java/co/elastic/otel/ElasticAutoConfigurationCustomizerProviderTest.java
@@ -31,6 +31,7 @@ import io.opentelemetry.sdk.metrics.InstrumentType;
 import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
 import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.semconv.DeploymentAttributes;
 import io.opentelemetry.semconv.incubating.DeploymentIncubatingAttributes;
 import java.util.HashMap;
 import java.util.List;
@@ -148,7 +149,7 @@ class ElasticAutoConfigurationCustomizerProviderTest {
         .hasSize(3)
         .describedAs("when legacy attribute set agent should send both")
         .containsEntry(DeploymentIncubatingAttributes.DEPLOYMENT_ENVIRONMENT, "test")
-        .containsEntry(DeploymentIncubatingAttributes.DEPLOYMENT_ENVIRONMENT_NAME, "test")
+        .containsEntry(DeploymentAttributes.DEPLOYMENT_ENVIRONMENT_NAME, "test")
         .containsEntry("other", "other");
   }
 
@@ -157,7 +158,7 @@ class ElasticAutoConfigurationCustomizerProviderTest {
     Resource input =
         Resource.builder()
             .put(DeploymentIncubatingAttributes.DEPLOYMENT_ENVIRONMENT, "legacy")
-            .put(DeploymentIncubatingAttributes.DEPLOYMENT_ENVIRONMENT_NAME, "new")
+            .put(DeploymentAttributes.DEPLOYMENT_ENVIRONMENT_NAME, "new")
             .put("other", "other")
             .build();
     Resource resource = resourceProviders().apply(input, null);
@@ -165,7 +166,7 @@ class ElasticAutoConfigurationCustomizerProviderTest {
         .hasSize(3)
         .describedAs("when both attributes are set, agent should send them as-is")
         .containsEntry(DeploymentIncubatingAttributes.DEPLOYMENT_ENVIRONMENT, "legacy")
-        .containsEntry(DeploymentIncubatingAttributes.DEPLOYMENT_ENVIRONMENT_NAME, "new")
+        .containsEntry(DeploymentAttributes.DEPLOYMENT_ENVIRONMENT_NAME, "new")
         .containsEntry("other", "other");
   }
 }

--- a/custom/src/test/java/co/elastic/otel/SpanStackTraceTest.java
+++ b/custom/src/test/java/co/elastic/otel/SpanStackTraceTest.java
@@ -126,9 +126,7 @@ public class SpanStackTraceTest {
     if (stackTraceExpected) {
       assertThat(span)
           .hasAttribute(
-              satisfies(
-                  CodeAttributes.CODE_STACKTRACE,
-                  AbstractCharSequenceAssert::isNotBlank));
+              satisfies(CodeAttributes.CODE_STACKTRACE, AbstractCharSequenceAssert::isNotBlank));
     } else {
       assertThat(span.getAttributes().get(CodeAttributes.CODE_STACKTRACE)).isNull();
     }

--- a/custom/src/test/java/co/elastic/otel/SpanStackTraceTest.java
+++ b/custom/src/test/java/co/elastic/otel/SpanStackTraceTest.java
@@ -30,7 +30,7 @@ import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.contrib.stacktrace.StackTraceSpanProcessor;
 import io.opentelemetry.sdk.trace.data.SpanData;
-import io.opentelemetry.semconv.incubating.CodeIncubatingAttributes;
+import io.opentelemetry.semconv.CodeAttributes;
 import java.util.List;
 import org.assertj.core.api.AbstractCharSequenceAssert;
 import org.junit.jupiter.api.AfterEach;
@@ -127,10 +127,10 @@ public class SpanStackTraceTest {
       assertThat(span)
           .hasAttribute(
               satisfies(
-                  CodeIncubatingAttributes.CODE_STACKTRACE,
+                  CodeAttributes.CODE_STACKTRACE,
                   AbstractCharSequenceAssert::isNotBlank));
     } else {
-      assertThat(span.getAttributes().get(CodeIncubatingAttributes.CODE_STACKTRACE)).isNull();
+      assertThat(span.getAttributes().get(CodeAttributes.CODE_STACKTRACE)).isNull();
     }
   }
 

--- a/universal-profiling-integration/src/test/java/co/elastic/otel/UniversalProfilingProcessorTest.java
+++ b/universal-profiling-integration/src/test/java/co/elastic/otel/UniversalProfilingProcessorTest.java
@@ -49,7 +49,6 @@ import io.opentelemetry.sdk.trace.samplers.Sampler;
 import io.opentelemetry.sdk.trace.samplers.SamplingResult;
 import io.opentelemetry.semconv.ServiceAttributes;
 import io.opentelemetry.semconv.incubating.HostIncubatingAttributes;
-import io.opentelemetry.semconv.incubating.ServiceIncubatingAttributes;
 import java.lang.ref.WeakReference;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -254,7 +253,7 @@ public class UniversalProfilingProcessorTest {
       Resource withNamespace =
           Resource.builder()
               .put(ServiceAttributes.SERVICE_NAME, "service Ä 1")
-              .put(ServiceIncubatingAttributes.SERVICE_NAMESPACE, "my nameßspace")
+              .put(ServiceAttributes.SERVICE_NAMESPACE, "my nameßspace")
               .build();
       try (OpenTelemetrySdk sdk = initSdk(withNamespace, b -> {}, Sampler.alwaysOn())) {
         checkProcessStorage("service Ä 1", "my nameßspace");


### PR DESCRIPTION
Use stable semconv attributes constants for:
- `code.stacktrace`
- `deployment.environment.name`

no visible changes to the end-user, this is only test code.