### PR TITLE
Retarget EDOT Java agent-skill callouts to observability-onboarding

### DIFF
--- a/docs/reference/edot-java/migration.md
+++ b/docs/reference/edot-java/migration.md
@@ -26,7 +26,7 @@ Compared to the Elastic {{product.apm}} Java agent, the {{edot}} Java presents a
 ## Migration steps
 
 :::{agent-skill}
-:url: https://github.com/elastic/agent-skills@observability-onboarding
+:url: https://github.com/elastic/agent-skills/tree/main/skills/observability/onboarding
 
 Use this skill to migrate from the Elastic APM Java agent to EDOT Java.
 :::

--- a/docs/reference/edot-java/migration.md
+++ b/docs/reference/edot-java/migration.md
@@ -25,6 +25,12 @@ Compared to the Elastic {{product.apm}} Java agent, the {{edot}} Java presents a
 
 ## Migration steps
 
+:::{agent-skill}
+:url: https://github.com/elastic/agent-skills@observability-onboarding
+
+Use this skill to migrate from the Elastic APM Java agent to EDOT Java.
+:::
+
 Follow these steps to migrate from the legacy Elastic {{product.apm}} Java agent to the {{edot}} Java.
 
 ::::::{stepper}

--- a/docs/reference/edot-java/migration.md
+++ b/docs/reference/edot-java/migration.md
@@ -25,12 +25,6 @@ Compared to the Elastic {{product.apm}} Java agent, the {{edot}} Java presents a
 
 ## Migration steps
 
-:::{agent-skill}
-:url: https://github.com/elastic/agent-skills/tree/main/skills/observability/edot-java-migrate
-
-Use this skill to migrate from the Elastic APM Java agent to EDOT Java.
-:::
-
 Follow these steps to migrate from the legacy Elastic {{product.apm}} Java agent to the {{edot}} Java.
 
 ::::::{stepper}

--- a/docs/reference/edot-java/setup/index.md
+++ b/docs/reference/edot-java/setup/index.md
@@ -33,12 +33,6 @@ For environments where modifying the JVM arguments or configuration is impossibl
 
 Follow the following Java setup guide for all other environments.
 
-:::{agent-skill}
-:url: https://github.com/elastic/agent-skills/tree/main/skills/observability/edot-java-instrument
-
-Use this skill to instrument Java services with EDOT for tracing, metrics, and logs.
-:::
-
 ## Download the agent
 
 You can download the latest release version of the EDOT Java agent from [![Maven Central](https://img.shields.io/maven-central/v/co.elastic.otel/elastic-otel-javaagent?label=elastic-otel-javaagent&style=for-the-badge)](https://mvnrepository.com/artifact/co.elastic.otel/elastic-otel-javaagent/latest)

--- a/docs/reference/edot-java/setup/index.md
+++ b/docs/reference/edot-java/setup/index.md
@@ -33,6 +33,12 @@ For environments where modifying the JVM arguments or configuration is impossibl
 
 Follow the following Java setup guide for all other environments.
 
+:::{agent-skill}
+:url: https://github.com/elastic/agent-skills@observability-onboarding
+
+Use this skill to instrument Java services with EDOT for tracing, metrics, and logs.
+:::
+
 ## Download the agent
 
 You can download the latest release version of the EDOT Java agent from [![Maven Central](https://img.shields.io/maven-central/v/co.elastic.otel/elastic-otel-javaagent?label=elastic-otel-javaagent&style=for-the-badge)](https://mvnrepository.com/artifact/co.elastic.otel/elastic-otel-javaagent/latest)

--- a/docs/reference/edot-java/setup/index.md
+++ b/docs/reference/edot-java/setup/index.md
@@ -34,7 +34,7 @@ For environments where modifying the JVM arguments or configuration is impossibl
 Follow the following Java setup guide for all other environments.
 
 :::{agent-skill}
-:url: https://github.com/elastic/agent-skills@observability-onboarding
+:url: https://github.com/elastic/agent-skills/tree/main/skills/observability/onboarding
 
 Use this skill to instrument Java services with EDOT for tracing, metrics, and logs.
 :::


### PR DESCRIPTION
## Summary

elastic/agent-skills [v0.6.0](https://github.com/elastic/agent-skills/releases/tag/v0.6.0) removed `edot-java-instrument` and `edot-java-migrate`. Those skills now live in `observability-onboarding`, which still covers both paths for Java: attach EDOT when no classic APM agent is present, and migrate off the Elastic APM Java agent. The attach method, environment variables, and do-not-reuse-APM-Server-URL guidance match the old skills.

This PR points the setup and migration `{agent-skill}` callouts at the GitHub folder [`skills/observability/onboarding`](https://github.com/elastic/agent-skills/tree/main/skills/observability/onboarding). Page-specific body text is unchanged so setup still orients to instrument, and migration still orients to migrate.

These companion docs use a `/tree/main/skills/...` URL instead of the `repo@skill` form. The `@` URLs 404 if opened as GitHub links, and in these EDOT repos they also break the link the directive embeds.

Companion to elastic/docs-content#8227. Tracked in elastic/docs-content#8230.

## Test plan

- [ ] Preview the setup and migration pages and confirm each callout links to the `observability/onboarding` skill folder.
- [ ] Confirm surrounding setup and migration steps are unchanged.
