### PR TITLE
[ci] fix changelog-submit permissions

### DIFF
--- a/.github/workflows/changelog-submit.yml
+++ b/.github/workflows/changelog-submit.yml
@@ -6,8 +6,7 @@ on:
     types:
       - completed
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   submit:

--- a/.github/workflows/changelog-submit.yml
+++ b/.github/workflows/changelog-submit.yml
@@ -12,6 +12,8 @@ permissions:
 jobs:
   submit:
     permissions:
-      contents: write
-      pull-requests: write
+      contents: write       # commit the generated changelog file to the PR branch
+      pull-requests: write  # post the changelog comment on the PR
+      id-token: write       # OIDC token for the org-membership check on fork PRs
+      packages: read        # pull the docs-builder edge image from GHCR
     uses: elastic/docs-actions/.github/workflows/changelog-submit.yml@v1


### PR DESCRIPTION
Fixes GH action failures like https://github.com/elastic/elastic-otel-java/actions/runs/26442583583

Applies permissions from the documentation: https://github.com/elastic/docs-actions/tree/main/changelog#2-create-the-workflows

This was not previously required when the changelog-submit action had been added in this repository.