### PR TITLE
[release] remove deprecated changelog resolve

### DIFF
--- a/docs/changelog.yml
+++ b/docs/changelog.yml
@@ -35,7 +35,6 @@ rules:
 bundle:
   directory: docs/changelog
   output_directory: docs/releases
-  resolve: true
   repo: elastic-otel-java
   owner: elastic
   release_dates: true


### PR DESCRIPTION
Should fix warnings at release time : https://github.com/elastic/elastic-otel-java/actions/runs/30613292001

As suggested by @cotti 