### PR TITLE
add app_server resource provider in default declarative configuration

### DIFF
--- a/custom/src/main/resources/co/elastic/otel/config.yaml
+++ b/custom/src/main/resources/co/elastic/otel/config.yaml
@@ -21,6 +21,10 @@ resource:
       - host:
       # Provides 'container.id'
       - container:
+      # Provides 'service.name' from application server (if available)
+      # Requires the resource-providers extension
+      # https://github.com/open-telemetry/opentelemetry-java-contrib/tree/main/resource-providers
+      - app_server:
       # Provides 'service.name' and 'service.instance.id'
       - service:
 

--- a/custom/src/main/resources/co/elastic/otel/config.yaml
+++ b/custom/src/main/resources/co/elastic/otel/config.yaml
@@ -21,7 +21,9 @@ resource:
       - host:
       # Provides 'container.id'
       - container:
-      # Provides 'service.name' from application server (if available)
+      # Provides 'service.name' from application server deployed application (if available)
+      # When multiple applications are deployed, it might be relevant to provide an explicit 'service.name'
+      # to get a deterministic behavior on the effective 'service.name'
       # Requires the resource-providers extension
       # https://github.com/open-telemetry/opentelemetry-java-contrib/tree/main/resource-providers
       - app_server:

--- a/custom/src/test/java/co/elastic/otel/declarativeconfig/DefaultDeclarativeConfigTest.java
+++ b/custom/src/test/java/co/elastic/otel/declarativeconfig/DefaultDeclarativeConfigTest.java
@@ -51,7 +51,7 @@ public class DefaultDeclarativeConfigTest {
               assertThatJson(json(config.getResource()))
                   .inPath("detection/development.detectors")
                   .isArray()
-                  .hasSize(9);
+                  .hasSize(10);
 
           // those are the providers magically added by upstream and elastic distributions
           detectorsAssert
@@ -64,6 +64,7 @@ public class DefaultDeclarativeConfigTest {
               json("{\"aws\":null}"),
               json("{\"gcp\":null}"),
               json("{\"azure\":null}"),
+              json("{\"app_server\":null}"),
               // TODO: maybe investigate why those are including empty objects
               json("{\"process\":{}}"),
               json("{\"container\":{}}"),


### PR DESCRIPTION
Adds application server resource detector to set `service.name` from deployed application.

implementation in contrib: https://github.com/open-telemetry/opentelemetry-java-contrib/tree/main/resource-providers
