### PR TITLE
ci: add changelog-upload workflow and tighten changelog-init permissions

### DIFF
--- a/.github/workflows/changelog-init.yml
+++ b/.github/workflows/changelog-init.yml
@@ -10,8 +10,7 @@ on:
       - labeled
       - unlabeled
 
-permissions:
-  contents: read
+permissions: {}
 
 concurrency:
   group: changelog-init-${{ github.event.pull_request.number }}
@@ -54,4 +53,6 @@ jobs:
     if: ${{ always() }}
     # needs to execute after init-upstream-update
     needs: [ upstream-update ]
+    permissions:
+      contents: read  # reusable workflow checks out the repo to read docs/changelog.yml
     uses: elastic/docs-actions/.github/workflows/changelog-validate.yml@v1

--- a/.github/workflows/changelog-upload.yml
+++ b/.github/workflows/changelog-upload.yml
@@ -1,0 +1,15 @@
+name: changelog-upload
+
+on:
+  push:
+    branches: [main]
+
+permissions: {}
+
+jobs:
+  upload:
+    permissions:
+      contents: read        # checkout the pushed commit
+      id-token: write       # OIDC token for AWS authentication
+      pull-requests: read   # look up merged PRs for the pushed commit so fork-PR entries can be regenerated
+    uses: elastic/docs-actions/.github/workflows/changelog-upload.yml@v1


### PR DESCRIPTION
## Summary

Two small pieces were missing for the changelog setup to be complete end-to-end:

1. **`changelog-upload.yml` (new file).** The existing `changelog-init` (validate + the bespoke `upstream-update` job) and `changelog-submit` workflows cover the *PR lifecycle*, but nothing was wired up to regenerate and upload changelog bundles to S3 when PRs land on `main`. That left **fork-PR entries in particular without a path to the public bundle** — the upload action re-derives them from the merged commit's pull-request record via `docs-builder changelog add --prs <N>`, which only runs on push. This PR adds the reusable workflow call with the three scopes the upload step needs:
   - `contents: read` — checkout the pushed commit
   - `id-token: write` — OIDC token for AWS authentication
   - `pull-requests: read` — look up merged PRs for the pushed commit so fork-PR entries can be regenerated
2. **`changelog-init.yml` — workflow-level → job-level permissions.** Today `changelog-init.yml` grants `contents: read` at the workflow level. It works because the `upstream-update` job already overrides to `contents: write` + `pull-requests: write` and the `validate` job only needs read, but the workflow-level grant would silently get inherited by any future job added to this file. Switching to the same least-privilege pattern adopted in #1118 for `changelog-submit.yml`: workflow-level `permissions: {}` ceiling, each job declaring its own. The `validate` job now spells out `contents: read` explicitly (the reusable workflow declares the same internally, but a caller-side declaration is required because the workflow-level ceiling propagates down into reusable workflow calls).

No behaviour change for existing PR runs. The upload path will start firing on the next push to `main`.

## Infrastructure prerequisites (verified already in place)

- `elastic/elastic-otel-java` is declared in `elastic/docs-infra/modules/aws-github-actions-oidc-roles/repositories.yml` (line 66) — the OIDC role exists, so `aws-actions/configure-aws-credentials` will succeed.
- `elastic-otel-java` is declared in `elastic/docs-builder/config/assembler.yml` (line 121) without `private: true` — the scrubber Lambda will allow links to this repo through to the public CDN copy.
- Default branch is `main`, which the upload action's branch guard accepts (`refs/heads/main` or `refs/heads/master`).
- `docs/changelog.yml` is correctly configured (`bundle.repo: elastic-otel-java`, `bundle.owner: elastic`, `filename: pr`, `pivot.types` covers the team's labels), so both the per-PR upload and the fork-PR regeneration path will resolve cleanly.

## Test plan

- [x] `actionlint .github/workflows/changelog-*.yml` passes locally.
- [x] YAML parses cleanly.
- [ ] After merge, watch the `changelog-upload` run on the first push to `main` (no test PR required — the first merged PR after this lands will exercise it).
- [ ] Confirm the changelog appears in the bundle published to S3 / surfaces on the docs site.

## Companion context

The upstream changelog workflow bugs that were causing fork PRs to fail (detached-HEAD push, missing fallback comment) were fixed in `elastic/docs-actions#172` and shipped as part of today's `v1` retag. With those plus this PR, `elastic-otel-java` will have the complete changelog story: validate → submit (commit or comment) → upload (per push to main).

Made with [Cursor](https://cursor.com)