### PR TITLE
add doc+link for extensions

### DIFF
--- a/docs/reference/edot-java/features.md
+++ b/docs/reference/edot-java/features.md
@@ -79,3 +79,13 @@ This feature requires minimal code changes for creating and accessing the baggag
 - `OTEL_JAVA_EXPERIMENTAL_LOG_ATTRIBUTES_COPY_FROM_BAGGAGE_INCLUDE`
 
 Refer to [baggage-processor](https://github.com/open-telemetry/opentelemetry-java-contrib/tree/main/baggage-processor) and the [baggage example](https://github.com/elastic/elastic-otel-java/tree/main/examples/baggage) for more details.
+
+This feature is inherited from [OpenTelemetry Java Instrumentation](https://github.com/open-telemetry/opentelemetry-java-instrumentation).
+
+## Extensions
+
+The EDOT Java agent includes support for extensions which is inherited from [OpenTelemetry Java Instrumentation](https://github.com/open-telemetry/opentelemetry-java-instrumentation).
+
+This allows to extend or modify the agent behavior and features without having to maintain a complete fork.
+
+Refer to [OpenTelemetry Java Instrumentation extensions](https://opentelemetry.io/docs/zero-code/java/agent/extensions/) for more details.

--- a/docs/reference/edot-java/features.md
+++ b/docs/reference/edot-java/features.md
@@ -30,6 +30,7 @@ The EDOT Java agent includes the following resource attributes providers from [o
 
 - AWS: [aws-resources](https://github.com/open-telemetry/opentelemetry-java-contrib/tree/main/aws-resources). Turned on by default.
 - GCP: [gcp-resources](https://github.com/open-telemetry/opentelemetry-java-contrib/tree/main/gcp-resources). Turned on by default.
+- Azure: [azure-resources](https://github.com/open-telemetry/opentelemetry-java-contrib/tree/main/azure-resources). Turned on by default.
 - Application server service name detection: [resource-providers](https://github.com/open-telemetry/opentelemetry-java-contrib/tree/main/resource-providers).
 
 ## Inferred spans

--- a/docs/reference/edot-java/features.md
+++ b/docs/reference/edot-java/features.md
@@ -87,5 +87,6 @@ This feature is inherited from [OpenTelemetry Java Instrumentation](https://gith
 The EDOT Java agent includes support for extensions which is inherited from [OpenTelemetry Java Instrumentation](https://github.com/open-telemetry/opentelemetry-java-instrumentation).
 
 This allows to extend or modify the agent behavior and features without having to maintain a complete fork.
+A few examples are provided [here](https://github.com/elastic/elastic-otel-java/tree/main/examples/extensions).
 
 Refer to [OpenTelemetry Java Instrumentation extensions](https://opentelemetry.io/docs/zero-code/java/agent/extensions/) for more details.


### PR DESCRIPTION
documents extensions as a supported feature, using a link to upstream doc to remove duplication.