### PR TITLE
[DOCS] Add use_local_changelogs to changelog.yml

### DIFF
--- a/.github/workflows/pre-post-release.yml
+++ b/.github/workflows/pre-post-release.yml
@@ -113,6 +113,7 @@ jobs:
             --input-products 'edot-java * *' \
             --output-products 'edot-java ${{ env.RELEASE_VERSION }} ga' \
             --output docs/releases/${{ env.RELEASE_VERSION }}.yaml \
+            --force-local \
             --description "${description}"
           docs-builder changelog remove edot-java-release ${{ env.RELEASE_VERSION }}
   

--- a/docs/changelog.yml
+++ b/docs/changelog.yml
@@ -43,5 +43,4 @@ bundle:
   profiles:
     edot-java-release:
       products: "edot-java * *"
-      output: "{version}.yaml"
       output_products: "edot-java {version} ga"

--- a/docs/changelog.yml
+++ b/docs/changelog.yml
@@ -38,6 +38,7 @@ bundle:
   repo: elastic-otel-java
   owner: elastic
   release_dates: true
+  use_local_changelogs: true
 
   profiles:
     edot-java-release:


### PR DESCRIPTION
## Background

https://github.com/elastic/elastic-otel-java/actions/runs/34202678209/job/101984907127#step:11:36 is returning the following error:

```sh
Errors
  --input-products is not supported when sourcing changelog entries from the 
CDN, because entries are fetched by key (one per PR) and there is no pool 
enumeration. Pass --force-local or --directory to bundle from a local checkout 
instead.
```

The affected pipeline is defined here: https://github.com/elastic/elastic-otel-java/blob/main/.github/workflows/pre-post-release.yml#L105

I think this error relates to https://github.com/elastic/docs-builder/pull/3922
If you don't specify `--force-local`, the `changelog bundle` command assumes you're pulling changelogs from S3.
The `--input-products` option doesn't work with S3-based changelogs.

## Solution

If it's true that all of the relevant changelogs exist in the `docs/changelog` folder (i.e. not in S3), you can add the `--force-local` option or the equivalent `bundle.use_local_changelogs` setting, per https://docs-v3-preview.elastic.dev/elastic/docs-builder/tree/main/data/release-notes/configure-ref#bundle-entry-sourcing.

I've also removed the `output` setting from the `changelog.yml` file in this PR, since that's no longer supported per https://github.com/elastic/docs-builder/pull/3856

## AI analysis

### What the workflow actually does

`pre-post-release.yml`(pre phase):

```sh
docs-builder changelog bundle \
  --input-products 'edot-java * *' \
  --output-products 'edot-java ${RELEASE_VERSION} ga' \
  --output docs/releases/${RELEASE_VERSION}.yaml \
  --description "${description}"
docs-builder changelog remove edot-java-release ${RELEASE_VERSION}
```

Their profile is the same filter: `products: "edot-java * *"`.

This is a **folder-as-source-of-truth** pipeline:

1. PRs land changelog YAML in `docs/changelog` (`changelog add` / changelog-submit). Those files already omit `target` (see `docs/changelog/upstream-update.yaml` and entries inside `docs/releases/1.12.0.yaml`).
2. Pre-release bundles **everything currently in that folder** for `edot-java`, regardless of version.
3. Release version is **workflow input** via `--output-products` / `--output`, not a field on each file.
4. `changelog remove` wipes the folder so the next release does not double-count.

### What is actually likely broken

Two docs-builder changes collide with this repo:

1. **CDN is the default when `bundle.repo` resolves.** They set `bundle.repo` / `bundle.owner` and do **not** pass `--directory`, `--force-local`, or `bundle.use_local_changelogs`. `bundle.directory` is used for local discovery **after** the source gate; it does **not** force local. Then `--input-products` is a hard error on the CDN path (no pool enumeration).
2. **Profile `output: "{version}.yaml"`** is a hard error in **profile-based** `changelog bundle`. Their current job is option-mode with an explicit YAML `--output`, so this does not fire today. The commented-out `changelog bundle edot-java-release ${VERSION}` would fail until `output` is removed. `{changelog} /releases/` currently consumes `1.12.0.yaml`-style names; conventional `{repo}-{product}-{version}.yaml` would be a second, separate migration.

### Git vs S3: where otel-java changelog YAML actually lives

Not “all files live only in git” and not “some unreleased files exist only in S3.” It is both, at different lifecycle stages.

**In the repo (authoring / current release window):**

- `changelog-submit` commits YAML into `docs/changelog` on the PR branch.
- `changelog-upload` on push to `main` copies whatever is in that folder to S3 (`changelog/elastic/elastic-otel-java/main/...`).
- Current `main` has only `docs/changelog/upstream-update.yaml` (PR 1212, 2026-08-26) plus `.gitkeep`.

**Removed from the repo at pre-release:**
- `0f0030d` (`pre release: elastic-otel-java v1.12.0`, 2026-07-31) deleted `1089.yaml`, `1093.yaml`, `1117.yaml`, and the previous `upstream-update.yaml` after writing `docs/releases/1.12.0.yaml`. `changelog remove` does not delete S3 objects.

**On the public CDN (S3 public bucket via CloudFront):**

- `https://d10xozp44eyz7q.cloudfront.net/changelog/elastic/elastic-otel-java/main/registry.json` still lists those four **already-bundled** files, `generated_at` **2026-07-24** (before the 1.12.0 wipe). The current git `upstream-update.yaml` is **not** in that registry.
- Individual YAML GETs from that pool returned 500 via the docs fetcher; the registry is enough to know the pool was published and was not updated after the wipe / after PR 1212.

**What this does and does not prove:**

- Unreleased work for the next release is in git (`docs/changelog`), not “S3-only.”
- Already-bundled entries remain on the public pool after git delete. Bundling from CDN would mix those in again and could miss the current git-only file if the public registry is stale.
- Private-bucket vs public-CDN lag is not fully proven (no private S3 access). Public state is enough to treat CDN as the wrong source for this workflow.
- Fork PRs can be regenerated onto S3 at merge without a committed file; that is a general docs-builder path, not something observed in this repo’s current tree.

### Options

#### 1. Keep the folder model; force local sourcing (recommended for this team)

No change to `--input-products` semantics. Any of:

- `--force-local` on the bundle step
- `--directory docs/changelog` (also forces local)
- `bundle.use_local_changelogs: true` in [`docs/changelog.yml`](file:///Users/lcawley/Documents/GitHub/elastic-otel-java/docs/changelog.yml)

Leave `--input-products 'edot-java * *'` as-is. Version stays on `--output-products` / `--output`. Remove stays profile-based with the wildcard products pattern.

This is the smallest unbreak. It does **not** require commit hashes or PR lists.

#### 2. PR list, GitHub release, promotion report, or `--start-git-ref`/`--end-git-ref`

Valid, but a **different** source of truth. Only required if they **stop** treating “whatever is in `docs/changelog` since last wipe” as correct. Their `changelog:skip` release PRs and upstream-update rename (`N.yaml` → `upstream-update.yaml`) are built around the folder model. Git range also does **not** auto-include notes.

**Not the only option**, and not the one that matches this workflow.

