### PR TITLE
remove deprecated await-artifact config

### DIFF
--- a/.github/workflows/release-step-3.yml
+++ b/.github/workflows/release-step-3.yml
@@ -203,8 +203,6 @@ jobs:
     steps:
       - uses: elastic/oblt-actions/maven/await-artifact@v1
         with:
-          maven-central: true
-          sonatype-central: false
           group-id: 'co.elastic.otel'
           artifact-id: 'elastic-otel-javaagent'
           version: ${{ inputs.version }}


### PR DESCRIPTION
The `maven-central` and `sonatype-central` options are not relevant anymore in the await-artifact (it's now maven-central only).

Related changes
- https://github.com/elastic/oblt-actions/pull/480
- https://github.com/elastic/oblt-actions/pull/1085