### PR TITLE
fix enabling indy by default in declarative config

### DIFF
--- a/custom/src/main/resources/co/elastic/otel/config.yaml
+++ b/custom/src/main/resources/co/elastic/otel/config.yaml
@@ -136,12 +136,13 @@ logger_provider:
           #  endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT}
           #  headers_list: ${OTEL_EXPORTER_OTLP_HEADERS}
 
+distribution:
+  javaagent:
+    # enable experimental indy instrumentation
+    indy/development: true
+
 instrumentation/development:
   java:
     runtime_telemetry:
       # emit not-yet stable runtime telemetry metrics which are currently part of semconv for java runtime
       emit_experimental_metrics/development: ${OTEL_INSTRUMENTATION_RUNTIME_TELEMETRY_EMIT_EXPERIMENTAL_METRICS:-true}
-    agent:
-      experimental:
-        # enable experimental indy instrumentation
-        indy: true

--- a/custom/src/test/java/co/elastic/otel/declarativeconfig/DefaultDeclarativeConfigTest.java
+++ b/custom/src/test/java/co/elastic/otel/declarativeconfig/DefaultDeclarativeConfigTest.java
@@ -25,6 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.javaagent.tooling.resources.ResourceCustomizerProvider;
 import io.opentelemetry.sdk.autoconfigure.declarativeconfig.DeclarativeConfiguration;
+import io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.DistributionModel;
 import io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.ExperimentalComposableRuleBasedSamplerRuleModel;
 import io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.ExperimentalLanguageSpecificInstrumentationModel;
 import io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.OpenTelemetryConfigurationModel;
@@ -157,9 +158,12 @@ public class DefaultDeclarativeConfigTest {
               .inPath("runtime_telemetry.emit_experimental_metrics/development")
               .isBoolean()
               .isTrue();
-          assertThatJson(json(java))
+
+          DistributionModel distribution = config.getDistribution();
+          assertThat(distribution).isNotNull();
+          assertThatJson(json(distribution))
               .describedAs("experimental indy is enabled by default")
-              .inPath("agent.experimental.indy")
+              .inPath("javaagent.indy/development")
               .isBoolean()
               .isTrue();
         });


### PR DESCRIPTION
In the provided declarative configuration file, the following configuration was set to enable indy instrumentation by default

```yaml
instrumentation/development:
  java:
    agent:
      experimental:
        # enable experimental indy instrumentation
        indy: true
```

However, the correct configuration to enable it with declarative configuration is in `distribution` node as we can see in [upstream example](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/e398bcfc30ab45c2741a5025b1f82b66420aa076/javaagent-tooling/src/testDistributionConfig/resources/distribution-config.yaml#L10).

```yaml
distribution:
  javaagent:
    indy/development: true
```

This PR fixes this by using the correct yaml configuration and updating related tests.

There is unfortunately no easy way to test the configuration is effective in an automated way, so I was only able to perform manual testing with a debugger to validate the option is now read as expected in `io.opentelemetry.javaagent.extension.instrumentation.internal.AgentDistributionConfig` constructor.