### PR TITLE
Update release notes to keep publishing dates

### DIFF
--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -19,4 +19,5 @@ To check for security updates, go to [Security announcements for the Elastic sta
 
 :::{changelog} /releases/
 :type: all
+:release-dates:
 :::


### PR DESCRIPTION
Relates to https://github.com/elastic/docs-builder/pull/3559

That PR updates the changelog directive to **not** show release dates by default. Therefore this PR is necessary to turn on that option for the EDOT Java release notes.